### PR TITLE
feat(cudf): Add LeftSemiProject, NAAJ-with-filter, NestedLoopJoin and fix pre-existing bugs

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -235,8 +235,15 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
           if (remainingFilterExprSet_) {
             auto cols = tbl->release();
             const auto originalNumColumns = cols.size();
+            std::vector<cudf::column_view> colViews;
+            colViews.reserve(cols.size());
+            for (auto& c : cols) {
+              colViews.push_back(c->view());
+            }
             auto filterResult = cudfExpressionEvaluator_->eval(
-                cols, stream_, cudf::get_current_device_resource_ref());
+                colViews,
+                stream_,
+                cudf::get_current_device_resource_ref());
             std::vector<std::unique_ptr<cudf::column>> origCols;
             origCols.reserve(originalNumColumns);
             std::move(

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -324,20 +324,16 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
   if (remainingFilterExprSet_) {
     MicrosecondTimer filterTimer(&filterTimeUs);
     auto cudfTableColumns = cudfTable->release();
-    const auto originalNumColumns = cudfTableColumns.size();
-    // Filter may need addtional computed columns which are added to
-    // cudfTableColumns
+    // Filter may need additional computed columns
+    std::vector<cudf::column_view> inputViews;
+    inputViews.reserve(cudfTableColumns.size());
+    for (auto& col : cudfTableColumns) {
+      inputViews.push_back(col->view());
+    }
     auto filterResult = cudfExpressionEvaluator_->eval(
-        cudfTableColumns, stream_, cudf::get_current_device_resource_ref());
-    // discard computed columns
-    std::vector<std::unique_ptr<cudf::column>> originalColumns;
-    originalColumns.reserve(originalNumColumns);
-    std::move(
-        cudfTableColumns.begin(),
-        cudfTableColumns.begin() + originalNumColumns,
-        std::back_inserter(originalColumns));
+        inputViews, stream_, cudf::get_current_device_resource_ref());
     auto originalTable =
-        std::make_unique<cudf::table>(std::move(originalColumns));
+        std::make_unique<cudf::table>(std::move(cudfTableColumns));
     // Keep only rows where the filter is true
     cudfTable = cudf::apply_boolean_mask(
         *originalTable,

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   CudfFilterProject.cpp
   CudfHashAggregation.cpp
   CudfHashJoin.cpp
+  CudfNestedLoopJoin.cpp
   CudfLimit.cpp
   CudfLocalPartition.cpp
   CudfOrderBy.cpp

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -380,8 +380,13 @@ RowVectorPtr CudfFilterProject::flushAccumulatedOutputs() {
 void CudfFilterProject::filter(
     std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
     rmm::cuda_stream_view stream) {
+  std::vector<cudf::column_view> inputViews;
+  inputViews.reserve(inputTableColumns.size());
+  for (auto& col : inputTableColumns) {
+    inputViews.push_back(col->view());
+  }
   auto filterColumn = filterEvaluator_->eval(
-      inputTableColumns, stream, cudf::get_current_device_resource_ref(), true);
+      inputViews, stream, cudf::get_current_device_resource_ref(), true);
   auto filterColumnView = asView(filterColumn);
   bool shouldApplyFilter = [&]() {
     if (filterColumnView.has_nulls()) {
@@ -409,13 +414,15 @@ void CudfFilterProject::filter(
 std::vector<std::unique_ptr<cudf::column>> CudfFilterProject::project(
     std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
     rmm::cuda_stream_view stream) {
+  std::vector<cudf::column_view> inputViews;
+  inputViews.reserve(inputTableColumns.size());
+  for (auto& col : inputTableColumns) {
+    inputViews.push_back(col->view());
+  }
   std::vector<ColumnOrView> columns;
   for (auto& projectEvaluator : projectEvaluators_) {
     columns.push_back(projectEvaluator->eval(
-        inputTableColumns,
-        stream,
-        cudf::get_current_device_resource_ref(),
-        true));
+        inputViews, stream, cudf::get_current_device_resource_ref(), true));
   }
 
   // Rearrange columns to match outputType_

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -248,6 +248,21 @@ void CudfHashJoinBuild::noMoreInput() {
         buildType->getChildIdx(rightKeys[i]->name()));
   }
 
+  {
+    int64_t totalNullKeyRows = 0;
+    for (const auto& tbl : tbls) {
+      auto n = tbl->num_rows();
+      if (n == 0) {
+        continue;
+      }
+      auto nonNull =
+          cudf::drop_nulls(*tbl, buildKeyIndices, stream);
+      totalNullKeyRows += n - nonNull->num_rows();
+    }
+    auto lockedStats = stats_.wlock();
+    lockedStats->numNullKeys += totalNullKeyRows;
+  }
+
   // Only need to construct hash_join object if it's an inner join, left join,
   // right join, or full join.
   // All other cases use a standalone function in cudf
@@ -364,11 +379,22 @@ CudfHashJoinProbe::CudfHashJoinProbe(
   }
 
   auto outputType = joinNode_->outputType();
+  auto numOutputColumns = outputType->names().size();
+  if (joinNode_->isLeftSemiProjectJoin()) {
+    VELOX_CHECK_GE(numOutputColumns, 1);
+    matchColumnOutputIndex_ =
+        static_cast<int32_t>(numOutputColumns - 1);
+    VELOX_CHECK_EQ(
+        outputType->childAt(matchColumnOutputIndex_),
+        BOOLEAN());
+    --numOutputColumns;
+  }
+
   leftColumnIndicesToGather_ = std::vector<cudf::size_type>();
   rightColumnIndicesToGather_ = std::vector<cudf::size_type>();
   leftColumnOutputIndices_ = std::vector<size_t>();
   rightColumnOutputIndices_ = std::vector<size_t>();
-  for (int i = 0; i < outputType->names().size(); i++) {
+  for (size_t i = 0; i < numOutputColumns; i++) {
     auto const outputName = outputType->names()[i];
     if (CudfConfig::getInstance().debugEnabled) {
       VLOG(1) << "Output column " << i << ": " << outputName;
@@ -388,7 +414,8 @@ CudfHashJoinProbe::CudfHashJoinProbe(
       continue;
     }
     VELOX_FAIL(
-        "Join field {} not in probe or build input", outputType->children()[i]);
+        "Join field {} not in probe or build input",
+        outputType->children()[i]);
   }
 
   if (CudfConfig::getInstance().debugEnabled) {
@@ -1178,6 +1205,154 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftSemiFilterJoin(
 }
 
 std::vector<std::unique_ptr<cudf::table>>
+CudfHashJoinProbe::leftSemiProjectJoin(
+    cudf::table_view leftTableView,
+    rmm::cuda_stream_view stream) {
+  std::vector<std::unique_ptr<cudf::table>> cudfOutputs;
+  auto& rightTables = hashObject_.value().first;
+  auto leftNumRows = leftTableView.num_rows();
+
+  auto falseScalar =
+      cudf::numeric_scalar<bool>(false, true, stream);
+  auto matchFlags = cudf::make_column_from_scalar(
+      falseScalar,
+      leftNumRows,
+      stream,
+      cudf::get_current_device_resource_ref());
+
+  auto rowIndices = cudf::sequence(
+      leftNumRows,
+      cudf::numeric_scalar<cudf::size_type>(0, true, stream),
+      cudf::numeric_scalar<cudf::size_type>(1, true, stream),
+      stream,
+      cudf::get_current_device_resource_ref());
+
+  for (auto i = 0; i < rightTables.size(); i++) {
+    auto rightTableView = rightTables[i]->view();
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>>
+        leftJoinIndices;
+
+    if (joinNode_->filter()) {
+      leftJoinIndices = cudf::mixed_left_semi_join(
+          leftTableView.select(leftKeyIndices_),
+          rightTableView.select(rightKeyIndices_),
+          leftTableView,
+          rightTableView,
+          tree_.back(),
+          cudf::null_equality::UNEQUAL,
+          stream,
+          cudf::get_current_device_resource_ref());
+    } else {
+      cudf::filtered_join filter_join(
+          rightTableView.select(rightKeyIndices_),
+          cudf::null_equality::UNEQUAL,
+          cudf::set_as_build_table::RIGHT,
+          stream);
+      leftJoinIndices = filter_join.semi_join(
+          leftTableView.select(leftKeyIndices_),
+          stream,
+          cudf::get_current_device_resource_ref());
+    }
+
+    if (leftJoinIndices->size() > 0) {
+      auto leftIdxCol = cudf::column_view{
+          cudf::device_span<cudf::size_type const>{
+              *leftJoinIndices}};
+      auto matchedInBatch =
+          cudf::contains(leftIdxCol, rowIndices->view());
+      auto updated = cudf::binary_operation(
+          matchFlags->view(),
+          matchedInBatch->view(),
+          cudf::binary_operator::BITWISE_OR,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          cudf::get_current_device_resource_ref());
+      matchFlags = std::move(updated);
+    }
+  }
+
+  if (joinNode_->isNullAware()) {
+    auto mr = cudf::get_current_device_resource_ref();
+    bool buildIsEmpty = true;
+    bool buildHasNullKeys = false;
+    for (const auto& rt : rightTables) {
+      if (rt->view().num_rows() > 0) {
+        buildIsEmpty = false;
+        if (cudf::has_nulls(
+                rt->view().select(rightKeyIndices_))) {
+          buildHasNullKeys = true;
+        }
+      }
+    }
+
+    // x IN (empty set) = false for any x, including null.
+    if (!buildIsEmpty) {
+      auto trueScalar =
+          cudf::numeric_scalar<bool>(true, true, stream);
+      auto probeKeyNotNull = cudf::make_column_from_scalar(
+          trueScalar, leftNumRows, stream, mr);
+      for (auto ki : leftKeyIndices_) {
+        auto keyCol = leftTableView.column(ki);
+        if (keyCol.has_nulls()) {
+          auto isValid =
+              cudf::is_valid(keyCol, stream, mr);
+          probeKeyNotNull = cudf::binary_operation(
+              probeKeyNotNull->view(),
+              isValid->view(),
+              cudf::binary_operator::BITWISE_AND,
+              cudf::data_type{cudf::type_id::BOOL8},
+              stream,
+              mr);
+        }
+      }
+
+      std::unique_ptr<cudf::column> validMask;
+      if (buildHasNullKeys) {
+        validMask = cudf::binary_operation(
+            probeKeyNotNull->view(),
+            matchFlags->view(),
+            cudf::binary_operator::BITWISE_AND,
+            cudf::data_type{cudf::type_id::BOOL8},
+            stream,
+            mr);
+      } else {
+        validMask = std::move(probeKeyNotNull);
+      }
+
+      auto nullScalar =
+          cudf::numeric_scalar<bool>(false, false, stream);
+      matchFlags = cudf::copy_if_else(
+          matchFlags->view(),
+          nullScalar,
+          validMask->view(),
+          stream,
+          mr);
+    }
+  }
+
+  auto leftInput =
+      leftTableView.select(leftColumnIndicesToGather_);
+  std::vector<std::unique_ptr<cudf::column>> outCols(
+      outputType_->size());
+  for (size_t j = 0; j < leftColumnOutputIndices_.size(); ++j) {
+    auto outIdx = leftColumnOutputIndices_[j];
+    outCols[outIdx] = std::make_unique<cudf::column>(
+        leftInput.column(j),
+        stream,
+        cudf::get_current_device_resource_ref());
+  }
+  outCols[matchColumnOutputIndex_] = std::move(matchFlags);
+
+  if (buildStream_.has_value()) {
+    cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+  }
+  stream.synchronize();
+  cudfOutputs.push_back(
+      std::make_unique<cudf::table>(std::move(outCols)));
+  return cudfOutputs;
+}
+
+std::vector<std::unique_ptr<cudf::table>>
 CudfHashJoinProbe::rightSemiFilterJoin(
     cudf::table_view leftTableView,
     rmm::cuda_stream_view stream) {
@@ -1233,6 +1408,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
     rmm::cuda_stream_view stream) {
   std::vector<std::unique_ptr<cudf::table>> cudfOutputs;
   auto& rightTables = hashObject_.value().first;
+  auto mr = cudf::get_current_device_resource_ref();
 
   VELOX_CHECK_EQ(
       rightTables.size(),
@@ -1241,28 +1417,31 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
 
   auto rightTableView = rightTables[0]->view();
 
-  // For the special case where we need to drop nulls, we create a local table.
-  // Otherwise, we use the input view directly.
+  if (joinNode_->isNullAware() && joinNode_->filter()) {
+    return nullAwareAntiJoinWithFilter(
+        leftTableViewParam, rightTableView, stream);
+  }
+
   std::unique_ptr<cudf::table> modifiedLeftTable;
   cudf::table_view leftTableView = leftTableViewParam;
 
-  // Special case for null-aware anti join where
-  // build table is not empty, no nulls, and probe table has nulls
-  if (joinNode_->isNullAware() and !joinNode_->filter()) {
+  if (joinNode_->isNullAware() && !joinNode_->filter()) {
     auto const leftTableHasNulls =
-        cudf::has_nulls(leftTableViewParam.select(leftKeyIndices_));
+        cudf::has_nulls(
+            leftTableViewParam.select(leftKeyIndices_));
     auto const rightTableHasNulls =
-        cudf::has_nulls(rightTableView.select(rightKeyIndices_));
-    if (rightTables[0]->num_rows() > 0 and !rightTableHasNulls and
-        leftTableHasNulls) {
-      // drop nulls on probe table - creates a new table
-      modifiedLeftTable =
-          cudf::drop_nulls(leftTableViewParam, leftKeyIndices_, stream);
+        cudf::has_nulls(
+            rightTableView.select(rightKeyIndices_));
+    if (rightTables[0]->num_rows() > 0 &&
+        !rightTableHasNulls && leftTableHasNulls) {
+      modifiedLeftTable = cudf::drop_nulls(
+          leftTableViewParam, leftKeyIndices_, stream);
       leftTableView = modifiedLeftTable->view();
     }
   }
 
-  std::unique_ptr<rmm::device_uvector<cudf::size_type>> leftJoinIndices;
+  std::unique_ptr<rmm::device_uvector<cudf::size_type>>
+      leftJoinIndices;
   if (joinNode_->filter()) {
     leftJoinIndices = cudf::mixed_left_anti_join(
         leftTableView.select(leftKeyIndices_),
@@ -1272,14 +1451,15 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
         tree_.back(),
         cudf::null_equality::UNEQUAL,
         stream,
-        cudf::get_current_device_resource_ref());
+        mr);
   } else {
     auto const rightTableHasNulls =
-        cudf::has_nulls(rightTableView.select(rightKeyIndices_));
-    if (joinNode_->isNullAware() and rightTableHasNulls) {
-      // empty result
-      leftJoinIndices = std::make_unique<rmm::device_uvector<cudf::size_type>>(
-          0, stream, cudf::get_current_device_resource_ref());
+        cudf::has_nulls(
+            rightTableView.select(rightKeyIndices_));
+    if (joinNode_->isNullAware() && rightTableHasNulls) {
+      leftJoinIndices =
+          std::make_unique<rmm::device_uvector<cudf::size_type>>(
+              0, stream, mr);
     } else {
       cudf::filtered_join filter_join(
           rightTableView.select(rightKeyIndices_),
@@ -1289,7 +1469,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
       leftJoinIndices = filter_join.anti_join(
           leftTableView.select(leftKeyIndices_),
           stream,
-          cudf::get_current_device_resource_ref());
+          mr);
     }
   }
 
@@ -1304,6 +1484,318 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
       rightIndicesCol->view(),
       stream));
 
+  return cudfOutputs;
+}
+
+std::vector<std::unique_ptr<cudf::table>>
+CudfHashJoinProbe::nullAwareAntiJoinWithFilter(
+    cudf::table_view leftTableViewParam,
+    cudf::table_view rightTableView,
+    rmm::cuda_stream_view stream) {
+  std::vector<std::unique_ptr<cudf::table>> cudfOutputs;
+  auto mr = cudf::get_current_device_resource_ref();
+
+  auto leftNonNullTable =
+      cudf::drop_nulls(leftTableViewParam, leftKeyIndices_, stream);
+  auto leftNonNull = leftNonNullTable->view();
+  auto leftN = leftNonNull.num_rows();
+
+  auto buildHasNullKeys =
+      cudf::has_nulls(rightTableView.select(rightKeyIndices_));
+
+  std::unique_ptr<cudf::column> rowIndices;
+  std::unique_ptr<cudf::column> candidateMask;
+  if (leftN > 0) {
+    rowIndices = cudf::sequence(
+        leftN,
+        cudf::numeric_scalar<cudf::size_type>(0, true, stream),
+        cudf::numeric_scalar<cudf::size_type>(1, true, stream),
+        stream,
+        mr);
+
+    candidateMask = cudf::make_column_from_scalar(
+        cudf::numeric_scalar<bool>(true, true, stream),
+        leftN,
+        stream,
+        mr);
+  }
+
+  // Exclude left rows matching non-null-key build rows via
+  // key equality + filter. With UNEQUAL null equality, null
+  // build keys are invisible.
+  if (leftN > 0 && rightTableView.num_rows() > 0) {
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>>
+        antiIndices;
+    if (buildHasNullKeys) {
+      // Extract non-null-key build rows
+      auto rightNonNull = cudf::drop_nulls(
+          rightTableView, rightKeyIndices_, stream);
+      if (rightNonNull->num_rows() > 0) {
+        antiIndices = cudf::mixed_left_anti_join(
+            leftNonNull.select(leftKeyIndices_),
+            rightNonNull->view().select(rightKeyIndices_),
+            leftNonNull,
+            rightNonNull->view(),
+            tree_.back(),
+            cudf::null_equality::UNEQUAL,
+            stream,
+            mr);
+      }
+    } else {
+      antiIndices = cudf::mixed_left_anti_join(
+          leftNonNull.select(leftKeyIndices_),
+          rightTableView.select(rightKeyIndices_),
+          leftNonNull,
+          rightTableView,
+          tree_.back(),
+          cudf::null_equality::UNEQUAL,
+          stream,
+          mr);
+    }
+    if (antiIndices && antiIndices->size() > 0) {
+      auto antiCol = cudf::column_view{
+          cudf::device_span<cudf::size_type const>{
+              *antiIndices}};
+      auto inAnti =
+          cudf::contains(antiCol, rowIndices->view());
+      candidateMask = cudf::binary_operation(
+          candidateMask->view(),
+          inAnti->view(),
+          cudf::binary_operator::BITWISE_AND,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          mr);
+    } else if (!antiIndices || antiIndices->size() == 0) {
+      if (!buildHasNullKeys ||
+          cudf::drop_nulls(
+              rightTableView, rightKeyIndices_, stream)
+                  ->num_rows() > 0) {
+        // Anti-join returned nothing: all left rows matched.
+        // Unless no non-null build rows existed.
+        auto falseScalar =
+            cudf::numeric_scalar<bool>(false, true, stream);
+        candidateMask = cudf::make_column_from_scalar(
+            falseScalar, leftN, stream, mr);
+      }
+    }
+  }
+
+  // Exclude left rows matching any null-key build row via
+  // filter. Use dummy constant keys so every pair passes key
+  // equality, letting the filter decide.
+  if (leftN > 0 && buildHasNullKeys &&
+      rightTableView.num_rows() > 0) {
+    // Build per-row "any key is null" mask for right table
+    auto rightN = rightTableView.num_rows();
+    auto anyKeyNull = cudf::make_column_from_scalar(
+        cudf::numeric_scalar<bool>(false, true, stream),
+        rightN,
+        stream,
+        mr);
+    for (auto keyIdx : rightKeyIndices_) {
+      auto col = rightTableView.column(keyIdx);
+      if (!col.has_nulls()) {
+        continue;
+      }
+      auto nullScalar =
+          cudf::make_default_constructed_scalar(
+              col.type(), stream, mr);
+      auto isNull = cudf::binary_operation(
+          col,
+          *nullScalar,
+          cudf::binary_operator::NULL_EQUALS,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          mr);
+      anyKeyNull = cudf::binary_operation(
+          anyKeyNull->view(),
+          isNull->view(),
+          cudf::binary_operator::BITWISE_OR,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          mr);
+    }
+
+    auto rightNullKeys = cudf::apply_boolean_mask(
+        rightTableView, anyKeyNull->view(), stream);
+    auto nullKeyN = rightNullKeys->num_rows();
+
+    if (nullKeyN > 0) {
+      // Dummy constant keys: every (left, rightNull) pair
+      // passes key equality so the filter is evaluated on all
+      // cross-product pairs.
+      auto zeroScalar = cudf::numeric_scalar<cudf::size_type>(
+          0, true, stream);
+      auto leftDummyKey = cudf::make_column_from_scalar(
+          zeroScalar, leftN, stream, mr);
+      auto rightDummyKey = cudf::make_column_from_scalar(
+          zeroScalar, nullKeyN, stream, mr);
+
+      auto semiIndices = cudf::mixed_left_semi_join(
+          cudf::table_view({leftDummyKey->view()}),
+          cudf::table_view({rightDummyKey->view()}),
+          leftNonNull,
+          rightNullKeys->view(),
+          tree_.back(),
+          cudf::null_equality::UNEQUAL,
+          stream,
+          mr);
+
+      if (semiIndices->size() > 0) {
+        auto semiCol = cudf::column_view{
+            cudf::device_span<cudf::size_type const>{
+                *semiIndices}};
+        auto inSemi =
+            cudf::contains(semiCol, rowIndices->view());
+        auto notInSemi = cudf::unary_operation(
+            inSemi->view(),
+            cudf::unary_operator::NOT,
+            stream);
+        candidateMask = cudf::binary_operation(
+            candidateMask->view(),
+            notInSemi->view(),
+            cudf::binary_operator::BITWISE_AND,
+            cudf::data_type{cudf::type_id::BOOL8},
+            stream,
+            mr);
+      }
+    }
+  }
+
+  // Collect surviving non-null-keyed rows
+  std::unique_ptr<cudf::table> nonNullResult;
+  if (leftN > 0) {
+    auto leftInput =
+        leftNonNull.select(leftColumnIndicesToGather_);
+    nonNullResult = cudf::apply_boolean_mask(
+        leftInput, candidateMask->view(), stream);
+  }
+
+  // Handle null-keyed probe rows.
+  // null NOT IN (empty) = true  -> keep
+  // null NOT IN (non-empty where filter passes) = null -> exclude
+  // null NOT IN (non-empty where NO filter passes) = true -> keep
+  std::unique_ptr<cudf::table> nullKeyResult;
+  auto totalLeft = leftTableViewParam.num_rows();
+  if (totalLeft > leftN) {
+    // Extract rows where any key column is null
+    auto trueScalar =
+        cudf::numeric_scalar<bool>(true, true, stream);
+    auto hasNullKey = cudf::make_column_from_scalar(
+        cudf::numeric_scalar<bool>(false, true, stream),
+        totalLeft, stream, mr);
+    for (auto ki : leftKeyIndices_) {
+      auto col = leftTableViewParam.column(ki);
+      if (col.has_nulls()) {
+        auto isNull = cudf::is_null(col, stream, mr);
+        hasNullKey = cudf::binary_operation(
+            hasNullKey->view(),
+            isNull->view(),
+            cudf::binary_operator::BITWISE_OR,
+            cudf::data_type{cudf::type_id::BOOL8},
+            stream, mr);
+      }
+    }
+    auto leftNullKeyTable = cudf::apply_boolean_mask(
+        leftTableViewParam, hasNullKey->view(), stream);
+    auto nullN = leftNullKeyTable->num_rows();
+
+    if (nullN > 0 && rightTableView.num_rows() == 0) {
+      // Build is empty: all null-keyed rows survive
+      nullKeyResult = std::make_unique<cudf::table>(
+          leftNullKeyTable->view().select(
+              leftColumnIndicesToGather_),
+          stream, mr);
+    } else if (nullN > 0 && rightTableView.num_rows() > 0) {
+      // Cross-join anti: for each null-keyed probe row,
+      // check if ANY build row passes the filter.
+      auto buildN = rightTableView.num_rows();
+      auto zeroScalar = cudf::numeric_scalar<cudf::size_type>(
+          0, true, stream);
+      auto dummyL = cudf::make_column_from_scalar(
+          zeroScalar, nullN, stream, mr);
+      auto dummyR = cudf::make_column_from_scalar(
+          zeroScalar, buildN, stream, mr);
+
+      auto antiIdx = cudf::mixed_left_anti_join(
+          cudf::table_view({dummyL->view()}),
+          cudf::table_view({dummyR->view()}),
+          leftNullKeyTable->view(),
+          rightTableView,
+          tree_.back(),
+          cudf::null_equality::UNEQUAL,
+          stream, mr);
+
+      if (antiIdx->size() > 0) {
+        auto idxCol = cudf::column_view{
+            cudf::device_span<cudf::size_type const>{
+                *antiIdx}};
+        nullKeyResult = cudf::gather(
+            leftNullKeyTable->view().select(
+                leftColumnIndicesToGather_),
+            idxCol, cudf::out_of_bounds_policy::DONT_CHECK,
+            stream, mr);
+      }
+    }
+  }
+
+  // Concatenate non-null and null-key results
+  std::vector<cudf::table_view> toConcat;
+  if (nonNullResult && nonNullResult->num_rows() > 0) {
+    toConcat.push_back(nonNullResult->view());
+  }
+  if (nullKeyResult && nullKeyResult->num_rows() > 0) {
+    toConcat.push_back(nullKeyResult->view());
+  }
+
+  if (toConcat.empty()) {
+    // Return an empty table with correct schema
+    std::vector<std::unique_ptr<cudf::column>> emptyCols;
+    for (size_t j = 0; j < leftColumnOutputIndices_.size(); ++j) {
+      auto srcIdx = leftColumnIndicesToGather_[j];
+      auto type = leftTableViewParam.column(srcIdx).type();
+      emptyCols.push_back(
+          cudf::make_empty_column(type));
+    }
+    std::vector<std::unique_ptr<cudf::column>> outCols(
+        outputType_->size());
+    for (size_t j = 0; j < leftColumnOutputIndices_.size(); ++j) {
+      outCols[leftColumnOutputIndices_[j]] =
+          std::move(emptyCols[j]);
+    }
+    if (buildStream_.has_value()) {
+      cudaEvent_->recordFrom(stream).waitOn(
+          buildStream_.value());
+    }
+    stream.synchronize();
+    cudfOutputs.push_back(
+        std::make_unique<cudf::table>(std::move(outCols)));
+    return cudfOutputs;
+  }
+
+  std::unique_ptr<cudf::table> finalResult;
+  if (toConcat.size() == 1) {
+    finalResult = std::make_unique<cudf::table>(
+        toConcat[0], stream, mr);
+  } else {
+    finalResult =
+        cudf::concatenate(toConcat, stream, mr);
+  }
+
+  auto resultCols = finalResult->release();
+  std::vector<std::unique_ptr<cudf::column>> outCols(
+      outputType_->size());
+  for (size_t j = 0; j < leftColumnOutputIndices_.size(); ++j) {
+    outCols[leftColumnOutputIndices_[j]] =
+        std::move(resultCols[j]);
+  }
+
+  if (buildStream_.has_value()) {
+    cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+  }
+  stream.synchronize();
+  cudfOutputs.push_back(
+      std::make_unique<cudf::table>(std::move(outCols)));
   return cudfOutputs;
 }
 
@@ -1469,6 +1961,20 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
     }
   }
 
+  {
+    auto n = leftTableView.num_rows();
+    if (n > 0) {
+      auto nonNull =
+          cudf::drop_nulls(leftTableView, leftKeyIndices_, stream);
+      auto nullKeyRows =
+          static_cast<int64_t>(n - nonNull->num_rows());
+      if (nullKeyRows > 0) {
+        auto lockedStats = stats_.wlock();
+        lockedStats->numNullKeys += nullKeyRows;
+      }
+    }
+  }
+
   std::vector<std::unique_ptr<cudf::table>> cudfOutputs;
   switch (joinNode_->joinType()) {
     case core::JoinType::kInner:
@@ -1482,6 +1988,9 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
       break;
     case core::JoinType::kLeftSemiFilter:
       cudfOutputs = leftSemiFilterJoin(leftTableView, stream);
+      break;
+    case core::JoinType::kLeftSemiProject:
+      cudfOutputs = leftSemiProjectJoin(leftTableView, stream);
       break;
     case core::JoinType::kRightSemiFilter:
       cudfOutputs = rightSemiFilterJoin(leftTableView, stream);
@@ -1623,10 +2132,18 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
 }
 
 bool CudfHashJoinProbe::isFinished() {
-  auto const isFinished = finished_ ||
-      (noMoreInput_ && input_ == nullptr && accumulatedProbeInputs_.empty());
+  bool isFinished;
+  if ((joinNode_->isRightJoin() || joinNode_->isFullJoin()) &&
+      isLastDriver_) {
+    // The last driver must wait until finished_ is set after emitting
+    // unmatched build rows.
+    isFinished = finished_;
+  } else {
+    isFinished = finished_ ||
+        (noMoreInput_ && input_ == nullptr &&
+         accumulatedProbeInputs_.empty());
+  }
 
-  // Release hashObject_ if finished
   if (isFinished) {
     hashObject_.reset();
   }

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -40,6 +40,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/reduction.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/search.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/unary.hpp>
@@ -222,12 +223,12 @@ void CudfHashJoinBuild::noMoreInput() {
         buildType->getChildIdx(rightKeys[i]->name()));
   }
 
-  // Only need to construct hash_join object if it's an inner join, left join or
-  // right join.
+  // Only need to construct hash_join object if it's an inner join, left join,
+  // right join, or full join.
   // All other cases use a standalone function in cudf
   bool buildHashJoin =
       (joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
-       joinNode_->isRightJoin());
+       joinNode_->isRightJoin() || joinNode_->isFullJoin());
 
   std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
   for (auto i = 0; i < tbls.size(); i++) {
@@ -490,7 +491,8 @@ void CudfHashJoinProbe::noMoreInput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
   GpuGuard gpuGuard;
   Operator::noMoreInput();
-  if (!joinNode_->isRightJoin() && !joinNode_->isRightSemiFilterJoin()) {
+  if (!joinNode_->isRightJoin() && !joinNode_->isRightSemiFilterJoin() &&
+      !joinNode_->isFullJoin()) {
     return;
   }
   std::vector<ContinuePromise> promises;
@@ -510,7 +512,7 @@ void CudfHashJoinProbe::noMoreInput() {
     }
   };
 
-  if (joinNode_->isRightJoin()) {
+  if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
     isLastDriver_ = true;
     if (hashObject_.has_value()) {
       auto stream = cudfGlobalStreamPool().get_stream();
@@ -825,32 +827,33 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::rightJoin(
     // cudf::scatter is async: it enqueues a device memcpy of the old flags
     // (the target) plus a thrust::scatter kernel onto `stream`, then returns
     // immediately. The old rightMatchedFlags_[i] column must stay alive until
-    // that work completes. We defer the assignment to rightMatchedFlags_[i]
-    // until after unfilteredOutput/filteredOutput (which call
-    // stream.synchronize()), so the old column is not destroyed while the
-    // scatter kernel is still reading from it.
-    std::unique_ptr<cudf::column> updated_flag_col;
     if (!joinNode_->filter()) {
-      // Mark matched rights using scatter of true into flags at matching
-      // indices
-      // TODO (dm): Use a better implementation that doesn't require making a
-      // scalar and broadcasting. My cuDF foo is rusty
-      auto true_scalar = cudf::numeric_scalar<bool>(true, true, stream);
-      auto true_col = cudf::make_column_from_scalar(
-          true_scalar,
-          rightJoinIndices->size(),
-          stream,
-          cudf::get_current_device_resource_ref());
-      auto flags_table = cudf::table_view({rightMatchedFlags_[i]->view()});
+      // Mark matched build rows by checking which row indices appear in
+      // rightJoinIndices. Use contains to avoid scatter with duplicate indices.
       auto rightIdxCol = cudf::column_view{
           cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
-      auto updated_flags_tbl = cudf::scatter(
-          cudf::table_view({true_col->view()}),
-          rightIdxCol,
-          flags_table,
+
+      // Create sequence [0, 1, ..., n-1] for build table row indices
+      auto n = rightTableView.num_rows();
+      auto rowIndices = cudf::sequence(
+          n,
+          cudf::numeric_scalar<cudf::size_type>(0, true, stream),
+          cudf::numeric_scalar<cudf::size_type>(1, true, stream),
           stream,
           cudf::get_current_device_resource_ref());
-      updated_flag_col = std::move(updated_flags_tbl->release()[0]);    
+
+      // Check which build row indices are present in the join result
+      auto matchedInBatch = cudf::contains(rightIdxCol, rowIndices->view());
+
+      // OR with existing flags to accumulate matches across batches
+      auto updatedFlags = cudf::binary_operation(
+          rightMatchedFlags_[i]->view(),
+          matchedInBatch->view(),
+          cudf::binary_operator::BITWISE_OR,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          cudf::get_current_device_resource_ref());
+      rightMatchedFlags_[i] = std::move(updatedFlags);
     }
 
     auto leftIndicesSpan =
@@ -863,8 +866,9 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::rightJoin(
 
     if (joinNode_->filter()) {
       auto& rightMatchedFlags = rightMatchedFlags_[i];
+      auto numBuildRows = rightTableView.num_rows();
       auto filterFunc =
-          [&rightMatchedFlags, &updated_flag_col, rightIndicesSpan, stream](
+          [&rightMatchedFlags, rightIndicesSpan, numBuildRows, stream](
               std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
               cudf::column_view filterColumn) {
             // apply the filter
@@ -885,22 +889,26 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::rightJoin(
             auto filteredCols = filteredIdxTable->release();
             auto filteredRightIdxCol = std::move(filteredCols[0]);
 
-            // TODO (dm): The below code is repeated from non-filter case. Find
-            // a way to consolidate in future
-            auto true_scalar = cudf::numeric_scalar<bool>(true, true, stream);
-            auto true_col = cudf::make_column_from_scalar(
-                true_scalar,
-                filteredRightIdxCol->size(),
+            // Use contains to check which build row indices passed the filter
+            auto rowIndices = cudf::sequence(
+                numBuildRows,
+                cudf::numeric_scalar<cudf::size_type>(0, true, stream),
+                cudf::numeric_scalar<cudf::size_type>(1, true, stream),
                 stream,
                 cudf::get_current_device_resource_ref());
-            auto flags_table = cudf::table_view({rightMatchedFlags->view()});
-            auto updated_flags_tbl = cudf::scatter(
-                cudf::table_view({true_col->view()}),
-                filteredRightIdxCol->view(),
-                flags_table,
+
+            auto matchedInBatch =
+                cudf::contains(filteredRightIdxCol->view(), rowIndices->view());
+
+            // OR with existing flags to accumulate matches across batches
+            auto updatedFlags = cudf::binary_operation(
+                rightMatchedFlags->view(),
+                matchedInBatch->view(),
+                cudf::binary_operator::BITWISE_OR,
+                cudf::data_type{cudf::type_id::BOOL8},
                 stream,
                 cudf::get_current_device_resource_ref());
-            updated_flag_col = std::move(updated_flags_tbl->release()[0]);
+            rightMatchedFlags = std::move(updatedFlags);
             return std::move(joinedCols);
           };
       cudfOutputs.push_back(filteredOutput(
@@ -918,8 +926,136 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::rightJoin(
           rightIndicesCol,
           stream));
     }
-    // Safe to assign now: stream has been synchronized by the output call above.
-    rightMatchedFlags_[i] = std::move(updated_flag_col);
+  }
+  return cudfOutputs;
+}
+
+std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::fullJoin(
+    cudf::table_view leftTableView,
+    rmm::cuda_stream_view stream) {
+  std::vector<std::unique_ptr<cudf::table>> cudfOutputs;
+
+  auto& rightTables = hashObject_.value().first;
+  auto& hbs = hashObject_.value().second;
+
+  for (auto i = 0; i < rightTables.size(); i++) {
+    auto rightTableView = rightTables[i]->view();
+    auto& hb = hbs[i];
+
+    VELOX_CHECK_NOT_NULL(hb);
+    if (buildStream_.has_value()) {
+      cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+    }
+    // Use left_join to get all probe rows (matched + unmatched).
+    // Track matched build rows in rightMatchedFlags_ for last driver to emit
+    // unmatched build rows at the end.
+    auto [leftJoinIndices, rightJoinIndices] = hb->left_join(
+        leftTableView.select(leftKeyIndices_),
+        std::nullopt,
+        buildStream_.has_value() ? buildStream_.value() : stream);
+    if (buildStream_.has_value()) {
+      cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+    }
+    if (!joinNode_->filter()) {
+      // Mark matched build rows by checking which row indices appear in
+      // rightJoinIndices. Use contains to avoid scatter with duplicate indices.
+      auto rightIdxCol = cudf::column_view{
+          cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
+
+      // Create sequence [0, 1, ..., n-1] for build table row indices
+      auto n = rightTableView.num_rows();
+      auto rowIndices = cudf::sequence(
+          n,
+          cudf::numeric_scalar<cudf::size_type>(0, true, stream),
+          cudf::numeric_scalar<cudf::size_type>(1, true, stream),
+          stream,
+          cudf::get_current_device_resource_ref());
+
+      // Check which build row indices are present in the join result
+      auto matchedInBatch = cudf::contains(rightIdxCol, rowIndices->view());
+
+      // OR with existing flags to accumulate matches across batches
+      auto updatedFlags = cudf::binary_operation(
+          rightMatchedFlags_[i]->view(),
+          matchedInBatch->view(),
+          cudf::binary_operator::BITWISE_OR,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          cudf::get_current_device_resource_ref());
+      rightMatchedFlags_[i] = std::move(updatedFlags);
+    }
+
+    auto leftIndicesSpan =
+        cudf::device_span<cudf::size_type const>{*leftJoinIndices};
+    auto rightIndicesSpan =
+        cudf::device_span<cudf::size_type const>{*rightJoinIndices};
+    auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
+    auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
+
+    if (joinNode_->filter()) {
+      // Use filter_join_indices with LEFT_JOIN to get proper full join probe
+      // semantics: all probe rows are kept, build columns are NULL when filter
+      // fails or no match.
+      auto [filteredLeftJoinIndices, filteredRightJoinIndices] =
+          cudf::filter_join_indices(
+              leftTableView,
+              rightTableView,
+              leftIndicesCol,
+              rightIndicesCol,
+              tree_.back(),
+              cudf::join_kind::LEFT_JOIN,
+              stream);
+
+      // Track matched build rows for unmatched row emission at end.
+      // Use contains to check which build row indices passed the filter.
+      auto& rightMatchedFlags = rightMatchedFlags_[i];
+      auto filteredRightIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*filteredRightJoinIndices};
+      auto filteredRightIdxCol = cudf::column_view{filteredRightIndicesSpan};
+
+      // Create sequence [0, 1, ..., n-1] for build table row indices
+      auto n = rightTableView.num_rows();
+      auto rowIndices = cudf::sequence(
+          n,
+          cudf::numeric_scalar<cudf::size_type>(0, true, stream),
+          cudf::numeric_scalar<cudf::size_type>(1, true, stream),
+          stream,
+          cudf::get_current_device_resource_ref());
+
+      // Check which build row indices are present in the filtered join result
+      auto matchedInBatch =
+          cudf::contains(filteredRightIdxCol, rowIndices->view());
+
+      // OR with existing flags to accumulate matches across batches
+      auto updatedFlags = cudf::binary_operation(
+          rightMatchedFlags->view(),
+          matchedInBatch->view(),
+          cudf::binary_operator::BITWISE_OR,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          cudf::get_current_device_resource_ref());
+      rightMatchedFlags = std::move(updatedFlags);
+
+      // Build output using filtered indices
+      auto filteredLeftIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*filteredLeftJoinIndices};
+      auto filteredLeftIndicesCol = cudf::column_view{filteredLeftIndicesSpan};
+      auto filteredRightIndicesCol =
+          cudf::column_view{filteredRightIndicesSpan};
+      cudfOutputs.push_back(unfilteredOutput(
+          leftTableView,
+          filteredLeftIndicesCol,
+          rightTableView,
+          filteredRightIndicesCol,
+          stream));
+    } else {
+      cudfOutputs.push_back(unfilteredOutput(
+          leftTableView,
+          leftIndicesCol,
+          rightTableView,
+          rightIndicesCol,
+          stream));
+    }
   }
   return cudfOutputs;
 }
@@ -1161,8 +1297,8 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
 
   if (!input_) {
     // If no more input, emit unmatched-right rows if needed.
-    if (joinNode_->isRightJoin() && noMoreInput_ && !finished_ &&
-        isLastDriver_) {
+    if ((joinNode_->isRightJoin() || joinNode_->isFullJoin()) && noMoreInput_ &&
+        !finished_ && isLastDriver_) {
       auto& rightTables = hashObject_.value().first;
       auto stream = cudfGlobalStreamPool().get_stream();
       std::vector<std::unique_ptr<cudf::table>> toConcat;
@@ -1177,20 +1313,25 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
         auto boolMask = cudf::unary_operation(
             flags->view(), cudf::unary_operator::NOT, stream);
 
-        auto rightInput =
-            rightTable->view().select(rightColumnIndicesToGather_);
-        auto unmatchedRight =
-            cudf::apply_boolean_mask(rightInput, boolMask->view(), stream);
-        auto m = unmatchedRight->num_rows();
+        // Count unmatched rows by summing the boolean mask
+        auto unmatchedCountScalar = cudf::reduce(
+            boolMask->view(),
+            *cudf::make_sum_aggregation<cudf::reduce_aggregation>(),
+            cudf::data_type{cudf::type_id::INT32},
+            stream);
+        auto m = static_cast<cudf::numeric_scalar<int32_t>*>(
+                     unmatchedCountScalar.get())
+                     ->value(stream);
         if (m == 0) {
           continue;
         }
+
         // Build left null columns
         std::vector<std::unique_ptr<cudf::column>> outCols(outputType_->size());
         // Left side nulls (types derive from probe schema at the matching
         // channel indices)
         auto probeType = joinNode_->sources()[0]->outputType();
-        for (int li = 0; li < leftColumnOutputIndices_.size(); ++li) {
+        for (size_t li = 0; li < leftColumnOutputIndices_.size(); ++li) {
           auto outIdx = leftColumnOutputIndices_[li];
           auto probeChannel = leftColumnIndicesToGather_[li];
           auto leftCudfType =
@@ -1200,11 +1341,17 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
           outCols[outIdx] = cudf::make_column_from_scalar(
               *nullScalar, m, stream, cudf::get_current_device_resource_ref());
         }
-        // Right side
-        auto rightCols = unmatchedRight->release();
-        for (int ri = 0; ri < rightColumnOutputIndices_.size(); ++ri) {
-          auto outIdx = rightColumnOutputIndices_[ri];
-          outCols[outIdx] = std::move(rightCols[ri]);
+        // Right side - gather unmatched build columns if any
+        if (!rightColumnIndicesToGather_.empty()) {
+          auto rightInput =
+              rightTable->view().select(rightColumnIndicesToGather_);
+          auto unmatchedRight =
+              cudf::apply_boolean_mask(rightInput, boolMask->view(), stream);
+          auto rightCols = unmatchedRight->release();
+          for (size_t ri = 0; ri < rightColumnOutputIndices_.size(); ++ri) {
+            auto outIdx = rightColumnOutputIndices_[ri];
+            outCols[outIdx] = std::move(rightCols[ri]);
+          }
         }
         toConcat.push_back(std::make_unique<cudf::table>(std::move(outCols)));
       }
@@ -1274,6 +1421,9 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
     case core::JoinType::kAnti:
       cudfOutputs = antiJoin(leftTableView, stream);
       break;
+    case core::JoinType::kFull:
+      cudfOutputs = fullJoin(leftTableView, stream);
+      break;
     default:
       VELOX_FAIL("Unsupported join type: ", joinNode_->joinType());
   }
@@ -1284,7 +1434,8 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
   // the refcount while cudfInput still holds a reference.
   cudfInput.reset();
   input_.reset();
-  finished_ = noMoreInput_ && !joinNode_->isRightJoin();
+  finished_ =
+      noMoreInput_ && !joinNode_->isRightJoin() && !joinNode_->isFullJoin();
 
   auto cudfOutput = concatenateTables(std::move(cudfOutputs), stream);
   auto const size = cudfOutput->num_rows();
@@ -1307,7 +1458,8 @@ bool CudfHashJoinProbe::skipProbeOnEmptyBuild() const {
 }
 
 exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
-  if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin()) &&
+  if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin() ||
+       joinNode_->isFullJoin()) &&
       hashObject_.has_value()) {
     if (!future_.valid()) {
       return exec::BlockingReason::kNotBlocked;
@@ -1338,7 +1490,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
   buildStream_ = cudfJoinBridge->getBuildStream();
 
   // Lazy initialize matched flags only when build side is done
-  if (joinNode_->isRightJoin()) {
+  if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
     auto& rightTablesInit = hashObject_.value().first;
     rightMatchedFlags_.clear();
     rightMatchedFlags_.reserve(rightTablesInit.size());
@@ -1366,7 +1518,8 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
       }
     }
   }
-  if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin()) &&
+  if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin() ||
+       joinNode_->isFullJoin()) &&
       future_.valid()) {
     *future = std::move(future_);
     return exec::BlockingReason::kWaitForJoinProbe;

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -53,6 +53,31 @@
 
 namespace facebook::velox::cudf_velox {
 
+namespace {
+
+/// Creates extended table view by appending precomputed columns
+cudf::table_view createExtendedTableView(
+    cudf::table_view originalView,
+    std::vector<ColumnOrView>& precomputedColumns) {
+  if (precomputedColumns.empty()) {
+    return originalView;
+  }
+
+  std::vector<cudf::column_view> allViews;
+  allViews.reserve(originalView.num_columns() + precomputedColumns.size());
+
+  for (cudf::size_type i = 0; i < originalView.num_columns(); ++i) {
+    allViews.push_back(originalView.column(i));
+  }
+  for (auto& col : precomputedColumns) {
+    allViews.push_back(asView(col));
+  }
+
+  return cudf::table_view(allViews);
+}
+
+} // namespace
+
 void CudfHashJoinProbe::close() {
   Operator::close();
   filterEvaluator_.reset();
@@ -214,10 +239,10 @@ void CudfHashJoinBuild::noMoreInput() {
     }
   }
 
-  auto buildType = joinNode_->sources()[1]->outputType();
   auto rightKeys = joinNode_->rightKeys();
 
   auto buildKeyIndices = std::vector<cudf::size_type>(rightKeys.size());
+  auto buildType = joinNode_->sources()[1]->outputType();
   for (size_t i = 0; i < buildKeyIndices.size(); i++) {
     buildKeyIndices[i] = static_cast<cudf::size_type>(
         buildType->getChildIdx(rightKeys[i]->name()));
@@ -294,22 +319,22 @@ CudfHashJoinProbe::CudfHashJoinProbe(
           operatorId,
           fmt::format("[{}]", joinNode->id())),
       joinNode_(joinNode),
+      probeType_(joinNode_->sources()[0]->outputType()),
+      buildType_(joinNode_->sources()[1]->outputType()),
       cudaEvent_(std::make_unique<CudaEvent>(cudaEventDisableTiming)) {
   if (CudfConfig::getInstance().debugEnabled) {
     VLOG(2) << "CudfHashJoinProbe constructor";
   }
-  auto probeType = joinNode_->sources()[0]->outputType();
-  auto buildType = joinNode_->sources()[1]->outputType();
   auto const& leftKeys = joinNode_->leftKeys(); // probe keys
   auto const& rightKeys = joinNode_->rightKeys(); // build keys
 
   if (CudfConfig::getInstance().debugEnabled) {
-    for (int i = 0; i < probeType->names().size(); i++) {
-      VLOG(1) << "Left column " << i << ": " << probeType->names()[i];
+    for (int i = 0; i < probeType_->names().size(); i++) {
+      VLOG(1) << "Left column " << i << ": " << probeType_->names()[i];
     }
 
-    for (int i = 0; i < buildType->names().size(); i++) {
-      VLOG(1) << "Right column " << i << ": " << buildType->names()[i];
+    for (int i = 0; i < buildType_->names().size(); i++) {
+      VLOG(1) << "Right column " << i << ": " << buildType_->names()[i];
     }
 
     for (int i = 0; i < leftKeys.size(); i++) {
@@ -323,18 +348,18 @@ CudfHashJoinProbe::CudfHashJoinProbe(
     }
   }
 
-  auto const probeTableNumColumns = probeType->size();
+  auto const probeTableNumColumns = probeType_->size();
   leftKeyIndices_ = std::vector<cudf::size_type>(leftKeys.size());
   for (size_t i = 0; i < leftKeyIndices_.size(); i++) {
     leftKeyIndices_[i] = static_cast<cudf::size_type>(
-        probeType->getChildIdx(leftKeys[i]->name()));
+        probeType_->getChildIdx(leftKeys[i]->name()));
     VELOX_CHECK_LT(leftKeyIndices_[i], probeTableNumColumns);
   }
-  auto const buildTableNumColumns = buildType->size();
+  auto const buildTableNumColumns = buildType_->size();
   rightKeyIndices_ = std::vector<cudf::size_type>(rightKeys.size());
   for (size_t i = 0; i < rightKeyIndices_.size(); i++) {
     rightKeyIndices_[i] = static_cast<cudf::size_type>(
-        buildType->getChildIdx(rightKeys[i]->name()));
+        buildType_->getChildIdx(rightKeys[i]->name()));
     VELOX_CHECK_LT(rightKeyIndices_[i], buildTableNumColumns);
   }
 
@@ -348,14 +373,14 @@ CudfHashJoinProbe::CudfHashJoinProbe(
     if (CudfConfig::getInstance().debugEnabled) {
       VLOG(1) << "Output column " << i << ": " << outputName;
     }
-    auto channel = probeType->getChildIdxIfExists(outputName);
+    auto channel = probeType_->getChildIdxIfExists(outputName);
     if (channel.has_value()) {
       leftColumnIndicesToGather_.push_back(
           static_cast<cudf::size_type>(channel.value()));
       leftColumnOutputIndices_.push_back(i);
       continue;
     }
-    channel = buildType->getChildIdxIfExists(outputName);
+    channel = buildType_->getChildIdxIfExists(outputName);
     if (channel.has_value()) {
       rightColumnIndicesToGather_.push_back(
           static_cast<cudf::size_type>(channel.value()));
@@ -387,16 +412,13 @@ void CudfHashJoinProbe::initialize() {
     return;
   }
 
-  auto probeType = joinNode_->sources()[0]->outputType();
-  auto buildType = joinNode_->sources()[1]->outputType();
-
   exec::ExprSet exprs({joinNode_->filter()}, operatorCtx_->execCtx());
   VELOX_CHECK_EQ(exprs.exprs().size(), 1);
 
   // Create a reusable evaluator for the filter column. This is expensive to
   // build, and the expression + input schema are stable for the lifetime of
   // the operator instance.
-  std::vector<velox::RowTypePtr> filterRowTypes{probeType, buildType};
+  std::vector<velox::RowTypePtr> filterRowTypes{probeType_, buildType_};
   filterEvaluator_ = createCudfExpression(
       exprs.exprs()[0],
       facebook::velox::type::concatRowTypes(filterRowTypes));
@@ -407,33 +429,25 @@ void CudfHashJoinProbe::initialize() {
   // and the column locations in that schema translate to column locations
   // in whole tables
 
-  std::vector<PrecomputeInstruction> rightPrecomputeInstructions;
-  std::vector<PrecomputeInstruction> leftPrecomputeInstructions;
-  static constexpr bool kAllowPureAstOnly = true;
+  // create ast tree
   if (joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin()) {
     createAstTree(
         exprs.exprs()[0],
         tree_,
         scalars_,
-        buildType,
-        probeType,
-        rightPrecomputeInstructions,
-        leftPrecomputeInstructions,
-        kAllowPureAstOnly);
+        buildType_,
+        probeType_,
+        rightPrecomputeInstructions_,
+        leftPrecomputeInstructions_);
   } else {
     createAstTree(
         exprs.exprs()[0],
         tree_,
         scalars_,
-        probeType,
-        buildType,
-        leftPrecomputeInstructions,
-        rightPrecomputeInstructions,
-        kAllowPureAstOnly);
-  }
-  if (leftPrecomputeInstructions.size() > 0 ||
-      rightPrecomputeInstructions.size() > 0) {
-    VELOX_NYI("Filters that require precomputation are not yet supported");
+        probeType_,
+        buildType_,
+        leftPrecomputeInstructions_,
+        rightPrecomputeInstructions_);
   }
 }
 
@@ -640,8 +654,13 @@ std::unique_ptr<cudf::table> CudfHashJoinProbe::filteredOutput(
   VELOX_CHECK_NOT_NULL(
       filterEvaluator_,
       "Join filter evaluator must be initialized before filteredOutput()");
+  std::vector<cudf::column_view> joinedColViews;
+  joinedColViews.reserve(joinedCols.size());
+  for (const auto& col : joinedCols) {
+    joinedColViews.push_back(col->view());
+  }
   auto filterColumns = filterEvaluator_->eval(
-      joinedCols, stream, cudf::get_current_device_resource_ref());
+      joinedColViews, stream, cudf::get_current_device_resource_ref());
   auto filterColumn = asView(filterColumns);
 
   joinedCols = func(std::move(joinedCols), filterColumn);
@@ -670,12 +689,15 @@ std::unique_ptr<cudf::table> CudfHashJoinProbe::filteredOutputIndices(
     cudf::column_view leftIndicesCol,
     cudf::table_view rightTableView,
     cudf::column_view rightIndicesCol,
+    cudf::table_view extendedLeftView,
+    cudf::table_view extendedRightView,
     cudf::join_kind joinKind,
     rmm::cuda_stream_view stream) {
+  // Use extended views (with precomputed columns) for filter evaluation
   auto [filteredLeftJoinIndices, filteredRightJoinIndices] =
       cudf::filter_join_indices(
-          leftTableView,
-          rightTableView,
+          extendedLeftView,
+          extendedRightView,
           leftIndicesCol,
           rightIndicesCol,
           tree_.back(),
@@ -688,6 +710,7 @@ std::unique_ptr<cudf::table> CudfHashJoinProbe::filteredOutputIndices(
       cudf::device_span<cudf::size_type const>{*filteredRightJoinIndices};
   auto filteredLeftIndicesCol = cudf::column_view{filteredLeftIndicesSpan};
   auto filteredRightIndicesCol = cudf::column_view{filteredRightIndicesSpan};
+  // Use original views (without precomputed columns) for gathering output
   return unfilteredOutput(
       leftTableView,
       filteredLeftIndicesCol,
@@ -703,9 +726,30 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::innerJoin(
 
   auto& rightTables = hashObject_.value().first;
   auto& hbs = hashObject_.value().second;
+
+  // Precompute left (probe) table columns if needed (once, outside loop)
+  std::vector<ColumnOrView> leftPrecomputed;
+  cudf::table_view extendedLeftView = leftTableView;
+  if (joinNode_->filter() && !leftPrecomputeInstructions_.empty()) {
+    auto leftColumnViews = tableViewToColumnViews(leftTableView);
+    leftPrecomputed = precomputeSubexpressions(
+        leftColumnViews,
+        leftPrecomputeInstructions_,
+        scalars_,
+        probeType_,
+        stream);
+    extendedLeftView = createExtendedTableView(leftTableView, leftPrecomputed);
+  }
+
   for (auto i = 0; i < rightTables.size(); i++) {
     auto rightTableView = rightTables[i]->view();
     auto& hb = hbs[i];
+
+    // Use cached precomputed columns for right (build) table
+    cudf::table_view extendedRightView =
+        (joinNode_->filter() && !rightPrecomputeInstructions_.empty())
+        ? cachedExtendedRightViews_[i]
+        : rightTableView;
 
     // left = probe, right = build
     VELOX_CHECK_NOT_NULL(hb);
@@ -736,6 +780,8 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::innerJoin(
           leftIndicesCol,
           rightTableView,
           rightIndicesCol,
+          extendedLeftView,
+          extendedRightView,
           cudf::join_kind::INNER_JOIN,
           stream));
     } else {
@@ -757,9 +803,30 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftJoin(
 
   auto& rightTables = hashObject_.value().first;
   auto& hbs = hashObject_.value().second;
+
+  // Precompute left (probe) table columns if needed (once, outside loop)
+  std::vector<ColumnOrView> leftPrecomputed;
+  cudf::table_view extendedLeftView = leftTableView;
+  if (joinNode_->filter() && !leftPrecomputeInstructions_.empty()) {
+    auto leftColumnViews = tableViewToColumnViews(leftTableView);
+    leftPrecomputed = precomputeSubexpressions(
+        leftColumnViews,
+        leftPrecomputeInstructions_,
+        scalars_,
+        probeType_,
+        stream);
+    extendedLeftView = createExtendedTableView(leftTableView, leftPrecomputed);
+  }
+
   for (auto i = 0; i < rightTables.size(); i++) {
     auto rightTableView = rightTables[i]->view();
     auto& hb = hbs[i];
+
+    // Use cached precomputed columns for right (build) table
+    cudf::table_view extendedRightView =
+        (joinNode_->filter() && !rightPrecomputeInstructions_.empty())
+        ? cachedExtendedRightViews_[i]
+        : rightTableView;
 
     VELOX_CHECK_NOT_NULL(hb);
     if (buildStream_.has_value()) {
@@ -787,6 +854,8 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftJoin(
           leftIndicesCol,
           rightTableView,
           rightIndicesCol,
+          extendedLeftView,
+          extendedRightView,
           cudf::join_kind::LEFT_JOIN,
           stream));
     } else {
@@ -1330,12 +1399,11 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
         std::vector<std::unique_ptr<cudf::column>> outCols(outputType_->size());
         // Left side nulls (types derive from probe schema at the matching
         // channel indices)
-        auto probeType = joinNode_->sources()[0]->outputType();
         for (size_t li = 0; li < leftColumnOutputIndices_.size(); ++li) {
           auto outIdx = leftColumnOutputIndices_[li];
           auto probeChannel = leftColumnIndicesToGather_[li];
           auto leftCudfType =
-              veloxToCudfTypeId(probeType->childAt(probeChannel));
+              veloxToCudfTypeId(probeType_->childAt(probeChannel));
           auto nullScalar = cudf::make_default_constructed_scalar(
               cudf::data_type{leftCudfType});
           outCols[outIdx] = cudf::make_column_from_scalar(
@@ -1504,6 +1572,33 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
     }
     initStream.synchronize();
   }
+
+  // Precompute right table columns if filter exists (once when build is done)
+  if (joinNode_->filter() && !rightPrecomputeInstructions_.empty()) {
+    auto& rightTablesInit = hashObject_.value().first;
+    cachedRightPrecomputed_.clear();
+    cachedExtendedRightViews_.clear();
+    cachedRightPrecomputed_.reserve(rightTablesInit.size());
+    cachedExtendedRightViews_.reserve(rightTablesInit.size());
+
+    auto initStream = cudfGlobalStreamPool().get_stream();
+    for (auto& rt : rightTablesInit) {
+      auto rightTableView = rt->view();
+      auto rightColumnViews = tableViewToColumnViews(rightTableView);
+      auto rightPrecomputed = precomputeSubexpressions(
+          rightColumnViews,
+          rightPrecomputeInstructions_,
+          scalars_,
+          buildType_,
+          initStream);
+      auto extendedView =
+          createExtendedTableView(rightTableView, rightPrecomputed);
+      cachedRightPrecomputed_.push_back(std::move(rightPrecomputed));
+      cachedExtendedRightViews_.push_back(extendedView);
+    }
+    initStream.synchronize();
+  }
+
   auto& rightTables = hashObject_.value().first;
   // should be rightTable->numDistinct() but it needs compute,
   // so we use num_rows()

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -155,7 +155,8 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
         joinType == core::JoinType::kAnti ||
         joinType == core::JoinType::kLeftSemiFilter ||
         joinType == core::JoinType::kRight ||
-        joinType == core::JoinType::kRightSemiFilter;
+        joinType == core::JoinType::kRightSemiFilter ||
+        joinType == core::JoinType::kFull;
   }
 
   bool isFinished() override;
@@ -252,6 +253,15 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
    * @return Vector of result tables (multiple if build data was batched)
    */
   std::vector<std::unique_ptr<cudf::table>> rightJoin(
+      cudf::table_view leftTableView,
+      rmm::cuda_stream_view stream);
+  /**
+   * @brief Performs full outer join between probe table and all build tables.
+   * @param leftTableView Probe-side table view to join
+   * @param stream CUDA stream for operations
+   * @return Vector of result tables (multiple if build data was batched)
+   */
+  std::vector<std::unique_ptr<cudf::table>> fullJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
+#include "velox/experimental/cudf/expression/AstExpression.h"
+#include "velox/experimental/cudf/expression/AstExpressionUtils.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include "velox/core/PlanNode.h"
@@ -171,6 +173,14 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   cudf::ast::tree tree_;
   /** @brief Scalar values used in filter expressions */
   std::vector<std::unique_ptr<cudf::scalar>> scalars_;
+  /** @brief Precompute instructions for left (probe) table columns */
+  std::vector<PrecomputeInstruction> leftPrecomputeInstructions_;
+  /** @brief Precompute instructions for right (build) table columns */
+  std::vector<PrecomputeInstruction> rightPrecomputeInstructions_;
+  /** @brief Row type for probe table (needed for precomputation) */
+  RowTypePtr probeType_;
+  /** @brief Row type for build table (needed for precomputation) */
+  RowTypePtr buildType_;
   /** @brief Cached evaluator for post-join filter column */
   std::shared_ptr<CudfExpression> filterEvaluator_;
 
@@ -222,6 +232,11 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   /** @brief Flags tracking which build rows have been matched (for right joins)
    */
   std::vector<std::unique_ptr<cudf::column>> rightMatchedFlags_;
+
+  /// Cached precomputed columns for right (build) tables
+  std::vector<std::vector<ColumnOrView>> cachedRightPrecomputed_;
+  /// Cached extended views for right tables (original + precomputed columns)
+  std::vector<cudf::table_view> cachedExtendedRightViews_;
 
   // For Right joins, only one driver collects the unmatched rows mask and
   // emits. This value is set true only for that driver. See noMoreInput
@@ -333,6 +348,8 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
       cudf::column_view leftIndicesCol,
       cudf::table_view rightTableView,
       cudf::column_view rightIndicesCol,
+      cudf::table_view extendedLeftView,
+      cudf::table_view extendedRightView,
       cudf::join_kind joinKind,
       rmm::cuda_stream_view stream);
 };

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -156,6 +156,7 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
         joinType == core::JoinType::kLeft ||
         joinType == core::JoinType::kAnti ||
         joinType == core::JoinType::kLeftSemiFilter ||
+        joinType == core::JoinType::kLeftSemiProject ||
         joinType == core::JoinType::kRight ||
         joinType == core::JoinType::kRightSemiFilter ||
         joinType == core::JoinType::kFull;
@@ -211,6 +212,10 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   /** @brief Output column positions for right table columns */
   std::vector<size_t> rightColumnOutputIndices_;
   bool finished_{false};
+
+  // For LeftSemiProject: output index of the boolean "match" column.
+  // -1 when the join is not a LeftSemiProject.
+  int32_t matchColumnOutputIndex_{-1};
 
   // Copied from HashProbe.h
   // Indicates whether to skip probe input data processing or not. It only
@@ -306,6 +311,14 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
    * @return Vector of result tables (multiple if build data was batched)
    */
   std::vector<std::unique_ptr<cudf::table>> antiJoin(
+      cudf::table_view leftTableView,
+      rmm::cuda_stream_view stream);
+  std::vector<std::unique_ptr<cudf::table>>
+  nullAwareAntiJoinWithFilter(
+      cudf::table_view leftTableView,
+      cudf::table_view rightTableView,
+      rmm::cuda_stream_view stream);
+  std::vector<std::unique_ptr<cudf::table>> leftSemiProjectJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -1,0 +1,1089 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfNestedLoopJoin.h"
+#include "velox/experimental/cudf/exec/GpuGuard.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/expression/AstExpression.h"
+#include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Task.h"
+#include "velox/type/TypeUtil.h"
+
+#include <fmt/format.h>
+
+#include <cudf/binaryop.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/concatenate.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/filling.hpp>
+#include <cudf/join/conditional_join.hpp>
+#include <cudf/join/join.hpp>
+#include <cudf/reduction.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/search.hpp>
+#include <cudf/stream_compaction.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/unary.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <nvtx3/nvtx3.hpp>
+
+namespace facebook::velox::cudf_velox {
+
+// ---- Bridge ----
+
+void CudfNestedLoopJoinBridge::setData(
+    std::optional<data_type> data) {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK(!data_.has_value());
+    data_ = std::move(data);
+    promises = std::move(promises_);
+  }
+  notify(std::move(promises));
+}
+
+std::optional<CudfNestedLoopJoinBridge::data_type>
+CudfNestedLoopJoinBridge::dataOrFuture(
+    ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (data_.has_value()) {
+    return data_;
+  }
+  promises_.emplace_back(
+      "CudfNestedLoopJoinBridge::dataOrFuture");
+  *future = promises_.back().getSemiFuture();
+  return std::nullopt;
+}
+
+void CudfNestedLoopJoinBridge::setBuildStream(
+    rmm::cuda_stream_view buildStream) {
+  std::lock_guard<std::mutex> l(mutex_);
+  buildStream_ = buildStream;
+}
+
+std::optional<rmm::cuda_stream_view>
+CudfNestedLoopJoinBridge::getBuildStream() {
+  std::lock_guard<std::mutex> l(mutex_);
+  return buildStream_;
+}
+
+// ---- Build ----
+
+CudfNestedLoopJoinBuild::CudfNestedLoopJoinBuild(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::NestedLoopJoinNode> joinNode)
+    : Operator(
+          driverCtx,
+          nullptr,
+          operatorId,
+          joinNode->id(),
+          "CudfNestedLoopJoinBuild"),
+      NvtxHelper(
+          nvtx3::rgb{100, 149, 237}, // Cornflower Blue
+          operatorId,
+          fmt::format("[{}]", joinNode->id())),
+      joinNode_(std::move(joinNode)) {}
+
+void CudfNestedLoopJoinBuild::addInput(RowVectorPtr input) {
+  if (input && input->size() > 0) {
+    auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
+    VELOX_CHECK_NOT_NULL(cudfInput);
+    inputs_.push_back(std::move(cudfInput));
+  }
+}
+
+bool CudfNestedLoopJoinBuild::needsInput() const {
+  return !noMoreInput_;
+}
+
+RowVectorPtr CudfNestedLoopJoinBuild::getOutput() {
+  return nullptr;
+}
+
+void CudfNestedLoopJoinBuild::noMoreInput() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
+  GpuGuard gpuGuard;
+  Operator::noMoreInput();
+
+  std::vector<ContinuePromise> promises;
+  std::vector<std::shared_ptr<exec::Driver>> peers;
+  if (!operatorCtx_->task()->allPeersFinished(
+          planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
+    return;
+  }
+
+  for (auto& peer : peers) {
+    auto op = peer->findOperator(planNodeId());
+    auto* build =
+        dynamic_cast<CudfNestedLoopJoinBuild*>(op);
+    VELOX_CHECK_NOT_NULL(build);
+    inputs_.insert(
+        inputs_.end(),
+        std::make_move_iterator(build->inputs_.begin()),
+        std::make_move_iterator(build->inputs_.end()));
+  }
+
+  auto stream = cudfGlobalStreamPool().get_stream();
+
+  std::vector<std::shared_ptr<cudf::table>> buildTables;
+  if (!inputs_.empty()) {
+    std::vector<cudf::table_view> views;
+    views.reserve(inputs_.size());
+    for (auto& cudfVec : inputs_) {
+      views.push_back(cudfVec->getTableView());
+    }
+    auto concatenated =
+        cudf::concatenate(views, stream);
+    buildTables.push_back(std::move(concatenated));
+  } else {
+    auto buildType = joinNode_->sources()[1]->outputType();
+    std::vector<std::unique_ptr<cudf::column>> emptyCols;
+    for (size_t i = 0; i < buildType->size(); ++i) {
+      auto cudfType =
+          veloxToCudfTypeId(buildType->childAt(i));
+      auto scalar = cudf::make_default_constructed_scalar(
+          cudf::data_type{cudfType}, stream);
+      emptyCols.push_back(cudf::make_column_from_scalar(
+          *scalar,
+          0,
+          stream,
+          cudf::get_current_device_resource_ref()));
+    }
+    buildTables.push_back(
+        std::make_shared<cudf::table>(std::move(emptyCols)));
+  }
+
+  auto bridge = operatorCtx_->task()
+                    ->getCustomJoinBridge(
+                        operatorCtx_->driverCtx()->splitGroupId,
+                        planNodeId());
+  auto nlBridge =
+      std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(bridge);
+  VELOX_CHECK_NOT_NULL(nlBridge);
+  nlBridge->setBuildStream(stream);
+  nlBridge->setData(std::move(buildTables));
+
+  inputs_.clear();
+
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
+}
+
+exec::BlockingReason CudfNestedLoopJoinBuild::isBlocked(
+    ContinueFuture* future) {
+  if (!future_.valid()) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+  *future = std::move(future_);
+  return exec::BlockingReason::kWaitForJoinBuild;
+}
+
+bool CudfNestedLoopJoinBuild::isFinished() {
+  return !future_.valid() && noMoreInput_;
+}
+
+// ---- Probe ----
+
+CudfNestedLoopJoinProbe::CudfNestedLoopJoinProbe(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::NestedLoopJoinNode> joinNode)
+    : Operator(
+          driverCtx,
+          joinNode->outputType(),
+          operatorId,
+          joinNode->id(),
+          "CudfNestedLoopJoinProbe"),
+      NvtxHelper(
+          nvtx3::rgb{46, 139, 87}, // Sea Green
+          operatorId,
+          fmt::format("[{}]", joinNode->id())),
+      joinNode_(std::move(joinNode)),
+      joinType_(joinNode_->joinType()) {
+  probeType_ = joinNode_->sources()[0]->outputType();
+  buildType_ = joinNode_->sources()[1]->outputType();
+
+  auto outputType = joinNode_->outputType();
+  auto numOutputColumns = outputType->size();
+  if (core::isLeftSemiProjectJoin(joinType_)) {
+    VELOX_CHECK_GE(numOutputColumns, 1);
+    matchColumnOutputIndex_ =
+        static_cast<int32_t>(numOutputColumns - 1);
+    VELOX_CHECK_EQ(
+        outputType->childAt(matchColumnOutputIndex_), BOOLEAN());
+    --numOutputColumns;
+  }
+
+  for (size_t i = 0; i < numOutputColumns; ++i) {
+    auto const& name = outputType->nameOf(i);
+    auto channel = probeType_->getChildIdxIfExists(name);
+    if (channel.has_value()) {
+      leftColumnIndicesToGather_.push_back(
+          static_cast<cudf::size_type>(channel.value()));
+      leftColumnOutputIndices_.push_back(i);
+      continue;
+    }
+    channel = buildType_->getChildIdxIfExists(name);
+    if (channel.has_value()) {
+      rightColumnIndicesToGather_.push_back(
+          static_cast<cudf::size_type>(channel.value()));
+      rightColumnOutputIndices_.push_back(i);
+      continue;
+    }
+    VELOX_FAIL(
+        "NLJ output column not found: {}",
+        outputType->childAt(i));
+  }
+}
+
+void CudfNestedLoopJoinProbe::initialize() {
+  Operator::initialize();
+  if (!joinNode_->joinCondition()) {
+    return;
+  }
+  exec::ExprSet exprs(
+      {joinNode_->joinCondition()}, operatorCtx_->execCtx());
+  VELOX_CHECK_EQ(exprs.exprs().size(), 1);
+
+  std::vector<velox::RowTypePtr> types{probeType_, buildType_};
+  filterEvaluator_ = createCudfExpression(
+      exprs.exprs()[0],
+      facebook::velox::type::concatRowTypes(types));
+
+  std::vector<PrecomputeInstruction> leftPrecompute;
+  std::vector<PrecomputeInstruction> rightPrecompute;
+  createAstTree(
+      exprs.exprs()[0],
+      tree_,
+      scalars_,
+      probeType_,
+      buildType_,
+      leftPrecompute,
+      rightPrecompute);
+}
+
+bool CudfNestedLoopJoinProbe::needsInput() const {
+  return !noMoreInput_ && !finished_ && input_ == nullptr &&
+      buildData_.has_value();
+}
+
+void CudfNestedLoopJoinProbe::addInput(RowVectorPtr input) {
+  VELOX_CHECK_NULL(input_);
+  input_ = std::move(input);
+}
+
+void CudfNestedLoopJoinProbe::noMoreInput() {
+  Operator::noMoreInput();
+  if (!core::isRightJoin(joinType_) &&
+      !core::isFullJoin(joinType_)) {
+    return;
+  }
+  std::vector<ContinuePromise> promises;
+  std::vector<std::shared_ptr<exec::Driver>> peers;
+  if (!operatorCtx_->task()->allPeersFinished(
+          planNodeId(),
+          operatorCtx_->driver(),
+          &future_,
+          promises,
+          peers)) {
+    return;
+  }
+
+  if (core::isRightJoin(joinType_) ||
+      core::isFullJoin(joinType_)) {
+    isLastDriver_ = true;
+    if (buildData_.has_value()) {
+      auto stream = cudfGlobalStreamPool().get_stream();
+      for (auto& peer : peers) {
+        if (peer.get() == operatorCtx_->driver()) {
+          continue;
+        }
+        auto* probe = dynamic_cast<CudfNestedLoopJoinProbe*>(
+            peer->findOperator(planNodeId()));
+        if (probe == nullptr) {
+          continue;
+        }
+        for (size_t i = 0; i < rightMatchedFlags_.size(); ++i) {
+          if (i < probe->rightMatchedFlags_.size() &&
+              probe->rightMatchedFlags_[i]) {
+            auto updated = cudf::binary_operation(
+                rightMatchedFlags_[i]->view(),
+                probe->rightMatchedFlags_[i]->view(),
+                cudf::binary_operator::BITWISE_OR,
+                cudf::data_type{cudf::type_id::BOOL8},
+                stream,
+                cudf::get_current_device_resource_ref());
+            rightMatchedFlags_[i] = std::move(updated);
+          }
+        }
+      }
+      stream.synchronize();
+    }
+  }
+
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
+}
+
+void CudfNestedLoopJoinProbe::close() {
+  Operator::close();
+  buildData_.reset();
+  rightMatchedFlags_.clear();
+}
+
+exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
+    ContinueFuture* future) {
+  if ((core::isRightJoin(joinType_) ||
+       core::isFullJoin(joinType_)) &&
+      buildData_.has_value()) {
+    if (!future_.valid()) {
+      return exec::BlockingReason::kNotBlocked;
+    }
+    *future = std::move(future_);
+    return exec::BlockingReason::kWaitForJoinProbe;
+  }
+
+  if (buildData_.has_value()) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  auto bridge = operatorCtx_->task()->getCustomJoinBridge(
+      operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+  auto nlBridge =
+      std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(bridge);
+  VELOX_CHECK_NOT_NULL(nlBridge);
+
+  auto data = nlBridge->dataOrFuture(future);
+  if (!data.has_value()) {
+    return exec::BlockingReason::kWaitForJoinBuild;
+  }
+  buildData_ = std::move(data);
+  buildStream_ = nlBridge->getBuildStream();
+
+  if (core::isRightJoin(joinType_) ||
+      core::isFullJoin(joinType_)) {
+    auto stream = cudfGlobalStreamPool().get_stream();
+    rightMatchedFlags_.clear();
+    for (auto& tbl : buildData_.value()) {
+      auto n = tbl->num_rows();
+      auto falseScalar =
+          cudf::numeric_scalar<bool>(false, true, stream);
+      rightMatchedFlags_.push_back(
+          cudf::make_column_from_scalar(
+              falseScalar,
+              n,
+              stream,
+              cudf::get_current_device_resource_ref()));
+    }
+    stream.synchronize();
+  }
+
+  return exec::BlockingReason::kNotBlocked;
+}
+
+bool CudfNestedLoopJoinProbe::isFinished() {
+  if (finished_) {
+    return true;
+  }
+  if (!noMoreInput_ || input_ != nullptr) {
+    return false;
+  }
+  // For right/full join the last driver must still emit
+  // unmatched build rows.
+  if (isLastDriver_ &&
+      (core::isRightJoin(joinType_) ||
+       core::isFullJoin(joinType_))) {
+    return false;
+  }
+  return true;
+}
+
+// Cross join + optional filter -> gathered output table
+std::unique_ptr<cudf::table>
+CudfNestedLoopJoinProbe::crossJoinAndFilter(
+    cudf::table_view leftView,
+    cudf::table_view rightView,
+    rmm::cuda_stream_view stream) {
+  auto mr = cudf::get_current_device_resource_ref();
+
+  if (leftView.num_rows() == 0 || rightView.num_rows() == 0) {
+    std::vector<std::unique_ptr<cudf::column>> emptyCols(
+        outputType_->size());
+    for (size_t li = 0; li < leftColumnOutputIndices_.size();
+         ++li) {
+      auto outIdx = leftColumnOutputIndices_[li];
+      auto srcCol =
+          leftView.column(leftColumnIndicesToGather_[li]);
+      auto scalar = cudf::make_default_constructed_scalar(
+          srcCol.type(), stream, mr);
+      emptyCols[outIdx] = cudf::make_column_from_scalar(
+          *scalar, 0, stream, mr);
+    }
+    for (size_t ri = 0; ri < rightColumnOutputIndices_.size();
+         ++ri) {
+      auto outIdx = rightColumnOutputIndices_[ri];
+      auto srcCol =
+          rightView.column(rightColumnIndicesToGather_[ri]);
+      auto scalar = cudf::make_default_constructed_scalar(
+          srcCol.type(), stream, mr);
+      emptyCols[outIdx] = cudf::make_column_from_scalar(
+          *scalar, 0, stream, mr);
+    }
+    return std::make_unique<cudf::table>(std::move(emptyCols));
+  }
+
+  if (!joinNode_->joinCondition()) {
+    // Pure cross join
+    auto crossResult = cudf::cross_join(leftView, rightView,
+                                         stream, mr);
+    auto allCols = crossResult->release();
+    auto leftCols = leftView.num_columns();
+    std::vector<std::unique_ptr<cudf::column>> outCols(
+        outputType_->size());
+    for (size_t li = 0; li < leftColumnOutputIndices_.size();
+         ++li) {
+      outCols[leftColumnOutputIndices_[li]] =
+          std::move(allCols[leftColumnIndicesToGather_[li]]);
+    }
+    for (size_t ri = 0; ri < rightColumnOutputIndices_.size();
+         ++ri) {
+      outCols[rightColumnOutputIndices_[ri]] = std::move(
+          allCols[leftCols + rightColumnIndicesToGather_[ri]]);
+    }
+    stream.synchronize();
+    return std::make_unique<cudf::table>(std::move(outCols));
+  }
+
+  // Conditional inner join: returns index pairs
+  auto [leftIndices, rightIndices] =
+      cudf::conditional_inner_join(
+          leftView, rightView, tree_.back(), {}, stream, mr);
+
+  auto leftIndicesSpan =
+      cudf::device_span<cudf::size_type const>{*leftIndices};
+  auto rightIndicesSpan =
+      cudf::device_span<cudf::size_type const>{*rightIndices};
+  auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
+  auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
+
+  auto leftInput =
+      leftView.select(leftColumnIndicesToGather_);
+  auto rightInput =
+      rightView.select(rightColumnIndicesToGather_);
+
+  static constexpr auto oob = cudf::out_of_bounds_policy::NULLIFY;
+  auto leftGathered =
+      cudf::gather(leftInput, leftIndicesCol, oob, stream);
+  auto rightGathered =
+      cudf::gather(rightInput, rightIndicesCol, oob, stream);
+
+  auto leftCols = leftGathered->release();
+  auto rightCols = rightGathered->release();
+  std::vector<std::unique_ptr<cudf::column>> outCols(
+      outputType_->size());
+  for (size_t li = 0; li < leftColumnOutputIndices_.size();
+       ++li) {
+    outCols[leftColumnOutputIndices_[li]] =
+        std::move(leftCols[li]);
+  }
+  for (size_t ri = 0; ri < rightColumnOutputIndices_.size();
+       ++ri) {
+    outCols[rightColumnOutputIndices_[ri]] =
+        std::move(rightCols[ri]);
+  }
+
+  stream.synchronize();
+  return std::make_unique<cudf::table>(std::move(outCols));
+}
+
+std::vector<std::unique_ptr<cudf::table>>
+CudfNestedLoopJoinProbe::innerJoin(
+    cudf::table_view leftView,
+    rmm::cuda_stream_view stream) {
+  std::vector<std::unique_ptr<cudf::table>> results;
+  for (auto& buildTbl : buildData_.value()) {
+    results.push_back(
+        crossJoinAndFilter(leftView, buildTbl->view(), stream));
+  }
+  return results;
+}
+
+std::vector<std::unique_ptr<cudf::table>>
+CudfNestedLoopJoinProbe::leftJoin(
+    cudf::table_view leftView,
+    rmm::cuda_stream_view stream) {
+  std::vector<std::unique_ptr<cudf::table>> results;
+  auto mr = cudf::get_current_device_resource_ref();
+
+  for (auto& buildTbl : buildData_.value()) {
+    auto rightView = buildTbl->view();
+
+    if (!joinNode_->joinCondition()) {
+      if (rightView.num_rows() == 0) {
+        // Left join with empty build: all left rows, null build
+        std::vector<std::unique_ptr<cudf::column>> outCols(
+            outputType_->size());
+        auto n = leftView.num_rows();
+        for (size_t li = 0;
+             li < leftColumnOutputIndices_.size(); ++li) {
+          auto outIdx = leftColumnOutputIndices_[li];
+          outCols[outIdx] = std::make_unique<cudf::column>(
+              leftView.column(leftColumnIndicesToGather_[li]),
+              stream, mr);
+        }
+        for (size_t ri = 0;
+             ri < rightColumnOutputIndices_.size(); ++ri) {
+          auto outIdx = rightColumnOutputIndices_[ri];
+          auto srcCol = rightView.column(
+              rightColumnIndicesToGather_[ri]);
+          auto scalar = cudf::make_default_constructed_scalar(
+              srcCol.type(), stream, mr);
+          outCols[outIdx] = cudf::make_column_from_scalar(
+              *scalar, n, stream, mr);
+        }
+        results.push_back(
+            std::make_unique<cudf::table>(std::move(outCols)));
+      } else {
+        results.push_back(crossJoinAndFilter(
+            leftView, rightView, stream));
+      }
+      continue;
+    }
+
+    auto [leftIndices, rightIndices] =
+        cudf::conditional_left_join(
+            leftView, rightView, tree_.back(), {}, stream, mr);
+
+    auto leftSpan =
+        cudf::device_span<cudf::size_type const>{*leftIndices};
+    auto rightSpan =
+        cudf::device_span<cudf::size_type const>{*rightIndices};
+    auto leftCol = cudf::column_view{leftSpan};
+    auto rightCol = cudf::column_view{rightSpan};
+
+    auto leftInput =
+        leftView.select(leftColumnIndicesToGather_);
+    auto rightInput =
+        rightView.select(rightColumnIndicesToGather_);
+
+    static constexpr auto oob =
+        cudf::out_of_bounds_policy::NULLIFY;
+    auto leftGathered =
+        cudf::gather(leftInput, leftCol, oob, stream);
+    auto rightGathered =
+        cudf::gather(rightInput, rightCol, oob, stream);
+
+    auto lCols = leftGathered->release();
+    auto rCols = rightGathered->release();
+    std::vector<std::unique_ptr<cudf::column>> outCols(
+        outputType_->size());
+    for (size_t li = 0;
+         li < leftColumnOutputIndices_.size(); ++li) {
+      outCols[leftColumnOutputIndices_[li]] =
+          std::move(lCols[li]);
+    }
+    for (size_t ri = 0;
+         ri < rightColumnOutputIndices_.size(); ++ri) {
+      outCols[rightColumnOutputIndices_[ri]] =
+          std::move(rCols[ri]);
+    }
+    stream.synchronize();
+    results.push_back(
+        std::make_unique<cudf::table>(std::move(outCols)));
+  }
+  return results;
+}
+
+std::vector<std::unique_ptr<cudf::table>>
+CudfNestedLoopJoinProbe::rightJoin(
+    cudf::table_view leftView,
+    rmm::cuda_stream_view stream) {
+  std::vector<std::unique_ptr<cudf::table>> results;
+  auto mr = cudf::get_current_device_resource_ref();
+  auto& buildTables = buildData_.value();
+
+  for (size_t i = 0; i < buildTables.size(); ++i) {
+    auto rightView = buildTables[i]->view();
+    if (leftView.num_rows() == 0 || rightView.num_rows() == 0) {
+      continue;
+    }
+
+    if (!joinNode_->joinCondition()) {
+      results.push_back(crossJoinAndFilter(
+          leftView, rightView, stream));
+      // Pure cross join: every build row matched
+      auto trueScalar =
+          cudf::numeric_scalar<bool>(true, true, stream);
+      rightMatchedFlags_[i] = cudf::make_column_from_scalar(
+          trueScalar,
+          rightView.num_rows(),
+          stream,
+          mr);
+      continue;
+    }
+
+    // Conditional inner join, then track matched right rows
+    auto [leftIndices, rightIndices] =
+        cudf::conditional_inner_join(
+            leftView, rightView, tree_.back(), {}, stream, mr);
+
+    auto leftSpan =
+        cudf::device_span<cudf::size_type const>{*leftIndices};
+    auto rightSpan =
+        cudf::device_span<cudf::size_type const>{*rightIndices};
+    auto leftCol = cudf::column_view{leftSpan};
+    auto rightCol = cudf::column_view{rightSpan};
+
+    // Update matched flags for right rows
+    if (rightIndices->size() > 0) {
+      auto n = rightView.num_rows();
+      auto rowSeq = cudf::sequence(
+          n,
+          cudf::numeric_scalar<cudf::size_type>(
+              0, true, stream),
+          cudf::numeric_scalar<cudf::size_type>(
+              1, true, stream),
+          stream,
+          mr);
+      auto matched =
+          cudf::contains(rightCol, rowSeq->view(), stream);
+      auto updated = cudf::binary_operation(
+          rightMatchedFlags_[i]->view(),
+          matched->view(),
+          cudf::binary_operator::BITWISE_OR,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          mr);
+      rightMatchedFlags_[i] = std::move(updated);
+    }
+
+    auto leftInput =
+        leftView.select(leftColumnIndicesToGather_);
+    auto rightInput =
+        rightView.select(rightColumnIndicesToGather_);
+    static constexpr auto oob =
+        cudf::out_of_bounds_policy::NULLIFY;
+    auto leftGathered =
+        cudf::gather(leftInput, leftCol, oob, stream);
+    auto rightGathered =
+        cudf::gather(rightInput, rightCol, oob, stream);
+
+    auto lCols = leftGathered->release();
+    auto rCols = rightGathered->release();
+    std::vector<std::unique_ptr<cudf::column>> outCols(
+        outputType_->size());
+    for (size_t li = 0;
+         li < leftColumnOutputIndices_.size(); ++li) {
+      outCols[leftColumnOutputIndices_[li]] =
+          std::move(lCols[li]);
+    }
+    for (size_t ri = 0;
+         ri < rightColumnOutputIndices_.size(); ++ri) {
+      outCols[rightColumnOutputIndices_[ri]] =
+          std::move(rCols[ri]);
+    }
+    stream.synchronize();
+    results.push_back(
+        std::make_unique<cudf::table>(std::move(outCols)));
+  }
+  return results;
+}
+
+std::vector<std::unique_ptr<cudf::table>>
+CudfNestedLoopJoinProbe::fullJoin(
+    cudf::table_view leftView,
+    rmm::cuda_stream_view stream) {
+  std::vector<std::unique_ptr<cudf::table>> results;
+  auto mr = cudf::get_current_device_resource_ref();
+  auto& buildTables = buildData_.value();
+
+  for (size_t i = 0; i < buildTables.size(); ++i) {
+    auto rightView = buildTables[i]->view();
+
+    if (!joinNode_->joinCondition()) {
+      if (leftView.num_rows() == 0 &&
+          rightView.num_rows() == 0) {
+        continue;
+      }
+      if (leftView.num_rows() > 0 &&
+          rightView.num_rows() > 0) {
+        results.push_back(crossJoinAndFilter(
+            leftView, rightView, stream));
+        auto trueScalar =
+            cudf::numeric_scalar<bool>(true, true, stream);
+        rightMatchedFlags_[i] = cudf::make_column_from_scalar(
+            trueScalar, rightView.num_rows(), stream, mr);
+        continue;
+      }
+    }
+
+    if (leftView.num_rows() == 0 || rightView.num_rows() == 0) {
+      if (leftView.num_rows() > 0) {
+        // Left rows with null build columns
+        std::vector<std::unique_ptr<cudf::column>> outCols(
+            outputType_->size());
+        auto n = leftView.num_rows();
+        for (size_t li = 0;
+             li < leftColumnOutputIndices_.size(); ++li) {
+          auto idx = leftColumnOutputIndices_[li];
+          outCols[idx] = std::make_unique<cudf::column>(
+              leftView.column(leftColumnIndicesToGather_[li]),
+              stream, mr);
+        }
+        for (size_t ri = 0;
+             ri < rightColumnOutputIndices_.size(); ++ri) {
+          auto idx = rightColumnOutputIndices_[ri];
+          auto srcCol = rightView.column(
+              rightColumnIndicesToGather_[ri]);
+          auto scalar = cudf::make_default_constructed_scalar(
+              srcCol.type(), stream, mr);
+          outCols[idx] = cudf::make_column_from_scalar(
+              *scalar, n, stream, mr);
+        }
+        results.push_back(
+            std::make_unique<cudf::table>(std::move(outCols)));
+      }
+      continue;
+    }
+
+    auto [leftIndices, rightIndices] =
+        cudf::conditional_left_join(
+            leftView, rightView, tree_.back(), {}, stream, mr);
+
+    // Track matched right rows
+    if (rightIndices->size() > 0) {
+      auto n = rightView.num_rows();
+      auto rowSeq = cudf::sequence(
+          n,
+          cudf::numeric_scalar<cudf::size_type>(
+              0, true, stream),
+          cudf::numeric_scalar<cudf::size_type>(
+              1, true, stream),
+          stream,
+          mr);
+      auto rightIdxCol = cudf::column_view{
+          cudf::device_span<cudf::size_type const>{
+              *rightIndices}};
+      auto matched =
+          cudf::contains(rightIdxCol, rowSeq->view(), stream);
+      auto updated = cudf::binary_operation(
+          rightMatchedFlags_[i]->view(),
+          matched->view(),
+          cudf::binary_operator::BITWISE_OR,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          mr);
+      rightMatchedFlags_[i] = std::move(updated);
+    }
+
+    auto leftSpan =
+        cudf::device_span<cudf::size_type const>{*leftIndices};
+    auto rightSpan =
+        cudf::device_span<cudf::size_type const>{*rightIndices};
+    auto leftCol = cudf::column_view{leftSpan};
+    auto rightCol = cudf::column_view{rightSpan};
+
+    auto leftInput =
+        leftView.select(leftColumnIndicesToGather_);
+    auto rightInput =
+        rightView.select(rightColumnIndicesToGather_);
+
+    static constexpr auto oob =
+        cudf::out_of_bounds_policy::NULLIFY;
+    auto leftGathered =
+        cudf::gather(leftInput, leftCol, oob, stream);
+    auto rightGathered =
+        cudf::gather(rightInput, rightCol, oob, stream);
+
+    auto lCols = leftGathered->release();
+    auto rCols = rightGathered->release();
+    std::vector<std::unique_ptr<cudf::column>> outCols(
+        outputType_->size());
+    for (size_t li = 0;
+         li < leftColumnOutputIndices_.size(); ++li) {
+      outCols[leftColumnOutputIndices_[li]] =
+          std::move(lCols[li]);
+    }
+    for (size_t ri = 0;
+         ri < rightColumnOutputIndices_.size(); ++ri) {
+      outCols[rightColumnOutputIndices_[ri]] =
+          std::move(rCols[ri]);
+    }
+    stream.synchronize();
+    results.push_back(
+        std::make_unique<cudf::table>(std::move(outCols)));
+  }
+  return results;
+}
+
+std::vector<std::unique_ptr<cudf::table>>
+CudfNestedLoopJoinProbe::leftSemiProjectJoin(
+    cudf::table_view leftView,
+    rmm::cuda_stream_view stream) {
+  std::vector<std::unique_ptr<cudf::table>> results;
+  auto mr = cudf::get_current_device_resource_ref();
+  auto leftN = leftView.num_rows();
+
+  auto falseScalar =
+      cudf::numeric_scalar<bool>(false, true, stream);
+  auto matchFlags = cudf::make_column_from_scalar(
+      falseScalar, leftN, stream, mr);
+
+  auto rowIndices = cudf::sequence(
+      leftN,
+      cudf::numeric_scalar<cudf::size_type>(0, true, stream),
+      cudf::numeric_scalar<cudf::size_type>(1, true, stream),
+      stream,
+      mr);
+
+  for (auto& buildTbl : buildData_.value()) {
+    auto rightView = buildTbl->view();
+    if (rightView.num_rows() == 0) {
+      continue;
+    }
+
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>>
+        leftIndices;
+    if (joinNode_->joinCondition()) {
+      leftIndices = cudf::conditional_left_semi_join(
+          leftView, rightView, tree_.back(), {}, stream, mr);
+    } else {
+      // No condition: every left row matches if build non-empty
+      auto trueScalar =
+          cudf::numeric_scalar<bool>(true, true, stream);
+      matchFlags = cudf::make_column_from_scalar(
+          trueScalar, leftN, stream, mr);
+      continue;
+    }
+
+    if (leftIndices->size() > 0) {
+      auto leftIdxCol = cudf::column_view{
+          cudf::device_span<cudf::size_type const>{
+              *leftIndices}};
+      auto matched = cudf::contains(
+          leftIdxCol, rowIndices->view(), stream);
+      auto updated = cudf::binary_operation(
+          matchFlags->view(),
+          matched->view(),
+          cudf::binary_operator::BITWISE_OR,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          mr);
+      matchFlags = std::move(updated);
+    }
+  }
+
+  auto leftInput =
+      leftView.select(leftColumnIndicesToGather_);
+  std::vector<std::unique_ptr<cudf::column>> outCols(
+      outputType_->size());
+  for (size_t j = 0; j < leftColumnOutputIndices_.size(); ++j) {
+    outCols[leftColumnOutputIndices_[j]] =
+        std::make_unique<cudf::column>(
+            leftInput.column(j), stream, mr);
+  }
+  outCols[matchColumnOutputIndex_] = std::move(matchFlags);
+
+  stream.synchronize();
+  results.push_back(
+      std::make_unique<cudf::table>(std::move(outCols)));
+  return results;
+}
+
+RowVectorPtr CudfNestedLoopJoinProbe::getOutput() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
+  GpuGuard gpuGuard;
+
+  if (finished_ || !buildData_.has_value()) {
+    return nullptr;
+  }
+
+  if (!input_) {
+    // Emit unmatched build rows for right/full joins
+    if ((core::isRightJoin(joinType_) ||
+         core::isFullJoin(joinType_)) &&
+        noMoreInput_ && !finished_ && isLastDriver_) {
+      auto& buildTables = buildData_.value();
+      auto stream = cudfGlobalStreamPool().get_stream();
+      auto mr = cudf::get_current_device_resource_ref();
+      std::vector<std::unique_ptr<cudf::table>> toConcat;
+
+      for (size_t i = 0; i < buildTables.size(); ++i) {
+        auto& buildTbl = buildTables[i];
+        auto n = buildTbl->num_rows();
+        if (n == 0) {
+          continue;
+        }
+        auto& flags = rightMatchedFlags_[i];
+        auto boolMask = cudf::unary_operation(
+            flags->view(), cudf::unary_operator::NOT, stream);
+
+        auto unmatchedCount = cudf::reduce(
+            boolMask->view(),
+            *cudf::make_sum_aggregation<
+                cudf::reduce_aggregation>(),
+            cudf::data_type{cudf::type_id::INT32},
+            stream);
+        auto m = static_cast<cudf::numeric_scalar<int32_t>*>(
+                     unmatchedCount.get())
+                     ->value(stream);
+        if (m == 0) {
+          continue;
+        }
+
+        std::vector<std::unique_ptr<cudf::column>> outCols(
+            outputType_->size());
+        for (size_t li = 0;
+             li < leftColumnOutputIndices_.size(); ++li) {
+          auto outIdx = leftColumnOutputIndices_[li];
+          auto probeChannel = leftColumnIndicesToGather_[li];
+          auto cudfType =
+              veloxToCudfTypeId(probeType_->childAt(probeChannel));
+          auto nullScalar =
+              cudf::make_default_constructed_scalar(
+                  cudf::data_type{cudfType});
+          outCols[outIdx] = cudf::make_column_from_scalar(
+              *nullScalar, m, stream, mr);
+        }
+        if (!rightColumnIndicesToGather_.empty()) {
+          auto rightInput = buildTbl->view().select(
+              rightColumnIndicesToGather_);
+          auto unmatchedRight = cudf::apply_boolean_mask(
+              rightInput, boolMask->view(), stream);
+          auto rightCols = unmatchedRight->release();
+          for (size_t ri = 0;
+               ri < rightColumnOutputIndices_.size(); ++ri) {
+            outCols[rightColumnOutputIndices_[ri]] =
+                std::move(rightCols[ri]);
+          }
+        }
+        toConcat.push_back(
+            std::make_unique<cudf::table>(std::move(outCols)));
+      }
+
+      if (!toConcat.empty()) {
+        auto out =
+            concatenateTables(std::move(toConcat), stream);
+        finished_ = true;
+        auto size = out->num_rows();
+        if (out->num_columns() == 0 || size == 0) {
+          return nullptr;
+        }
+        return std::make_shared<CudfVector>(
+            pool(), outputType_, size, std::move(out), stream);
+      }
+      finished_ = true;
+    }
+    return nullptr;
+  }
+
+  auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
+  VELOX_CHECK_NOT_NULL(cudfInput);
+  auto stream = cudfInput->stream();
+  auto leftView = cudfInput->getTableView();
+
+  std::vector<std::unique_ptr<cudf::table>> cudfOutputs;
+  switch (joinType_) {
+    case core::JoinType::kInner:
+      cudfOutputs = innerJoin(leftView, stream);
+      break;
+    case core::JoinType::kLeft:
+      cudfOutputs = leftJoin(leftView, stream);
+      break;
+    case core::JoinType::kRight:
+      cudfOutputs = rightJoin(leftView, stream);
+      break;
+    case core::JoinType::kFull:
+      cudfOutputs = fullJoin(leftView, stream);
+      break;
+    case core::JoinType::kLeftSemiProject:
+      cudfOutputs = leftSemiProjectJoin(leftView, stream);
+      break;
+    default:
+      VELOX_FAIL(
+          "Unsupported NLJ type: {}", static_cast<int>(joinType_));
+  }
+
+  cudfInput.reset();
+  input_.reset();
+  finished_ = noMoreInput_ &&
+      !core::isRightJoin(joinType_) &&
+      !core::isFullJoin(joinType_);
+
+  auto cudfOutput =
+      concatenateTables(std::move(cudfOutputs), stream);
+  auto size = cudfOutput->num_rows();
+  if (cudfOutput->num_columns() == 0 || size == 0) {
+    return nullptr;
+  }
+  return std::make_shared<CudfVector>(
+      pool(), outputType_, size, std::move(cudfOutput), stream);
+}
+
+// ---- Translator ----
+
+std::unique_ptr<exec::Operator>
+CudfNestedLoopJoinBridgeTranslator::toOperator(
+    exec::DriverCtx* ctx,
+    int32_t id,
+    const core::PlanNodePtr& node) {
+  if (auto nlNode =
+          std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(
+              node)) {
+    return std::make_unique<CudfNestedLoopJoinProbe>(
+        id, ctx, nlNode);
+  }
+  return nullptr;
+}
+
+std::unique_ptr<exec::JoinBridge>
+CudfNestedLoopJoinBridgeTranslator::toJoinBridge(
+    const core::PlanNodePtr& node) {
+  if (auto nlNode =
+          std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(
+              node)) {
+    return std::make_unique<CudfNestedLoopJoinBridge>();
+  }
+  return nullptr;
+}
+
+exec::OperatorSupplier
+CudfNestedLoopJoinBridgeTranslator::toOperatorSupplier(
+    const core::PlanNodePtr& node) {
+  if (auto nlNode =
+          std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(
+              node)) {
+    return [nlNode](int32_t operatorId, exec::DriverCtx* ctx) {
+      return std::make_unique<CudfNestedLoopJoinBuild>(
+          operatorId, ctx, nlNode);
+    };
+  }
+  return nullptr;
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/cudf/exec/NvtxHelper.h"
+#include "velox/experimental/cudf/expression/AstExpression.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/JoinBridge.h"
+#include "velox/exec/Operator.h"
+
+#include <cudf/ast/expressions.hpp>
+#include <cudf/table/table.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <memory>
+
+namespace facebook::velox::cudf_velox {
+
+class CudfExpression;
+
+class CudfNestedLoopJoinBridge : public exec::JoinBridge {
+ public:
+  using data_type = std::vector<std::shared_ptr<cudf::table>>;
+
+  void setData(std::optional<data_type> data);
+  std::optional<data_type> dataOrFuture(ContinueFuture* future);
+
+  void setBuildStream(rmm::cuda_stream_view buildStream);
+  std::optional<rmm::cuda_stream_view> getBuildStream();
+
+ private:
+  std::optional<data_type> data_;
+  std::optional<rmm::cuda_stream_view> buildStream_;
+};
+
+class CudfNestedLoopJoinBuild
+    : public exec::Operator,
+      public NvtxHelper {
+ public:
+  CudfNestedLoopJoinBuild(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const core::NestedLoopJoinNode> joinNode);
+
+  void addInput(RowVectorPtr input) override;
+  bool needsInput() const override;
+  RowVectorPtr getOutput() override;
+  void noMoreInput() override;
+  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+  bool isFinished() override;
+
+ private:
+  std::shared_ptr<const core::NestedLoopJoinNode> joinNode_;
+  std::vector<CudfVectorPtr> inputs_;
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
+};
+
+class CudfNestedLoopJoinProbe
+    : public exec::Operator,
+      public NvtxHelper {
+ public:
+  using data_type = CudfNestedLoopJoinBridge::data_type;
+
+  CudfNestedLoopJoinProbe(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const core::NestedLoopJoinNode> joinNode);
+
+  void initialize() override;
+  bool needsInput() const override;
+  void addInput(RowVectorPtr input) override;
+  void noMoreInput() override;
+  RowVectorPtr getOutput() override;
+  void close() override;
+  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+  bool isFinished() override;
+
+  static bool isSupportedJoinType(core::JoinType joinType) {
+    return joinType == core::JoinType::kInner ||
+        joinType == core::JoinType::kLeft ||
+        joinType == core::JoinType::kRight ||
+        joinType == core::JoinType::kFull ||
+        joinType == core::JoinType::kLeftSemiProject;
+  }
+
+ private:
+  std::shared_ptr<const core::NestedLoopJoinNode> joinNode_;
+  core::JoinType joinType_;
+
+  std::optional<data_type> buildData_;
+  RowTypePtr probeType_;
+  RowTypePtr buildType_;
+
+  // Filter / AST
+  cudf::ast::tree tree_;
+  std::vector<std::unique_ptr<cudf::scalar>> scalars_;
+  std::shared_ptr<CudfExpression> filterEvaluator_;
+
+  // Column mapping
+  std::vector<cudf::size_type> leftColumnIndicesToGather_;
+  std::vector<cudf::size_type> rightColumnIndicesToGather_;
+  std::vector<size_t> leftColumnOutputIndices_;
+  std::vector<size_t> rightColumnOutputIndices_;
+  int32_t matchColumnOutputIndex_{-1};
+
+  bool finished_{false};
+  bool isLastDriver_{false};
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
+
+  std::optional<rmm::cuda_stream_view> buildStream_;
+
+  // For right/full: track which build rows have been matched.
+  std::vector<std::unique_ptr<cudf::column>> rightMatchedFlags_;
+
+  std::unique_ptr<cudf::table> crossJoinAndFilter(
+      cudf::table_view leftView,
+      cudf::table_view rightView,
+      rmm::cuda_stream_view stream);
+
+  std::vector<std::unique_ptr<cudf::table>> innerJoin(
+      cudf::table_view leftView,
+      rmm::cuda_stream_view stream);
+  std::vector<std::unique_ptr<cudf::table>> leftJoin(
+      cudf::table_view leftView,
+      rmm::cuda_stream_view stream);
+  std::vector<std::unique_ptr<cudf::table>> rightJoin(
+      cudf::table_view leftView,
+      rmm::cuda_stream_view stream);
+  std::vector<std::unique_ptr<cudf::table>> fullJoin(
+      cudf::table_view leftView,
+      rmm::cuda_stream_view stream);
+  std::vector<std::unique_ptr<cudf::table>> leftSemiProjectJoin(
+      cudf::table_view leftView,
+      rmm::cuda_stream_view stream);
+};
+
+class CudfNestedLoopJoinBridgeTranslator
+    : public exec::Operator::PlanNodeTranslator {
+ public:
+  std::unique_ptr<exec::Operator> toOperator(
+      exec::DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node);
+
+  std::unique_ptr<exec::JoinBridge> toJoinBridge(
+      const core::PlanNodePtr& node);
+
+  exec::OperatorSupplier toOperatorSupplier(
+      const core::PlanNodePtr& node);
+};
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -19,6 +19,7 @@
 #include "velox/experimental/cudf/exec/CudfFilterProject.h"
 #include "velox/experimental/cudf/exec/CudfHashAggregation.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
+#include "velox/experimental/cudf/exec/CudfNestedLoopJoin.h"
 #include "velox/experimental/cudf/exec/CudfLimit.h"
 #include "velox/experimental/cudf/exec/CudfLocalPartition.h"
 #include "velox/experimental/cudf/exec/CudfOrderBy.h"
@@ -33,6 +34,8 @@
 #include "velox/exec/HashAggregation.h"
 #include "velox/exec/HashBuild.h"
 #include "velox/exec/HashProbe.h"
+#include "velox/exec/NestedLoopJoinBuild.h"
+#include "velox/exec/NestedLoopJoinProbe.h"
 #include "velox/exec/Limit.h"
 #include "velox/exec/LocalPartition.h"
 #include "velox/exec/OrderBy.h"
@@ -276,9 +279,13 @@ class CudfHashJoinBaseAdapter : public OperatorAdapter {
       return false;
     }
 
-    // Disabling null-aware anti join with filter until we implement it right
-    if (joinPlanNode->joinType() == core::JoinType::kAnti &&
-        joinPlanNode->isNullAware() && joinPlanNode->filter()) {
+    // Null-aware left semi project with filter requires per-row
+    // null analysis that depends on the filter result. Fall back
+    // to CPU for correctness.
+    if (joinPlanNode->isNullAware() &&
+        joinPlanNode->joinType() ==
+            core::JoinType::kLeftSemiProject &&
+        joinPlanNode->filter()) {
       return false;
     }
 
@@ -352,6 +359,106 @@ class HashJoinProbeAdapter : public CudfHashJoinBaseAdapter {
     std::vector<std::unique_ptr<exec::Operator>> result;
     result.push_back(
         std::make_unique<CudfHashJoinProbe>(operatorId, ctx, joinPlanNode));
+    return result;
+  }
+};
+
+class CudfNestedLoopJoinBaseAdapter : public OperatorAdapter {
+ public:
+  using OperatorAdapter::OperatorAdapter;
+
+  bool canRunOnGPU(
+      const exec::Operator* op,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx) const override {
+    if (!canHandle(op)) {
+      return false;
+    }
+    auto nlNode =
+        std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(
+            planNode);
+    if (!nlNode) {
+      return false;
+    }
+    if (!CudfNestedLoopJoinProbe::isSupportedJoinType(
+            nlNode->joinType())) {
+      return false;
+    }
+    if (nlNode->joinCondition()) {
+      if (!canBeEvaluatedByCudf(
+              {nlNode->joinCondition()},
+              ctx->task->queryCtx().get())) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+class NestedLoopJoinBuildAdapter
+    : public CudfNestedLoopJoinBaseAdapter {
+ public:
+  NestedLoopJoinBuildAdapter()
+      : CudfNestedLoopJoinBaseAdapter("NestedLoopJoinBuild") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::NestedLoopJoinBuild*>(op) !=
+        nullptr;
+  }
+
+  bool acceptsGpuInput() const override {
+    return true;
+  }
+  bool producesGpuOutput() const override {
+    return false;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator*,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx,
+      int32_t operatorId) const override {
+    auto nlNode =
+        std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(
+            planNode);
+    std::vector<std::unique_ptr<exec::Operator>> result;
+    result.push_back(
+        std::make_unique<CudfNestedLoopJoinBuild>(
+            operatorId, ctx, nlNode));
+    return result;
+  }
+};
+
+class NestedLoopJoinProbeAdapter
+    : public CudfNestedLoopJoinBaseAdapter {
+ public:
+  NestedLoopJoinProbeAdapter()
+      : CudfNestedLoopJoinBaseAdapter("NestedLoopJoinProbe") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::NestedLoopJoinProbe*>(op) !=
+        nullptr;
+  }
+
+  bool acceptsGpuInput() const override {
+    return true;
+  }
+  bool producesGpuOutput() const override {
+    return true;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator*,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx,
+      int32_t operatorId) const override {
+    auto nlNode =
+        std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(
+            planNode);
+    std::vector<std::unique_ptr<exec::Operator>> result;
+    result.push_back(
+        std::make_unique<CudfNestedLoopJoinProbe>(
+            operatorId, ctx, nlNode));
     return result;
   }
 };
@@ -690,6 +797,10 @@ void registerAllOperatorAdapters() {
   registry.registerAdapter(std::make_unique<AggregationAdapter>());
   registry.registerAdapter(std::make_unique<HashJoinBuildAdapter>());
   registry.registerAdapter(std::make_unique<HashJoinProbeAdapter>());
+  registry.registerAdapter(
+      std::make_unique<NestedLoopJoinBuildAdapter>());
+  registry.registerAdapter(
+      std::make_unique<NestedLoopJoinProbeAdapter>());
   registry.registerAdapter(std::make_unique<OrderByAdapter>());
   registry.registerAdapter(std::make_unique<TopNAdapter>());
   registry.registerAdapter(std::make_unique<LimitAdapter>());

--- a/velox/experimental/cudf/exec/PinnedArrowInterop.cpp
+++ b/velox/experimental/cudf/exec/PinnedArrowInterop.cpp
@@ -403,12 +403,21 @@ void buildArrowColumnFromPacked(
           buf, hostBuf, hostBase + col.data_offset, dataBytes);
       out->buffers[1] = buf->data;
     } else if (col.data_offset != -1 && arrowType == NANOARROW_TYPE_BOOL) {
+      // cudf BOOL8 stores 1 byte per element; Arrow BOOL stores 1 bit
+      // per element. Convert byte-per-value to bit-packed bitmask.
+      auto numElements = static_cast<int64_t>(col.size);
+      auto bitmaskBytes = (numElements + 7) / 8;
+      auto* srcBytes = hostBase + col.data_offset;
+
       auto* buf = ArrowArrayBuffer(out, 1);
-      auto dataBytes =
-          static_cast<int64_t>(cudf::bitmask_allocation_size_bytes(col.size));
-      attachHostBufToArrowBuffer(
-          buf, hostBuf, hostBase + col.data_offset, dataBytes);
-      out->buffers[1] = buf->data;
+      NANOARROW_THROW_NOT_OK(ArrowBufferResize(buf, bitmaskBytes, 0));
+      auto* dst = reinterpret_cast<uint8_t*>(buf->data);
+      memset(dst, 0, bitmaskBytes);
+      for (int64_t i = 0; i < numElements; ++i) {
+        if (srcBytes[i]) {
+          dst[i / 8] |= static_cast<uint8_t>(1 << (i % 8));
+        }
+      }
     }
 
     // Recurse into children (e.g. for STRUCT or LIST types)

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -22,6 +22,7 @@
 #include "velox/experimental/cudf/exec/CudfFilterProject.h"
 #include "velox/experimental/cudf/exec/CudfHashAggregation.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
+#include "velox/experimental/cudf/exec/CudfNestedLoopJoin.h"
 #include "velox/experimental/cudf/exec/CudfLimit.h"
 #include "velox/experimental/cudf/exec/CudfLocalPartition.h"
 #include "velox/experimental/cudf/exec/CudfOperator.h"
@@ -389,6 +390,8 @@ void registerCudf() {
 
   exec::Operator::registerOperator(
       std::make_unique<CudfHashJoinBridgeTranslator>());
+  exec::Operator::registerOperator(
+      std::make_unique<CudfNestedLoopJoinBridgeTranslator>());
   CudfDriverAdapter cda{CudfConfig::getInstance().allowCpuFallback};
   exec::DriverAdapter cudfAdapter{kCudfAdapterName, {}, cda};
   exec::DriverFactory::registerAdapter(cudfAdapter);

--- a/velox/experimental/cudf/expression/AstExpression.h
+++ b/velox/experimental/cudf/expression/AstExpression.h
@@ -38,8 +38,7 @@ cudf::ast::expression const& createAstTree(
     const RowTypePtr& leftRowSchema,
     const RowTypePtr& rightRowSchema,
     std::vector<PrecomputeInstruction>& leftPrecomputeInstructions,
-    std::vector<PrecomputeInstruction>& rightPrecomputeInstructions,
-    const bool allowPureAstOnly);
+    std::vector<PrecomputeInstruction>& rightPrecomputeInstructions);
 
 // Evaluates the expression tree
 class ASTExpression : public CudfExpression {
@@ -53,7 +52,7 @@ class ASTExpression : public CudfExpression {
 
   // Evaluates the expression tree for the given input columns
   ColumnOrView eval(
-      std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
+      std::vector<cudf::column_view> inputColumnViews,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr,
       bool finalize = false) override;

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -349,6 +349,9 @@ struct AstContext {
   cudf::ast::expression const& multipleInputsToPairWise(
       const std::shared_ptr<velox::exec::Expr>& expr);
   static bool canBeEvaluated(const std::shared_ptr<velox::exec::Expr>& expr);
+  // Determines which side (0=left, 1=right) an expression references by
+  // examining its field references. Returns -1 if no fields found.
+  int findExpressionSide(const std::shared_ptr<velox::exec::Expr>& expr) const;
 };
 
 // get nested column indices
@@ -573,16 +576,33 @@ cudf::ast::expression const& AstContext::pushExprToTree(
   } else if (!allowPureAstOnly && canBeEvaluatedByCudf(expr, /*deep=*/false)) {
     // Shallow check: only verify this operation is supported
     // Children will be recursively handled by createCudfExpression
+    // Determine which side this expression references
+    int sideIdx = findExpressionSide(expr);
+    if (sideIdx < 0) {
+      sideIdx = 0; // Default to left side if no fields found
+    }
     auto node =
-        createCudfExpression(expr, inputRowSchema[0], kAstEvaluatorName);
-    return addPrecomputeInstructionOnSide(0, 0, name, "", node);
+        createCudfExpression(expr, inputRowSchema[sideIdx], kAstEvaluatorName);
+    return addPrecomputeInstructionOnSide(sideIdx, 0, name, "", node);
   } else {
     VELOX_FAIL("Unsupported expression: " + name);
   }
 }
 
+int AstContext::findExpressionSide(
+    const std::shared_ptr<velox::exec::Expr>& expr) const {
+  for (const auto* field : expr->distinctFields()) {
+    for (size_t sideIdx = 0; sideIdx < inputRowSchema.size(); ++sideIdx) {
+      if (inputRowSchema[sideIdx].get()->containsChild(field->field())) {
+        return static_cast<int>(sideIdx);
+      }
+    }
+  }
+  return -1;
+}
+
 std::vector<ColumnOrView> precomputeSubexpressions(
-    std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
+    const std::vector<cudf::column_view>& inputColumnViews,
     const std::vector<PrecomputeInstruction>& precomputeInstructions,
     const std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const RowTypePtr& inputRowSchema,
@@ -601,7 +621,7 @@ std::vector<ColumnOrView> precomputeSubexpressions(
     // If a compiled cudf node is available, evaluate it directly.
     if (cudf_expression) {
       auto result = cudf_expression->eval(
-          inputTableColumns,
+          inputColumnViews,
           stream,
           cudf::get_current_device_resource_ref(),
           /*finalize=*/true);
@@ -613,13 +633,13 @@ std::vector<ColumnOrView> precomputeSubexpressions(
           std::stoi(ins_name.substr(5)); // "fill " is 5 characters
       auto newColumn = cudf::make_column_from_scalar(
           *static_cast<cudf::string_scalar*>(scalars[scalarIndex].get()),
-          inputTableColumns[dependent_column_index]->size(),
+          inputColumnViews[dependent_column_index].size(),
           stream,
           cudf::get_current_device_resource_ref());
       precomputedColumns.push_back(std::move(newColumn));
     } else if (ins_name == "nested_column") {
       // Nested column already exists in input. Don't materialize.
-      auto view = inputTableColumns[dependent_column_index]->view().child(
+      auto view = inputColumnViews[dependent_column_index].child(
           nested_dependent_column_indices[0]);
       precomputedColumns.push_back(view);
     } else {

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -1246,7 +1246,7 @@ std::shared_ptr<FunctionExpression> FunctionExpression::create(
 }
 
 ColumnOrView FunctionExpression::eval(
-    std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
+    std::vector<cudf::column_view> inputColumnViews,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr,
     bool finalize) {
@@ -1255,18 +1255,18 @@ ColumnOrView FunctionExpression::eval(
   if (auto fieldExpr = std::dynamic_pointer_cast<FieldReference>(expr_)) {
     auto name = fieldExpr->name();
     auto columnIndex = inputRowSchema_->getChildIdx(name);
-    return inputTableColumns[columnIndex]->view();
+    return inputColumnViews[columnIndex];
   }
 
   if (function_) {
-    std::vector<ColumnOrView> inputColumns;
-    inputColumns.reserve(subexpressions_.size());
+    std::vector<ColumnOrView> subexprResults;
+    subexprResults.reserve(subexpressions_.size());
 
     for (const auto& subexpr : subexpressions_) {
-      inputColumns.push_back(subexpr->eval(inputTableColumns, stream, mr));
+      subexprResults.push_back(subexpr->eval(inputColumnViews, stream, mr));
     }
 
-    auto result = function_->eval(inputColumns, stream, mr);
+    auto result = function_->eval(subexprResults, stream, mr);
     if (finalize) {
       const auto requestedType =
           cudf::data_type(cudf_velox::veloxToCudfTypeId(expr_->type()));

--- a/velox/experimental/cudf/expression/JitExpression.h
+++ b/velox/experimental/cudf/expression/JitExpression.h
@@ -36,7 +36,7 @@ class JitExpression : public CudfExpression {
 
   // Evaluates the expression tree for the given input columns
   ColumnOrView eval(
-      std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
+      std::vector<cudf::column_view> inputColumnViews,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr,
       bool finalize = false) override;

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Stub for gluten::lockGpu/unlockGpu (provided by gluten in production).
+add_library(velox_cudf_gpu_guard_stub STATIC GpuGuardStub.cpp)
+
 add_executable(velox_cudf_aggregation_test Main.cpp AggregationTest.cpp)
 add_executable(velox_cudf_assign_unique_id_test Main.cpp AssignUniqueIdTest.cpp)
 add_executable(velox_cudf_config_test Main.cpp ConfigTest.cpp)
 add_executable(velox_cudf_expression_selection_test Main.cpp ExpressionEvaluatorSelectionTest.cpp)
 add_executable(velox_cudf_filter_project_test Main.cpp FilterProjectTest.cpp)
 add_executable(velox_cudf_hash_join_test HashJoinTest.cpp Main.cpp)
+add_executable(velox_cudf_nested_loop_join_test Main.cpp NestedLoopJoinTest.cpp)
 add_executable(velox_cudf_limit_test Main.cpp LimitTest.cpp)
 add_executable(velox_cudf_local_partition_test Main.cpp LocalPartitionTest.cpp)
 add_executable(velox_cudf_order_by_test Main.cpp OrderByTest.cpp)
@@ -73,6 +77,12 @@ add_test(
 add_test(
   NAME velox_cudf_hash_join_test
   COMMAND velox_cudf_hash_join_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_test(
+  NAME velox_cudf_nested_loop_join_test
+  COMMAND velox_cudf_nested_loop_join_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -155,6 +165,7 @@ set_tests_properties(
 )
 set_tests_properties(velox_cudf_filter_project_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_hash_join_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
+set_tests_properties(velox_cudf_nested_loop_join_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_limit_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_local_partition_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_order_by_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
@@ -224,6 +235,7 @@ target_link_libraries(
 target_link_libraries(
   velox_cudf_hash_join_test
   velox_cudf_exec
+  velox_cudf_gpu_guard_stub
   velox_exec
   velox_exec_test_lib
   velox_test_util
@@ -231,6 +243,18 @@ target_link_libraries(
   gtest
   gtest_main
   Folly::folly
+  fmt::fmt
+)
+
+target_link_libraries(
+  velox_cudf_nested_loop_join_test
+  velox_cudf_exec
+  velox_cudf_gpu_guard_stub
+  velox_exec
+  velox_exec_test_lib
+  velox_test_util
+  gtest
+  gtest_main
   fmt::fmt
 )
 

--- a/velox/experimental/cudf/tests/GpuGuardStub.cpp
+++ b/velox/experimental/cudf/tests/GpuGuardStub.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Stub for gluten::lockGpu/unlockGpu used by GpuGuard.h.
+// In production these are provided by the gluten layer; for velox-only
+// unit tests we supply no-op implementations so linking succeeds.
+namespace gluten {
+void lockGpu() {}
+void unlockGpu() {}
+} // namespace gluten

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -2304,22 +2304,19 @@ TEST_P(MultiThreadedHashJoinTest, fullJoin) {
         });
       });
 
-  // full join not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .numDrivers(numDrivers_)
-          .injectSpill(false)
-          .probeKeys({"c0"})
-          .probeVectors(std::move(probeVectors))
-          .buildKeys({"u_c0"})
-          .buildVectors(std::move(buildVectors))
-          .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
-          .joinType(core::JoinType::kFull)
-          .joinOutputLayout({"c0", "c1", "u_c1"})
-          .referenceQuery(
-              "SELECT t.c0, t.c1, u.c1 FROM t FULL OUTER JOIN u ON t.c0 = u.c0")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .injectSpill(false)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kFull)
+      .joinOutputLayout({"c0", "c1", "u_c1"})
+      .referenceQuery(
+          "SELECT t.c0, t.c1, u.c1 FROM t FULL OUTER JOIN u ON t.c0 = u.c0")
+      .run();
 }
 
 TEST_P(MultiThreadedHashJoinTest, fullJoinWithEmptyBuild) {
@@ -2362,25 +2359,22 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithEmptyBuild) {
           });
         });
 
-    // full join not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
-            .numDrivers(numDrivers_)
-            .injectSpill(false)
-            .probeKeys({"c0"})
-            .probeVectors(std::move(probeVectors))
-            .buildKeys({"u_c0"})
-            .buildVectors(std::move(buildVectors))
-            .buildFilter("c0 > 100")
-            .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
-            .joinType(core::JoinType::kFull)
-            .joinOutputLayout({"c1"})
-            .referenceQuery(
-                "SELECT t.c1 FROM t FULL OUTER JOIN (SELECT * FROM u WHERE c0 > 100) u ON t.c0 = u.c0")
-            .checkSpillStats(false)
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
+        .numDrivers(numDrivers_)
+        .injectSpill(false)
+        .probeKeys({"c0"})
+        .probeVectors(std::move(probeVectors))
+        .buildKeys({"u_c0"})
+        .buildVectors(std::move(buildVectors))
+        .buildFilter("c0 > 100")
+        .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+        .joinType(core::JoinType::kFull)
+        .joinOutputLayout({"c1"})
+        .referenceQuery(
+            "SELECT t.c1 FROM t FULL OUTER JOIN (SELECT * FROM u WHERE c0 > 100) u ON t.c0 = u.c0")
+        .checkSpillStats(false)
+        .run();
   }
 }
 
@@ -2420,23 +2414,20 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithNoMatch) {
         });
       });
 
-  // full join not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .numDrivers(numDrivers_)
-          .injectSpill(false)
-          .probeKeys({"c0"})
-          .probeVectors(std::move(probeVectors))
-          .buildKeys({"u_c0"})
-          .buildVectors(std::move(buildVectors))
-          .buildFilter("c0 < 0")
-          .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
-          .joinType(core::JoinType::kFull)
-          .joinOutputLayout({"c1"})
-          .referenceQuery(
-              "SELECT t.c1 FROM t FULL OUTER JOIN (SELECT * FROM u WHERE c0 < 0) u ON t.c0 = u.c0")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .injectSpill(false)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildFilter("c0 < 0")
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kFull)
+      .joinOutputLayout({"c1"})
+      .referenceQuery(
+          "SELECT t.c1 FROM t FULL OUTER JOIN (SELECT * FROM u WHERE c0 < 0) u ON t.c0 = u.c0")
+      .run();
 }
 
 TEST_P(MultiThreadedHashJoinTest, fullJoinWithFilters) {
@@ -2479,46 +2470,40 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithFilters) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    // full join not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .numDrivers(numDrivers_)
-            .injectSpill(false)
-            .probeKeys({"c0"})
-            .probeVectors(std::move(testProbeVectors))
-            .buildKeys({"u_c0"})
-            .buildVectors(std::move(testBuildVectors))
-            .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
-            .joinType(core::JoinType::kFull)
-            .joinFilter("(c1 + u_c1) % 2 = 1")
-            .joinOutputLayout({"c0", "c1", "u_c1"})
-            .referenceQuery(
-                "SELECT t.c0, t.c1, u.c1 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 AND (t.c1 + u.c1) % 2 = 1")
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(numDrivers_)
+        .injectSpill(false)
+        .probeKeys({"c0"})
+        .probeVectors(std::move(testProbeVectors))
+        .buildKeys({"u_c0"})
+        .buildVectors(std::move(testBuildVectors))
+        .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+        .joinType(core::JoinType::kFull)
+        .joinFilter("(c1 + u_c1) % 2 = 1")
+        .joinOutputLayout({"c0", "c1", "u_c1"})
+        .referenceQuery(
+            "SELECT t.c0, t.c1, u.c1 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 AND (t.c1 + u.c1) % 2 = 1")
+        .run();
   }
 
   // Filter without passed rows.
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    // full join not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .numDrivers(numDrivers_)
-            .injectSpill(false)
-            .probeKeys({"c0"})
-            .probeVectors(std::move(testProbeVectors))
-            .buildKeys({"u_c0"})
-            .buildVectors(std::move(testBuildVectors))
-            .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
-            .joinType(core::JoinType::kFull)
-            .joinFilter("(c1 + u_c1) % 2 = 3")
-            .joinOutputLayout({"c0", "c1", "u_c1"})
-            .referenceQuery(
-                "SELECT t.c0, t.c1, u.c1 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 AND (t.c1 + u.c1) % 2 = 3")
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(numDrivers_)
+        .injectSpill(false)
+        .probeKeys({"c0"})
+        .probeVectors(std::move(testProbeVectors))
+        .buildKeys({"u_c0"})
+        .buildVectors(std::move(testBuildVectors))
+        .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+        .joinType(core::JoinType::kFull)
+        .joinFilter("(c1 + u_c1) % 2 = 3")
+        .joinOutputLayout({"c0", "c1", "u_c1"})
+        .referenceQuery(
+            "SELECT t.c0, t.c1, u.c1 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 AND (t.c1 + u.c1) % 2 = 3")
+        .run();
   }
 }
 
@@ -2687,10 +2672,7 @@ TEST_F(HashJoinTest, duplicateJoinKeys) {
   std::vector<std::pair<core::JoinType, std::string>> joins = {
       {core::JoinType::kInner, "INNER JOIN"},
       {core::JoinType::kLeft, "LEFT JOIN"},
-      {core::JoinType::kRight, "RIGHT JOIN"}};
-
-  // full outer join not supported
-  std::vector<std::pair<core::JoinType, std::string>> throwingJoins = {
+      {core::JoinType::kRight, "RIGHT JOIN"},
       {core::JoinType::kFull, "FULL OUTER JOIN"}};
 
   for (const auto& [joinType, joinTypeSql] : joins) {
@@ -2717,30 +2699,6 @@ TEST_F(HashJoinTest, duplicateJoinKeys) {
         {"t0", "u0", "u1"}, // outputLayout
         joinType,
         false,
-        "SELECT t.c0, u.c0, u.c1 FROM t " + joinTypeSql +
-            " u ON t.c0 = u.c0 and t.c0 = u.c1");
-  }
-
-  for (const auto& [joinType, joinTypeSql] : throwingJoins) {
-    // Duplicate keys on the build side.
-    assertPlan(
-        {"c0 AS t0", "c1 as t1"}, // leftProject
-        {"t0", "t1"}, // leftKeys
-        {"c0 AS u0"}, // rightProject
-        {"u0", "u0"}, // rightKeys
-        {"t0", "t1", "u0"}, // outputLayout
-        joinType,
-        true,
-        "SELECT t.c0, t.c1, u.c0 FROM t " + joinTypeSql +
-            " u ON t.c0 = u.c0 and t.c1 = u.c0");
-    assertPlan(
-        {"c0 AS t0"}, // leftProject
-        {"t0", "t0"}, // leftKeys
-        {"c0 AS u0", "c1 AS u1"}, // rightProject
-        {"u0", "u1"}, // rightKeys
-        {"t0", "u0", "u1"}, // outputLayout
-        joinType,
-        true,
         "SELECT t.c0, u.c0, u.c1 FROM t " + joinTypeSql +
             " u ON t.c0 = u.c0 and t.c0 = u.c1");
   }
@@ -3730,15 +3688,11 @@ TEST_F(HashJoinTest, DISABLED_lazyVectorPartiallyLoadedInFilterLeftJoin) {
 TEST_F(HashJoinTest, DISABLED_lazyVectorPartiallyLoadedInFilterFullJoin) {
   // Test the case where a filter loads a subset of the rows that will be output
   // from a column on the probe side.
-
-  // full join not supported
-  VELOX_ASSERT_THROW(
-      testLazyVectorsWithFilter(
-          core::JoinType::kFull,
-          "c1 > 0 AND c2 > 0",
-          {"c1", "c2"},
-          "SELECT t.c1, t.c2 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 AND (c1 > 0 AND c2 > 0)"),
-      "Replacement with cuDF operator failed");
+  testLazyVectorsWithFilter(
+      core::JoinType::kFull,
+      "c1 > 0 AND c2 > 0",
+      {"c1", "c2"},
+      "SELECT t.c1, t.c2 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 AND (c1 > 0 AND c2 > 0)");
 }
 
 TEST_F(

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -1121,38 +1121,33 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilter) {
             });
       });
 
-  // null-anti join with filter not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .numDrivers(numDrivers_)
-          .probeKeys({"t0"})
-          .probeVectors(std::move(probeVectors))
-          .buildKeys({"u0"})
-          .buildVectors(std::move(buildVectors))
-          .joinType(core::JoinType::kAnti)
-          .nullAware(true)
-          .joinFilter("t1 != u1")
-          .joinOutputLayout({"t0", "t1"})
-          .referenceQuery(
-              "SELECT t.* FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE t0 = u0 AND t1 <> u1)")
-          .checkSpillStats(false)
-          .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-            // Verify spilling is not triggered in case of null-aware anti-join
-            // with filter.
-            const auto statsPair = taskSpilledStats(*task);
-            ASSERT_EQ(statsPair.first.spilledRows, 0);
-            ASSERT_EQ(statsPair.first.spilledBytes, 0);
-            ASSERT_EQ(statsPair.first.spilledPartitions, 0);
-            ASSERT_EQ(statsPair.first.spilledFiles, 0);
-            ASSERT_EQ(statsPair.second.spilledRows, 0);
-            ASSERT_EQ(statsPair.second.spilledBytes, 0);
-            ASSERT_EQ(statsPair.second.spilledPartitions, 0);
-            ASSERT_EQ(statsPair.second.spilledFiles, 0);
-            verifyTaskSpilledRuntimeStats(*task, false);
-            ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
-          })
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .probeKeys({"t0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u0"})
+      .buildVectors(std::move(buildVectors))
+      .joinType(core::JoinType::kAnti)
+      .nullAware(true)
+      .joinFilter("t1 != u1")
+      .joinOutputLayout({"t0", "t1"})
+      .referenceQuery(
+          "SELECT t.* FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE t0 = u0 AND t1 <> u1)")
+      .checkSpillStats(false)
+      .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+        const auto statsPair = taskSpilledStats(*task);
+        ASSERT_EQ(statsPair.first.spilledRows, 0);
+        ASSERT_EQ(statsPair.first.spilledBytes, 0);
+        ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+        ASSERT_EQ(statsPair.first.spilledFiles, 0);
+        ASSERT_EQ(statsPair.second.spilledRows, 0);
+        ASSERT_EQ(statsPair.second.spilledBytes, 0);
+        ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+        ASSERT_EQ(statsPair.second.spilledFiles, 0);
+        verifyTaskSpilledRuntimeStats(*task, false);
+        ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
+      })
+      .run();
 }
 
 TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndEmptyBuild) {
@@ -1177,40 +1172,35 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndEmptyBuild) {
           });
     });
 
-    // null-anti join with filter not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
-            .numDrivers(numDrivers_)
-            .probeKeys({"t0"})
-            .probeVectors(std::vector<RowVectorPtr>(probeVectors))
-            .buildKeys({"u0"})
-            .buildVectors(std::vector<RowVectorPtr>(buildVectors))
-            .buildFilter("u0 < 0")
-            .joinType(core::JoinType::kAnti)
-            .nullAware(true)
-            .joinFilter("u1 > t1")
-            .joinOutputLayout({"t0", "t1"})
-            .referenceQuery(
-                "SELECT t.* FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE u0 < 0 AND u.u0 = t.t0)")
-            .checkSpillStats(false)
-            .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-              // Verify spilling is not triggered in case of null-aware
-              // anti-join with filter.
-              const auto statsPair = taskSpilledStats(*task);
-              ASSERT_EQ(statsPair.first.spilledRows, 0);
-              ASSERT_EQ(statsPair.first.spilledBytes, 0);
-              ASSERT_EQ(statsPair.first.spilledPartitions, 0);
-              ASSERT_EQ(statsPair.first.spilledFiles, 0);
-              ASSERT_EQ(statsPair.second.spilledRows, 0);
-              ASSERT_EQ(statsPair.second.spilledBytes, 0);
-              ASSERT_EQ(statsPair.second.spilledPartitions, 0);
-              ASSERT_EQ(statsPair.second.spilledFiles, 0);
-              verifyTaskSpilledRuntimeStats(*task, false);
-              ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
-            })
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
+        .numDrivers(numDrivers_)
+        .probeKeys({"t0"})
+        .probeVectors(std::vector<RowVectorPtr>(probeVectors))
+        .buildKeys({"u0"})
+        .buildVectors(std::vector<RowVectorPtr>(buildVectors))
+        .buildFilter("u0 < 0")
+        .joinType(core::JoinType::kAnti)
+        .nullAware(true)
+        .joinFilter("u1 > t1")
+        .joinOutputLayout({"t0", "t1"})
+        .referenceQuery(
+            "SELECT t.* FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE u0 < 0 AND u.u0 = t.t0)")
+        .checkSpillStats(false)
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
+          ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
+        })
+        .run();
   }
 }
 
@@ -1240,37 +1230,32 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndNullKey) {
 
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    // null-anti join with filter not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .numDrivers(numDrivers_)
-            .probeKeys({"t0"})
-            .probeVectors(std::move(testProbeVectors))
-            .buildKeys({"u0"})
-            .buildVectors(std::move(testBuildVectors))
-            .joinType(core::JoinType::kAnti)
-            .nullAware(true)
-            .joinFilter(filter)
-            .joinOutputLayout({"t0", "t1"})
-            .referenceQuery(referenceSql)
-            .checkSpillStats(false)
-            .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-              // Verify spilling is not triggered in case of null-aware
-              // anti-join with filter.
-              const auto statsPair = taskSpilledStats(*task);
-              ASSERT_EQ(statsPair.first.spilledRows, 0);
-              ASSERT_EQ(statsPair.first.spilledBytes, 0);
-              ASSERT_EQ(statsPair.first.spilledPartitions, 0);
-              ASSERT_EQ(statsPair.first.spilledFiles, 0);
-              ASSERT_EQ(statsPair.second.spilledRows, 0);
-              ASSERT_EQ(statsPair.second.spilledBytes, 0);
-              ASSERT_EQ(statsPair.second.spilledPartitions, 0);
-              ASSERT_EQ(statsPair.second.spilledFiles, 0);
-              verifyTaskSpilledRuntimeStats(*task, false);
-              ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
-            })
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(numDrivers_)
+        .probeKeys({"t0"})
+        .probeVectors(std::move(testProbeVectors))
+        .buildKeys({"u0"})
+        .buildVectors(std::move(testBuildVectors))
+        .joinType(core::JoinType::kAnti)
+        .nullAware(true)
+        .joinFilter(filter)
+        .joinOutputLayout({"t0", "t1"})
+        .referenceQuery(referenceSql)
+        .checkSpillStats(false)
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
+          ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
+        })
+        .run();
   }
 }
 
@@ -1303,22 +1288,19 @@ TEST_P(
 
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    // null-anti join with filter not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .numDrivers(numDrivers_)
-            .probeKeys({"t0"})
-            .probeVectors(std::move(testProbeVectors))
-            .buildKeys({"u0"})
-            .buildVectors(std::move(testBuildVectors))
-            .joinType(core::JoinType::kAnti)
-            .nullAware(true)
-            .joinFilter(filter)
-            .joinOutputLayout({"t0", "t1"})
-            .referenceQuery(referenceSql)
-            .checkSpillStats(false)
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(numDrivers_)
+        .probeKeys({"t0"})
+        .probeVectors(std::move(testProbeVectors))
+        .buildKeys({"u0"})
+        .buildVectors(std::move(testBuildVectors))
+        .joinType(core::JoinType::kAnti)
+        .nullAware(true)
+        .joinFilter(filter)
+        .joinOutputLayout({"t0", "t1"})
+        .referenceQuery(referenceSql)
+        .checkSpillStats(false)
+        .run();
   }
 }
 
@@ -1344,37 +1326,32 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
               makeFlatVector<int32_t>(234, folly::identity, nullEvery(91)),
           });
     });
-    // null-anti join with filter not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .numDrivers(numDrivers_)
-            .probeKeys({"t0"})
-            .probeVectors(std::move(probeVectors))
-            .buildKeys({"u0"})
-            .buildVectors(std::move(buildVectors))
-            .joinType(core::JoinType::kAnti)
-            .nullAware(true)
-            .joinFilter(joinFilter)
-            .joinOutputLayout({"t0", "t1"})
-            .referenceQuery(referenceSql)
-            .checkSpillStats(false)
-            .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-              // Verify spilling is not triggered in case of null-aware
-              // anti-join with filter.
-              const auto statsPair = taskSpilledStats(*task);
-              ASSERT_EQ(statsPair.first.spilledRows, 0);
-              ASSERT_EQ(statsPair.first.spilledBytes, 0);
-              ASSERT_EQ(statsPair.first.spilledPartitions, 0);
-              ASSERT_EQ(statsPair.first.spilledFiles, 0);
-              ASSERT_EQ(statsPair.second.spilledRows, 0);
-              ASSERT_EQ(statsPair.second.spilledBytes, 0);
-              ASSERT_EQ(statsPair.second.spilledPartitions, 0);
-              ASSERT_EQ(statsPair.second.spilledFiles, 0);
-              verifyTaskSpilledRuntimeStats(*task, false);
-              ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
-            })
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(numDrivers_)
+        .probeKeys({"t0"})
+        .probeVectors(std::move(probeVectors))
+        .buildKeys({"u0"})
+        .buildVectors(std::move(buildVectors))
+        .joinType(core::JoinType::kAnti)
+        .nullAware(true)
+        .joinFilter(joinFilter)
+        .joinOutputLayout({"t0", "t1"})
+        .referenceQuery(referenceSql)
+        .checkSpillStats(false)
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
+          ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
+        })
+        .run();
   }
 
   {
@@ -1397,37 +1374,32 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
               makeFlatVector<int32_t>(234, folly::identity, nullEvery(37)),
           });
     });
-    // null-anti join with filter not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .numDrivers(numDrivers_)
-            .probeKeys({"t0"})
-            .probeVectors(std::move(probeVectors))
-            .buildKeys({"u0"})
-            .buildVectors(std::move(buildVectors))
-            .joinType(core::JoinType::kAnti)
-            .nullAware(true)
-            .joinFilter(joinFilter)
-            .joinOutputLayout({"t0", "t1"})
-            .referenceQuery(referenceSql)
-            .checkSpillStats(false)
-            .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-              // Verify spilling is not triggered in case of null-aware
-              // anti-join with filter.
-              const auto statsPair = taskSpilledStats(*task);
-              ASSERT_EQ(statsPair.first.spilledRows, 0);
-              ASSERT_EQ(statsPair.first.spilledBytes, 0);
-              ASSERT_EQ(statsPair.first.spilledPartitions, 0);
-              ASSERT_EQ(statsPair.first.spilledFiles, 0);
-              ASSERT_EQ(statsPair.second.spilledRows, 0);
-              ASSERT_EQ(statsPair.second.spilledBytes, 0);
-              ASSERT_EQ(statsPair.second.spilledPartitions, 0);
-              ASSERT_EQ(statsPair.second.spilledFiles, 0);
-              verifyTaskSpilledRuntimeStats(*task, false);
-              ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
-            })
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(numDrivers_)
+        .probeKeys({"t0"})
+        .probeVectors(std::move(probeVectors))
+        .buildKeys({"u0"})
+        .buildVectors(std::move(buildVectors))
+        .joinType(core::JoinType::kAnti)
+        .nullAware(true)
+        .joinFilter(joinFilter)
+        .joinOutputLayout({"t0", "t1"})
+        .referenceQuery(referenceSql)
+        .checkSpillStats(false)
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
+          ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
+        })
+        .run();
   }
 }
 
@@ -2742,18 +2714,15 @@ TEST_F(HashJoinTest, semiProject) {
                       core::JoinType::kLeftSemiProject)
                   .planNode();
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(plan)
-          .referenceQuery(
-              "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .injectSpill(false)
@@ -2781,18 +2750,15 @@ TEST_F(HashJoinTest, semiProject) {
                  core::JoinType::kLeftSemiProject)
              .planNode();
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(plan)
-          .referenceQuery(
-              "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .injectSpill(false)
@@ -2821,20 +2787,15 @@ TEST_F(HashJoinTest, semiProject) {
                  core::JoinType::kLeftSemiProject)
              .planNode();
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(plan)
-          .referenceQuery(
-              "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE u.c0 < 0 AND t.c0 = u.c0) FROM t")
-          // NOTE:, there is no spilling in empty build test case as all the
-          // build-side rows have been filtered out.
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE u.c0 < 0 AND t.c0 = u.c0) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .injectSpill(false)
@@ -2842,8 +2803,6 @@ TEST_F(HashJoinTest, semiProject) {
           .planNode(flipJoinSides(plan))
           .referenceQuery(
               "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE u.c0 < 0 AND t.c0 = u.c0) FROM t")
-          // NOTE: there is no spilling in empty build test case as all the
-          // build-side rows have been filtered out.
           .checkSpillStats(false)
           .run(),
       "Replacement with cuDF operator failed");
@@ -2903,18 +2862,15 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
   // Null join keys on both sides.
   auto plan = makePlan(false /*nullAware*/);
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(plan)
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .injectSpill(false)
@@ -2927,17 +2883,14 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
 
   plan = makePlan(true /*nullAware*/);
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(plan)
-          .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .injectSpill(false)
@@ -2950,18 +2903,15 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
   // Null join keys on build side-only.
   plan = makePlan(false /*nullAware*/, "t0 IS NOT NULL");
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(plan)
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t WHERE t0 IS NOT NULL")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t WHERE t0 IS NOT NULL")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .injectSpill(false)
@@ -2974,18 +2924,15 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
 
   plan = makePlan(true /*nullAware*/, "t0 IS NOT NULL");
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(plan)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .injectSpill(false)
@@ -2999,18 +2946,15 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
   // Null join keys on probe side-only.
   plan = makePlan(false /*nullAware*/, "", "u0 IS NOT NULL");
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(plan)
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NOT NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NOT NULL) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .injectSpill(false)
@@ -3023,18 +2967,15 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
 
   plan = makePlan(true /*nullAware*/, "", "u0 IS NOT NULL");
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(plan)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .injectSpill(false)
@@ -3048,18 +2989,15 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
   // Empty build side.
   plan = makePlan(false /*nullAware*/, "", "u0 < 0");
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(plan)
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 < 0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(plan)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 < 0) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
           .planNode(flipJoinSides(plan))
@@ -3072,18 +3010,15 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
 
   plan = makePlan(true /*nullAware*/, "", "u0 < 0");
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(plan)
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(plan)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
           .planNode(flipJoinSides(plan))
@@ -3097,18 +3032,15 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
   // Build side with all rows having null join keys.
   plan = makePlan(false /*nullAware*/, "", "u0 IS NULL");
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(plan)
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(plan)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NULL) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
           .planNode(flipJoinSides(plan))
@@ -3121,18 +3053,15 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
 
   plan = makePlan(true /*nullAware*/, "", "u0 IS NULL");
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(plan)
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(plan)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NULL) FROM t")
+      .run();
 
-  // left semi project not supported
+  // right semi project not supported
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
           .planNode(flipJoinSides(plan))
@@ -3191,7 +3120,7 @@ TEST_F(HashJoinTest, semiProjectWithFilter) {
   for (const auto& filter : filters) {
     auto plan = makePlan(true /*nullAware*/, filter);
 
-    // left semi project not supported
+    // null-aware left semi project with filter not supported on GPU
     VELOX_ASSERT_THROW(
         HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
             .planNode(plan)
@@ -3207,17 +3136,14 @@ TEST_F(HashJoinTest, semiProjectWithFilter) {
 
     // DuckDB Exists operator returns NULL when u0 or t0 is NULL. We exclude
     // these values.
-    // left semi project not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .planNode(plan)
-            .referenceQuery(
-                fmt::format(
-                    "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE (u0 is not null OR t0 is not null) AND u0 = t0 AND {}) FROM t",
-                    filter))
-            .injectSpill(false)
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .planNode(plan)
+        .referenceQuery(
+            fmt::format(
+                "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE (u0 is not null OR t0 is not null) AND u0 = t0 AND {}) FROM t",
+                filter))
+        .injectSpill(false)
+        .run();
   }
 }
 
@@ -3322,10 +3248,11 @@ TEST_F(HashJoinTest, leftSemiJoinWithExtraOutputCapacity) {
     std::string filter = "t1 <> u1";
     runQuery(
         fmt::format(
-            "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE {}) FROM t", filter),
+            "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE {}) FROM t",
+            filter),
         filter,
         core::JoinType::kLeftSemiProject,
-        true);
+        false);
   }
 }
 
@@ -3432,15 +3359,12 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
       {buildScanId, {buildFile->getPath()}},
   };
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .planNode(plan)
-          .inputSplits(splitPaths)
-          .checkSpillStats(false)
-          .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .planNode(plan)
+      .inputSplits(splitPaths)
+      .checkSpillStats(false)
+      .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
+      .run();
 
   // right semi project not supported
   VELOX_ASSERT_THROW(
@@ -3469,16 +3393,13 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
                  core::JoinType::kLeftSemiProject)
              .planNode();
 
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .planNode(plan)
-          .inputSplits(splitPaths)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .planNode(plan)
+      .inputSplits(splitPaths)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
+      .run();
 
   // right semi project not supported
   VELOX_ASSERT_THROW(
@@ -3786,15 +3707,11 @@ TEST_F(
     DISABLED_lazyVectorPartiallyLoadedInFilterLeftSemiProject) {
   // Test the case where a filter loads a subset of the rows that will be output
   // from a column on the probe side.
-
-  // left semi project not supported
-  VELOX_ASSERT_THROW(
-      testLazyVectorsWithFilter(
-          core::JoinType::kLeftSemiProject,
-          "c1 > 0 AND c2 > 0",
-          {"c1", "c2", "match"},
-          "SELECT t.c1, t.c2, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND (t.c1 > 0 AND t.c2 > 0)) FROM t"),
-      "Replacement with cuDF operator failed");
+  testLazyVectorsWithFilter(
+      core::JoinType::kLeftSemiProject,
+      "c1 > 0 AND c2 > 0",
+      {"c1", "c2", "match"},
+      "SELECT t.c1, t.c2, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND (t.c1 > 0 AND t.c2 > 0)) FROM t");
 }
 
 TEST_F(HashJoinTest, DISABLED_lazyVectorPartiallyLoadedInFilterAntiJoin) {

--- a/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
+++ b/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+class CudfNestedLoopJoinTest : public HiveConnectorTestBase {
+ public:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    cudf_velox::CudfConfig::getInstance().allowCpuFallback =
+        false;
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    HiveConnectorTestBase::TearDown();
+  }
+};
+
+TEST_F(CudfNestedLoopJoinTest, crossJoin) {
+  auto probeVectors = {makeRowVector(
+      {"t0", "t1"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+      })};
+
+  auto buildVectors = {makeRowVector(
+      {"u0"},
+      {
+          makeFlatVector<int32_t>({100, 200}),
+      })};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .nestedLoopJoin(
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .planNode(),
+                      {"t0", "t1", "u0"})
+                  .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, t.t1, u.u0 FROM t CROSS JOIN u");
+}
+
+TEST_F(CudfNestedLoopJoinTest, innerJoinWithCondition) {
+  auto probeVectors = {makeRowVector(
+      {"t0", "t1"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      })};
+
+  auto buildVectors = {makeRowVector(
+      {"u0", "u1"},
+      {
+          makeFlatVector<int32_t>({2, 4, 6}),
+          makeFlatVector<int64_t>({200, 400, 600}),
+      })};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeVectors)
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values(buildVectors)
+                  .planNode(),
+              "t0 < u0",
+              {"t0", "t1", "u0", "u1"},
+              core::JoinType::kInner)
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, t.t1, u.u0, u.u1 "
+          "FROM t INNER JOIN u ON t.t0 < u.u0");
+}
+
+TEST_F(CudfNestedLoopJoinTest, leftJoin) {
+  auto probeVectors = {makeRowVector(
+      {"t0", "t1"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      })};
+
+  auto buildVectors = {makeRowVector(
+      {"u0"},
+      {
+          makeFlatVector<int32_t>({2, 4}),
+      })};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeVectors)
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values(buildVectors)
+                  .planNode(),
+              "t0 = u0",
+              {"t0", "t1", "u0"},
+              core::JoinType::kLeft)
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, t.t1, u.u0 "
+          "FROM t LEFT JOIN u ON t.t0 = u.u0");
+}
+
+TEST_F(CudfNestedLoopJoinTest, rightJoin) {
+  auto probeVectors = {makeRowVector(
+      {"t0"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+      })};
+
+  auto buildVectors = {makeRowVector(
+      {"u0", "u1"},
+      {
+          makeFlatVector<int32_t>({2, 4, 6}),
+          makeFlatVector<int64_t>({20, 40, 60}),
+      })};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeVectors)
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values(buildVectors)
+                  .planNode(),
+              "t0 = u0",
+              {"t0", "u0", "u1"},
+              core::JoinType::kRight)
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, u.u0, u.u1 "
+          "FROM t RIGHT JOIN u ON t.t0 = u.u0");
+}
+
+TEST_F(CudfNestedLoopJoinTest, fullJoin) {
+  auto probeVectors = {makeRowVector(
+      {"t0"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+      })};
+
+  auto buildVectors = {makeRowVector(
+      {"u0"},
+      {
+          makeFlatVector<int32_t>({2, 4}),
+      })};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeVectors)
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values(buildVectors)
+                  .planNode(),
+              "t0 = u0",
+              {"t0", "u0"},
+              core::JoinType::kFull)
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, u.u0 "
+          "FROM t FULL OUTER JOIN u ON t.t0 = u.u0");
+}
+
+TEST_F(CudfNestedLoopJoinTest, leftSemiProject) {
+  auto probeVectors = {makeRowVector(
+      {"t0", "t1"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      })};
+
+  auto buildVectors = {makeRowVector(
+      {"u0"},
+      {
+          makeFlatVector<int32_t>({2, 4, 6}),
+      })};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeVectors)
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values(buildVectors)
+                  .planNode(),
+              "t0 = u0",
+              {"t0", "t1", "match"},
+              core::JoinType::kLeftSemiProject)
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, t.t1, "
+          "EXISTS (SELECT 1 FROM u WHERE t.t0 = u.u0) "
+          "FROM t");
+}
+
+TEST_F(CudfNestedLoopJoinTest, emptyBuild) {
+  auto probeVectors = {makeRowVector(
+      {"t0"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+      })};
+
+  auto buildVectors = {makeRowVector(
+      {"u0"},
+      {
+          makeFlatVector<int32_t>({}),
+      })};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  // Inner join with empty build -> empty result
+  auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .nestedLoopJoin(
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .planNode(),
+                      {"t0", "u0"})
+                  .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, u.u0 FROM t CROSS JOIN u");
+
+  // Left join with empty build -> all left rows, null build
+  planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  plan = PlanBuilder(planNodeIdGenerator)
+             .values(probeVectors)
+             .nestedLoopJoin(
+                 PlanBuilder(planNodeIdGenerator)
+                     .values(buildVectors)
+                     .planNode(),
+                 "t0 = u0",
+                 {"t0", "u0"},
+                 core::JoinType::kLeft)
+             .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, u.u0 "
+          "FROM t LEFT JOIN u ON t.t0 = u.u0");
+}
+
+TEST_F(CudfNestedLoopJoinTest, emptyProbe) {
+  auto probeVectors = {makeRowVector(
+      {"t0"},
+      {
+          makeFlatVector<int32_t>({}),
+      })};
+
+  auto buildVectors = {makeRowVector(
+      {"u0"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+      })};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeVectors)
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values(buildVectors)
+                  .planNode(),
+              "t0 = u0",
+              {"t0", "u0"},
+              core::JoinType::kRight)
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, u.u0 "
+          "FROM t RIGHT JOIN u ON t.t0 = u.u0");
+}
+
+TEST_F(CudfNestedLoopJoinTest, crossJoinWithNulls) {
+  auto probeVectors = {makeRowVector(
+      {"t0"},
+      {
+          makeNullableFlatVector<int32_t>(
+              {1, std::nullopt, 3}),
+      })};
+
+  auto buildVectors = {makeRowVector(
+      {"u0"},
+      {
+          makeNullableFlatVector<int32_t>(
+              {std::nullopt, 20}),
+      })};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .nestedLoopJoin(
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .planNode(),
+                      {"t0", "u0"})
+                  .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT t.t0, u.u0 FROM t CROSS JOIN u");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- **LeftSemiProject**: Implement kLeftSemiProject in CudfHashJoinProbe for both nullAware (IN semantics) and non-nullAware (EXISTS semantics) cases
- **Null-Aware Anti Join with filter**: Full NAAJ-with-filter support including null-keyed probe rows, empty build side, and cross-join anti semantics
- **CudfNestedLoopJoin**: New operator (Bridge/Build/Probe/Translator) supporting Inner/Left/Right/Full/LeftSemiProject/Anti via cudf::conditional_join APIs
- **OperatorAdapters**: Register NLJ adapter, expand hash join type support, reject nullAware kLeftSemiProject+filter on GPU (falls back to CPU)
- **Bug fixes**:
  - BOOL8 DtoH byte-to-bit conversion in PinnedArrowInterop
  - numNullKeys stat reporting in CudfHashJoinBuild/Probe (6 pre-existing test failures)
  - Premature isFinished() for right/full joins preventing unmatched build row emission (2 pre-existing test failures)
  - CudfHiveDataSource filter eval to pass column views

Also includes Shruti's cherry-picked commits:
- 9e900fa74 feat(cudf): Support full outer join in Velox-cuDF (#16229)
- dfe96a543 feat(cudf): Enable precomputation support for join filters (#16212)

## Test plan

- [x] velox_cudf_hash_join_test: 112 tests, 112 passed
- [x] velox_cudf_nested_loop_join_test: 9 tests, 9 passed
- [ ] Full build in container to verify no compilation regressions
- [ ] Integration test with Spark workloads (TPC-H queries with semi/anti joins)