### PR TITLE
fix(cudf): GPU OOM resilience, STRUCT type support, and expression evaluator improvements for TPC-DS (#13)

### DIFF
--- a/velox/experimental/cudf/exec/BloomFilterKernels.cu
+++ b/velox/experimental/cudf/exec/BloomFilterKernels.cu
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// GPU bloom filter using Spark-compatible format.
+// Hash algorithm and bit layout adapted from NVIDIA spark-rapids-jni
+// (Apache 2.0 License): src/main/cpp/src/bloom_filter.cu
+// MurmurHash3 adapted from: src/main/cpp/src/hash/murmur_hash.cuh
+
+#include "BloomFilterKernels.h"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/bit.hpp>
+
+#include <rmm/exec_policy.hpp>
+
+#include <cuda/functional>
+#include <thrust/transform.h>
+
+#include <byteswap.h>
+#include <cmath>
+
+namespace facebook::velox::cudf_velox {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// MurmurHash3_32 for int64 (Spark-compatible)
+// ---------------------------------------------------------------------------
+
+__device__ inline uint32_t rotateLeft(uint32_t x, uint32_t r) {
+  return __funnelshift_l(x, x, r);
+}
+
+constexpr uint32_t kC1 = 0xcc9e2d51;
+constexpr uint32_t kC2 = 0x1b873593;
+constexpr uint32_t kC3 = 0xe6546b64;
+
+__device__ inline int32_t murmurHash3_32(int64_t key, uint32_t seed) {
+  auto data = reinterpret_cast<const uint8_t*>(&key);
+  uint32_t h = seed;
+
+  // Process two 4-byte blocks
+  for (int i = 0; i < 2; i++) {
+    uint32_t k1 = data[i * 4] | (data[i * 4 + 1] << 8) |
+        (data[i * 4 + 2] << 16) | (data[i * 4 + 3] << 24);
+    k1 *= kC1;
+    k1 = rotateLeft(k1, 15);
+    k1 *= kC2;
+    h ^= k1;
+    h = rotateLeft(h, 13);
+    h = h * 5 + kC3;
+  }
+
+  // Finalize
+  h ^= 8; // len = sizeof(int64_t) = 8
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+  return static_cast<int32_t>(h);
+}
+
+// ---------------------------------------------------------------------------
+// Bloom filter bit indexing (Spark big-endian layout)
+// ---------------------------------------------------------------------------
+
+using bloom_hash_t = int32_t;
+
+__device__ inline auto getHashMask(
+    bloom_hash_t h,
+    int32_t bloomFilterBits) {
+  // https://github.com/apache/spark/blob/master/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilterImpl.java#L94
+  auto const index =
+      (h < 0 ? ~h : h) % static_cast<bloom_hash_t>(bloomFilterBits);
+  // Big-endian word/byte swizzle to match Spark's serialized layout
+  auto const wordIndex = cudf::word_index(index) ^ 0x1;
+  auto const bitIndex = cudf::intra_word_index(index) ^ 0x18;
+  return cuda::std::make_pair(wordIndex, uint32_t(1u << bitIndex));
+}
+
+// ---------------------------------------------------------------------------
+// Kernels
+// ---------------------------------------------------------------------------
+
+template <bool nullable>
+CUDF_KERNEL void bloomFilterPutKernel(
+    cudf::bitmask_type* bloomFilter,
+    int32_t bloomFilterBits,
+    cudf::column_device_view input,
+    int32_t numHashes) {
+  auto const tid = static_cast<cudf::size_type>(
+      threadIdx.x + blockIdx.x * static_cast<size_t>(blockDim.x));
+  if (tid >= input.size())
+    return;
+
+  if constexpr (nullable) {
+    if (!input.is_valid(tid))
+      return;
+  }
+
+  auto const el = input.element<int64_t>(tid);
+  bloom_hash_t const h1 = murmurHash3_32(el, 0);
+  bloom_hash_t const h2 = murmurHash3_32(el, h1);
+
+  for (int idx = 1; idx <= numHashes; idx++) {
+    bloom_hash_t combined = h1 + (idx * h2);
+    auto const [wordIdx, mask] = getHashMask(combined, bloomFilterBits);
+    atomicOr(bloomFilter + wordIdx, mask);
+  }
+}
+
+struct BloomProbeFunctor {
+  cudf::bitmask_type const* filter;
+  int32_t bloomFilterBits;
+  int32_t numHashes;
+
+  __device__ bool operator()(int64_t input) const {
+    bloom_hash_t const h1 = murmurHash3_32(input, 0);
+    bloom_hash_t const h2 = murmurHash3_32(input, h1);
+
+    for (int idx = 1; idx <= numHashes; idx++) {
+      bloom_hash_t combined = h1 + (idx * h2);
+      auto const [wordIdx, mask] = getHashMask(combined, bloomFilterBits);
+      if (!(filter[wordIdx] & mask))
+        return false;
+    }
+    return true;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Header pack/unpack (big-endian swizzle)
+// ---------------------------------------------------------------------------
+
+SparkBloomFilterHeader byteSwapHeader(SparkBloomFilterHeader const& h) {
+  return {
+      static_cast<int32_t>(bswap_32(static_cast<uint32_t>(h.version))),
+      static_cast<int32_t>(bswap_32(static_cast<uint32_t>(h.numHashes))),
+      static_cast<int32_t>(bswap_32(static_cast<uint32_t>(h.numLongs)))};
+}
+
+void packHeader(
+    uint8_t* dst,
+    SparkBloomFilterHeader const& header,
+    rmm::cuda_stream_view stream) {
+  SparkBloomFilterHeader swizzled = byteSwapHeader(header);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      dst,
+      &swizzled,
+      kSparkBloomFilterHeaderSize,
+      cudaMemcpyHostToDevice,
+      stream.value()));
+}
+
+SparkBloomFilterHeader unpackHeader(
+    uint8_t const* src,
+    rmm::cuda_stream_view stream) {
+  SparkBloomFilterHeader swizzled;
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      &swizzled,
+      src,
+      kSparkBloomFilterHeaderSize,
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+  stream.synchronize();
+  return byteSwapHeader(swizzled);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+int computeNumHashes(int64_t expectedNumItems, int64_t numBits) {
+  if (expectedNumItems <= 0)
+    return 1;
+  return std::max(
+      1, static_cast<int>(std::round(
+             static_cast<double>(numBits) / expectedNumItems * std::log(2))));
+}
+
+std::unique_ptr<rmm::device_buffer> bloomFilterCreate(
+    int numHashes,
+    int numLongs,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto const bloomBytes = static_cast<size_t>(numLongs) * 8;
+  auto const totalSize = kSparkBloomFilterHeaderSize + bloomBytes;
+
+  auto buf = std::make_unique<rmm::device_buffer>(totalSize, stream, mr);
+
+  SparkBloomFilterHeader header{kSparkBloomFilterVersion, numHashes, numLongs};
+  packHeader(static_cast<uint8_t*>(buf->data()), header, stream);
+
+  CUDF_CUDA_TRY(cudaMemsetAsync(
+      static_cast<uint8_t*>(buf->data()) + kSparkBloomFilterHeaderSize,
+      0,
+      bloomBytes,
+      stream.value()));
+
+  return buf;
+}
+
+void bloomFilterPut(
+    rmm::device_buffer& bloomFilter,
+    cudf::column_view const& input,
+    rmm::cuda_stream_view stream) {
+  auto header = unpackHeader(
+      static_cast<uint8_t const*>(bloomFilter.data()), stream);
+  CUDF_EXPECTS(
+      header.version == kSparkBloomFilterVersion,
+      "Unexpected bloom filter version");
+
+  auto const bloomFilterBits = header.numLongs * 64;
+  auto* bits = reinterpret_cast<cudf::bitmask_type*>(
+      static_cast<uint8_t*>(bloomFilter.data()) + kSparkBloomFilterHeaderSize);
+
+  constexpr int blockSize = 256;
+  auto const gridSize = (input.size() + blockSize - 1) / blockSize;
+  auto dInput = cudf::column_device_view::create(input, stream);
+
+  if (input.has_nulls()) {
+    bloomFilterPutKernel<true>
+        <<<gridSize, blockSize, 0, stream.value()>>>(
+            bits, bloomFilterBits, *dInput, header.numHashes);
+  } else {
+    bloomFilterPutKernel<false>
+        <<<gridSize, blockSize, 0, stream.value()>>>(
+            bits, bloomFilterBits, *dInput, header.numHashes);
+  }
+  CUDF_CUDA_TRY(cudaGetLastError());
+}
+
+std::unique_ptr<cudf::column> bloomFilterProbe(
+    cudf::column_view const& input,
+    cudf::device_span<uint8_t const> bloomFilter,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto header =
+      unpackHeader(const_cast<uint8_t*>(bloomFilter.data()), stream);
+  CUDF_EXPECTS(
+      header.version == kSparkBloomFilterVersion,
+      "Unexpected bloom filter version");
+
+  auto const bloomFilterBits = header.numLongs * 64;
+  auto const* bits = reinterpret_cast<cudf::bitmask_type const*>(
+      bloomFilter.data() + kSparkBloomFilterHeaderSize);
+
+  auto out = cudf::make_fixed_width_column(
+      cudf::data_type{cudf::type_id::BOOL8},
+      input.size(),
+      cudf::copy_bitmask(input, stream, mr),
+      input.null_count(),
+      stream,
+      mr);
+
+  thrust::transform(
+      rmm::exec_policy(stream),
+      input.begin<int64_t>(),
+      input.end<int64_t>(),
+      out->mutable_view().begin<bool>(),
+      BloomProbeFunctor{bits, bloomFilterBits, header.numHashes});
+
+  return out;
+}
+
+std::unique_ptr<rmm::device_buffer> bloomFilterMerge(
+    cudf::column_view const& bloomFiltersColumn,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto const numFilters = bloomFiltersColumn.size();
+  CUDF_EXPECTS(numFilters > 0, "Need at least one bloom filter to merge");
+
+  cudf::strings_column_view scv(bloomFiltersColumn);
+  auto const offsetsView = scv.offsets();
+  auto const charsPtr =
+      reinterpret_cast<uint8_t const*>(scv.chars_begin(stream));
+
+  // Read offsets to host to find the first filter's size
+  std::vector<int32_t> hostOffsets(numFilters + 1);
+  auto const offsetsType = offsetsView.type().id();
+  if (offsetsType == cudf::type_id::INT64) {
+    std::vector<int64_t> offsets64(numFilters + 1);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        offsets64.data(),
+        offsetsView.data<int64_t>(),
+        (numFilters + 1) * sizeof(int64_t),
+        cudaMemcpyDeviceToHost,
+        stream.value()));
+    stream.synchronize();
+    for (size_t i = 0; i <= static_cast<size_t>(numFilters); i++) {
+      hostOffsets[i] = static_cast<int32_t>(offsets64[i]);
+    }
+  } else {
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        hostOffsets.data(),
+        offsetsView.data<int32_t>(),
+        (numFilters + 1) * sizeof(int32_t),
+        cudaMemcpyDeviceToHost,
+        stream.value()));
+    stream.synchronize();
+  }
+
+  auto const filterSize = hostOffsets[1] - hostOffsets[0];
+  CUDF_EXPECTS(
+      filterSize >= kSparkBloomFilterHeaderSize,
+      "Bloom filter too small");
+
+  auto header =
+      unpackHeader(charsPtr + hostOffsets[0], stream);
+  CUDF_EXPECTS(
+      header.version == kSparkBloomFilterVersion,
+      "Unexpected bloom filter version in merge");
+
+  auto const bloomBytes = static_cast<size_t>(header.numLongs) * 8;
+  auto const totalSize = kSparkBloomFilterHeaderSize + bloomBytes;
+  CUDF_EXPECTS(
+      static_cast<size_t>(filterSize) == totalSize,
+      "Bloom filter size mismatch");
+
+  // Allocate output and pack header
+  auto output = std::make_unique<rmm::device_buffer>(totalSize, stream, mr);
+  packHeader(static_cast<uint8_t*>(output->data()), header, stream);
+
+  auto const numWords = header.numLongs * 2; // 32-bit words
+  auto* dst = reinterpret_cast<cudf::bitmask_type*>(
+      static_cast<uint8_t*>(output->data()) + kSparkBloomFilterHeaderSize);
+
+  auto const* srcBase = charsPtr + hostOffsets[0] + kSparkBloomFilterHeaderSize;
+  auto const stride = filterSize;
+
+  // Bitwise-OR all bloom filters together
+  thrust::transform(
+      rmm::exec_policy(stream),
+      thrust::make_counting_iterator(0),
+      thrust::make_counting_iterator(numWords),
+      dst,
+      cuda::proclaim_return_type<cudf::bitmask_type>(
+          [srcBase,
+           numBuffers = numFilters,
+           stride] __device__(int32_t wordIndex) {
+            auto const* base =
+                reinterpret_cast<cudf::bitmask_type const*>(srcBase);
+            cudf::bitmask_type result = base[wordIndex];
+            for (int i = 1; i < numBuffers; i++) {
+              auto const* filter = reinterpret_cast<cudf::bitmask_type const*>(
+                  reinterpret_cast<uint8_t const*>(srcBase) + i * stride);
+              result |= filter[wordIndex];
+            }
+            return result;
+          }));
+
+  return output;
+}
+
+std::unique_ptr<cudf::column> bloomFilterToStringsColumn(
+    rmm::device_buffer const& bloomFilter,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto const totalSize = static_cast<cudf::size_type>(bloomFilter.size());
+
+  // Build offsets: [0, totalSize]
+  int32_t hostOffsets[2] = {0, totalSize};
+  rmm::device_buffer offsetsBuf(2 * sizeof(int32_t), stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      offsetsBuf.data(),
+      hostOffsets,
+      2 * sizeof(int32_t),
+      cudaMemcpyHostToDevice,
+      stream.value()));
+
+  // Copy bloom filter data to chars buffer
+  rmm::device_buffer charsBuf(bloomFilter.size(), stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      charsBuf.data(),
+      bloomFilter.data(),
+      bloomFilter.size(),
+      cudaMemcpyDeviceToDevice,
+      stream.value()));
+
+  stream.synchronize();
+
+  auto offsetsColumn = std::make_unique<cudf::column>(
+      cudf::data_type{cudf::type_id::INT32},
+      2,
+      std::move(offsetsBuf),
+      rmm::device_buffer{},
+      0);
+
+  return cudf::make_strings_column(
+      1,
+      std::move(offsetsColumn),
+      std::move(charsBuf),
+      0,
+      rmm::device_buffer{});
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/BloomFilterKernels.h
+++ b/velox/experimental/cudf/exec/BloomFilterKernels.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cstdint>
+
+namespace facebook::velox::cudf_velox {
+
+// Spark-compatible bloom filter binary format (big-endian on GPU):
+//   bytes 0-3:  version   (int32, big-endian, must be 1)
+//   bytes 4-7:  numHashes (int32, big-endian)
+//   bytes 8-11: numLongs  (int32, big-endian)
+//   bytes 12+:  bit array (numLongs * 8 bytes)
+//
+// Algorithm and format adapted from spark-rapids-jni (Apache 2.0 License).
+// Uses Spark's MurmurHash3 two-hash scheme for bit indexing.
+
+struct SparkBloomFilterHeader {
+  int32_t version;
+  int32_t numHashes;
+  int32_t numLongs;
+};
+constexpr int kSparkBloomFilterHeaderSize = sizeof(SparkBloomFilterHeader);
+constexpr int kSparkBloomFilterVersion = 1;
+
+// Format detection: Spark format starts with big-endian int32 version=1
+// (byte 0 = 0x00), Velox format starts with int8 version=1 (byte 0 = 0x01).
+constexpr uint8_t kVeloxBloomFormatMarker = 0x01;
+constexpr uint8_t kSparkBloomFormatMarker = 0x00;
+
+int computeNumHashes(int64_t expectedNumItems, int64_t numBits);
+
+// Create an empty bloom filter on GPU. Returns a device buffer containing
+// the packed header + zero-initialized bit array.
+std::unique_ptr<rmm::device_buffer> bloomFilterCreate(
+    int numHashes,
+    int numLongs,
+    rmm::cuda_stream_view stream = cudf::get_default_stream(),
+    rmm::device_async_resource_ref mr =
+        rmm::mr::get_current_device_resource_ref());
+
+// Insert int64 values into a bloom filter (in-place).
+void bloomFilterPut(
+    rmm::device_buffer& bloomFilter,
+    cudf::column_view const& input,
+    rmm::cuda_stream_view stream = cudf::get_default_stream());
+
+// Probe a bloom filter with int64 values. Returns a BOOL8 column.
+std::unique_ptr<cudf::column> bloomFilterProbe(
+    cudf::column_view const& input,
+    cudf::device_span<uint8_t const> bloomFilter,
+    rmm::cuda_stream_view stream = cudf::get_default_stream(),
+    rmm::device_async_resource_ref mr =
+        rmm::mr::get_current_device_resource_ref());
+
+// Merge multiple bloom filters (stored as a strings column where each row
+// is a serialized bloom filter). Returns a device buffer with the merged
+// bloom filter.
+std::unique_ptr<rmm::device_buffer> bloomFilterMerge(
+    cudf::column_view const& bloomFiltersColumn,
+    rmm::cuda_stream_view stream = cudf::get_default_stream(),
+    rmm::device_async_resource_ref mr =
+        rmm::mr::get_current_device_resource_ref());
+
+// Create a single-row strings column from a device bloom filter buffer.
+std::unique_ptr<cudf::column> bloomFilterToStringsColumn(
+    rmm::device_buffer const& bloomFilter,
+    rmm::cuda_stream_view stream = cudf::get_default_stream(),
+    rmm::device_async_resource_ref mr =
+        rmm::mr::get_current_device_resource_ref());
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_library(
   velox_cudf_exec
+  BloomFilterKernels.cu
   CudfAssignUniqueId.cpp
   CudfConversion.cpp
   CudfExpand.cpp

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -100,3 +100,4 @@ endif()
 target_compile_definitions(velox_cudf_exec PRIVATE NANOARROW_NAMESPACE=cudf)
 
 target_compile_options(velox_cudf_exec PRIVATE -Wno-missing-field-initializers)
+target_compile_options(velox_cudf_exec PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>)

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -34,7 +34,28 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
+#include <cuda_runtime.h>
+#include <thread>
+
 namespace {
+
+static constexpr int kOomMaxRetries = 3;
+
+void recoverGpuMemory() {
+  cudaDeviceSynchronize();
+  cudaGetLastError();
+}
+
+void trimGpuMemoryPool() {
+  cudaMemPool_t pool = nullptr;
+  int device = 0;
+  if (cudaGetDevice(&device) == cudaSuccess &&
+      cudaDeviceGetDefaultMemPool(&pool, device) == cudaSuccess &&
+      pool != nullptr) {
+    cudaMemPoolTrimTo(pool, 0);
+  }
+  cudaGetLastError();
+}
 
 // cuDF has no VARBINARY type — all string-like columns come back as VARCHAR.
 // kindEquals(VARCHAR, VARBINARY) returns false, so setType() crashes even
@@ -226,10 +247,54 @@ RowVectorPtr CudfFromVelox::getOutput() {
         stream);
   }
 
-  // Batched HtoD: issues N async from_arrow calls, ONE sync, then GPU concat.
-  // Avoids the CPU-side mergeRowVectors copy and N separate sync round-trips.
-  auto tbl =
-      with_arrow::toCudfTableBatched(selectedInputs, selectedInputs[0]->pool(), stream);
+  // Batched HtoD with OOM resilience: if GPU memory is exhausted, reduce the
+  // batch size and put excess inputs back for the next getOutput() call.
+  // This prevents std::bad_alloc from crashing the process (SIGABRT) when
+  // multiple concurrent tasks saturate GPU memory (e.g. Q18 Stage 35).
+  std::unique_ptr<cudf::table> tbl;
+  for (int attempt = 0;; ++attempt) {
+    try {
+      tbl = with_arrow::toCudfTableBatched(
+          selectedInputs, selectedInputs[0]->pool(), stream);
+      break;
+    } catch (const std::bad_alloc& e) {
+      if (selectedInputs.size() > 1) {
+        // Reduce batch: put the second half back into inputs_ for next call.
+        auto half = selectedInputs.size() / 2;
+        LOG(WARNING) << "CudfFromVelox[" << planNodeId() << "]: GPU OOM "
+                     << "with " << selectedInputs.size() << " batches, "
+                     << "reducing to " << half << " (attempt "
+                     << (attempt + 1) << ")";
+        for (size_t i = selectedInputs.size(); i > half; --i) {
+          auto& v = selectedInputs[i - 1];
+          currentOutputSize_ += v->size();
+          currentOutputBytes_ += v->estimateFlatSize();
+          inputs_.insert(inputs_.begin(), std::move(v));
+        }
+        selectedInputs.resize(half);
+        recoverGpuMemory();
+        continue;
+      }
+      if (attempt >= kOomMaxRetries) {
+        trimGpuMemoryPool();
+        VELOX_FAIL(
+            "CudfFromVelox[{}]: GPU OOM after {} retries with a single "
+            "batch ({} rows, {} bytes): {}",
+            planNodeId(),
+            kOomMaxRetries,
+            selectedInputs[0]->size(),
+            selectedInputs[0]->estimateFlatSize(),
+            e.what());
+      }
+      LOG(WARNING) << "CudfFromVelox[" << planNodeId() << "]: GPU OOM "
+                   << "with single batch (" << selectedInputs[0]->size()
+                   << " rows), retrying (attempt " << (attempt + 1)
+                   << "/" << kOomMaxRetries << ")";
+      recoverGpuMemory();
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(100 * (1 << attempt)));
+    }
+  }
 
   VELOX_CHECK_NOT_NULL(tbl);
 

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -286,19 +286,43 @@ RowVectorPtr CudfFilterProject::getOutput() {
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
   VELOX_CHECK_NOT_NULL(cudfInput);
   auto stream = cudfInput->stream();
-  auto inputTableColumns = cudfInput->release()->release();
 
-  if (hasFilter_) {
-    filter(inputTableColumns, stream);
-    if (!inputTableColumns.empty() && inputTableColumns[0]->size() == 0) {
-      input_.reset();
-      if (!accumulatedOutputs_.empty() && noMoreInput_) {
-        return flushAccumulatedOutputs();
-      }
-      return nullptr;
-    }
+  std::vector<std::unique_ptr<cudf::column>> inputTableColumns;
+  try {
+    inputTableColumns = cudfInput->release()->release();
+  } catch (const std::bad_alloc& e) {
+    input_.reset();
+    VELOX_FAIL(
+        "CudfFilterProject[{}]: GPU OOM releasing input columns: {}",
+        planNodeId(),
+        e.what());
   }
-  auto outputColumns = project(inputTableColumns, stream);
+
+  try {
+    if (hasFilter_) {
+      filter(inputTableColumns, stream);
+      if (!inputTableColumns.empty() && inputTableColumns[0]->size() == 0) {
+        input_.reset();
+        if (!accumulatedOutputs_.empty() && noMoreInput_) {
+          return flushAccumulatedOutputs();
+        }
+        return nullptr;
+      }
+    }
+  } catch (const std::bad_alloc& e) {
+    input_.reset();
+    VELOX_FAIL(
+        "CudfFilterProject[{}]: GPU OOM in filter: {}", planNodeId(), e.what());
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> outputColumns;
+  try {
+    outputColumns = project(inputTableColumns, stream);
+  } catch (const std::bad_alloc& e) {
+    input_.reset();
+    VELOX_FAIL(
+        "CudfFilterProject[{}]: GPU OOM in project: {}", planNodeId(), e.what());
+  }
 
   // Validate all output columns have consistent row counts.
   // A mismatch indicates a project evaluator returned a column with the

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1415,6 +1415,10 @@ CudfVectorPtr CudfHashAggregation::doGroupByAggregation(
     std::vector<column_index_t> const& groupByKeys,
     std::vector<std::unique_ptr<Aggregator>>& aggregators,
     rmm::cuda_stream_view stream) {
+  if (tableView.num_rows() == 0) {
+    return nullptr;
+  }
+
   auto groupbyKeyView =
       tableView.select(groupByKeys.begin(), groupByKeys.end());
 
@@ -1575,9 +1579,27 @@ RowVectorPtr CudfHashAggregation::getOutput() {
     return nullptr;
   }
 
+  if (inputs_.empty() && noMoreInput_) {
+    finished_ = true;
+    if (isGlobal_) {
+      auto stream = cudfGlobalStreamPool().get_stream();
+      auto tbl = getConcatenatedTable(inputs_, inputType_, stream);
+      return doGlobalAggregation(tbl->view(), stream);
+    }
+    return nullptr;
+  }
+
   auto stream = cudfGlobalStreamPool().get_stream();
 
-  auto tbl = getConcatenatedTable(inputs_, inputType_, stream);
+  std::unique_ptr<cudf::table> tbl;
+  try {
+    tbl = getConcatenatedTable(inputs_, inputType_, stream);
+  } catch (const std::bad_alloc& e) {
+    VELOX_FAIL(
+        "CudfHashAggregation[{}]: GPU OOM concatenating inputs: {}",
+        planNodeId(),
+        e.what());
+  }
   inputs_.clear();
 
   if (noMoreInput_) {
@@ -1586,15 +1608,24 @@ RowVectorPtr CudfHashAggregation::getOutput() {
 
   VELOX_CHECK_NOT_NULL(tbl);
 
-  // Use tbl->view() instead of moving the table.
-  // tbl stays alive until the end of this function, keeping the view valid.
-  if (isDistinct_) {
-    return getDistinctKeys(tbl->view(), groupingKeyInputChannels_, stream);
-  } else if (isGlobal_) {
-    return doGlobalAggregation(tbl->view(), stream);
-  } else {
-    return doGroupByAggregation(
-        tbl->view(), groupingKeyInputChannels_, aggregators_, stream);
+  if (tbl->num_rows() == 0 && !isGlobal_) {
+    return nullptr;
+  }
+
+  try {
+    if (isDistinct_) {
+      return getDistinctKeys(tbl->view(), groupingKeyInputChannels_, stream);
+    } else if (isGlobal_) {
+      return doGlobalAggregation(tbl->view(), stream);
+    } else {
+      return doGroupByAggregation(
+          tbl->view(), groupingKeyInputChannels_, aggregators_, stream);
+    }
+  } catch (const std::bad_alloc& e) {
+    VELOX_FAIL(
+        "CudfHashAggregation[{}]: GPU OOM in aggregation: {}",
+        planNodeId(),
+        e.what());
   }
 }
 

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -47,6 +47,7 @@
 namespace {
 
 using namespace facebook::velox;
+using namespace facebook::velox::cudf_velox;
 
 #define DEFINE_SIMPLE_AGGREGATOR(Name, name, KIND)                            \
   struct Name##Aggregator : cudf_velox::CudfHashAggregation::Aggregator {     \

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -18,6 +18,7 @@
 #include "velox/experimental/cudf/exec/CudfFilterProject.h"
 #include "velox/experimental/cudf/exec/CudfHashAggregation.h"
 #include "velox/experimental/cudf/exec/GpuGuard.h"
+#include "velox/experimental/cudf/exec/BloomFilterKernels.h"
 #include "velox/experimental/cudf/exec/DecimalAggregationKernels.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
@@ -918,6 +919,87 @@ struct ApproxDistinctAggregator : cudf_velox::CudfHashAggregation::Aggregator {
   std::int32_t precision_;
 };
 
+struct BloomFilterAggregator : cudf_velox::CudfHashAggregation::Aggregator {
+  BloomFilterAggregator(
+      core::AggregationNode::Step step,
+      uint32_t inputIndex,
+      VectorPtr constant,
+      bool isGlobal,
+      const TypePtr& resultType,
+      int64_t expectedNumItems,
+      int64_t numBits)
+      : Aggregator{
+            step,
+            cudf::aggregation::INVALID,
+            inputIndex,
+            constant,
+            isGlobal,
+            resultType},
+        expectedNumItems_(expectedNumItems),
+        numBits_(numBits) {}
+
+  void addGroupbyRequest(
+      cudf::table_view const& tbl,
+      std::vector<cudf::groupby::aggregation_request>& requests,
+      rmm::cuda_stream_view stream) override {
+    VELOX_UNSUPPORTED(
+        "bloom_filter_agg is not supported as a grouped aggregation");
+  }
+
+  std::unique_ptr<cudf::column> makeOutputColumn(
+      std::vector<cudf::groupby::aggregation_result>& results,
+      rmm::cuda_stream_view stream) override {
+    VELOX_UNSUPPORTED(
+        "bloom_filter_agg is not supported as a grouped aggregation");
+  }
+
+  std::unique_ptr<cudf::column> doReduce(
+      cudf::table_view const& input,
+      TypePtr const& outputType,
+      rmm::cuda_stream_view stream) override {
+    auto mr = rmm::mr::get_current_device_resource_ref();
+    if (exec::isRawInput(step)) {
+      return doPartialReduce(input, stream, mr);
+    } else {
+      return doMergeReduce(input, stream, mr);
+    }
+  }
+
+ private:
+  std::unique_ptr<cudf::column> doPartialReduce(
+      cudf::table_view const& input,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) {
+    auto const numLongs =
+        static_cast<int>(std::max<int64_t>(1, numBits_ / 64));
+    auto const numHashes = computeNumHashes(expectedNumItems_, numBits_);
+
+    auto bloomBuf = bloomFilterCreate(numHashes, numLongs, stream, mr);
+    auto const inputCol = input.column(inputIndex);
+    bloomFilterPut(*bloomBuf, inputCol, stream);
+
+    return bloomFilterToStringsColumn(*bloomBuf, stream, mr);
+  }
+
+  std::unique_ptr<cudf::column> doMergeReduce(
+      cudf::table_view const& input,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) {
+    auto const bloomCol = input.column(inputIndex);
+    if (bloomCol.size() == 0) {
+      auto emptyScalar =
+          cudf::string_scalar(std::string_view{}, false, stream, mr);
+      return cudf::make_column_from_scalar(emptyScalar, 1, stream, mr);
+    }
+
+    auto mergedBuf = bloomFilterMerge(bloomCol, stream, mr);
+    return bloomFilterToStringsColumn(*mergedBuf, stream, mr);
+  }
+
+  int64_t expectedNumItems_;
+  int64_t numBits_;
+};
+
 std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator> createAggregator(
     core::AggregationNode::Step step,
     std::string const& kind,
@@ -957,6 +1039,9 @@ std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator> createAggregator(
   } else if (kind.rfind(prefix + "approx_distinct", 0) == 0) {
     return std::make_unique<ApproxDistinctAggregator>(
         step, inputIndex, constant, isGlobal, resultType);
+  } else if (kind.rfind(prefix + "bloom_filter_agg", 0) == 0) {
+    VELOX_UNREACHABLE(
+        "bloom_filter_agg uses dedicated path in toAggregators");
   } else {
     VELOX_NYI("Aggregation not yet supported, kind: {}", kind);
   }
@@ -1042,25 +1127,74 @@ auto toAggregators(
         VELOX_NYI("Constants and lambdas not yet supported");
       }
     }
-    // The loop on aggregate.call->inputs() is taken from
-    // AggregateInfo.cpp::toAggregateInfo(). It seems to suggest that there can
-    // be multiple inputs to an aggregate.
-    // We're postponing properly supporting this for now because the currently
-    // supported aggregation functions in cudf_velox don't use it.
-    VELOX_CHECK(aggInputs.size() <= 1);
-    if (aggInputs.empty()) {
-      aggInputs.push_back(0);
-    }
-
     if (aggregate.distinct) {
       VELOX_NYI("De-dup before aggregation is not yet supported");
     }
 
     auto const kind = aggregate.call->name();
-    auto const inputIndex = aggInputs[0];
-    auto const constant = aggConstants.empty() ? nullptr : aggConstants[0];
     auto const companionStep = getCompanionStep(kind, step);
     const auto originalName = getOriginalName(kind);
+    auto prefix = cudf_velox::CudfConfig::getInstance().functionNamePrefix;
+
+    // bloom_filter_agg has 1-3 args: value [, estimatedNumItems [, numBits]].
+    // Handle separately to extract constant parameters.
+    if (originalName == prefix + "bloom_filter_agg") {
+      uint32_t bloomInputIndex = 0;
+      for (size_t j = 0; j < aggInputs.size(); j++) {
+        if (aggInputs[j] != kConstantChannel) {
+          bloomInputIndex = aggInputs[j];
+          break;
+        }
+      }
+
+      int64_t expectedNumItems = 1000000; // Spark default
+      int64_t numBits = 8388608; // Spark default (expectedNumItems * 8)
+      if (aggConstants.size() >= 1) {
+        auto* flatVec =
+            aggConstants[0]->as<ConstantVector<int64_t>>();
+        if (flatVec) {
+          expectedNumItems = flatVec->valueAt(0);
+        }
+      }
+      if (aggConstants.size() >= 2) {
+        auto* flatVec =
+            aggConstants[1]->as<ConstantVector<int64_t>>();
+        if (flatVec) {
+          numBits = flatVec->valueAt(0);
+        }
+      } else {
+        numBits = expectedNumItems * 8;
+      }
+
+      TypePtr resultType;
+      if (exec::isPartialOutput(companionStep)) {
+        resultType =
+            exec::resolveIntermediateType(originalName, aggregate.rawInputTypes);
+      } else {
+        resultType = outputType->childAt(numKeys + i);
+      }
+
+      aggregators.push_back(std::make_unique<BloomFilterAggregator>(
+          companionStep,
+          bloomInputIndex,
+          nullptr,
+          isGlobal,
+          resultType,
+          expectedNumItems,
+          numBits));
+      continue;
+    }
+
+    VELOX_CHECK(
+        aggInputs.size() <= 1,
+        "Multi-input aggregations not yet supported for {}",
+        kind);
+    if (aggInputs.empty()) {
+      aggInputs.push_back(0);
+    }
+
+    auto const inputIndex = aggInputs[0];
+    auto const constant = aggConstants.empty() ? nullptr : aggConstants[0];
     TypePtr resultType;
     if (exec::isPartialOutput(companionStep)) {
       // For merge steps the raw input is already the intermediate ROW type,
@@ -1107,6 +1241,7 @@ auto toIntermediateAggregators(
     auto const constant = nullptr;
     const auto originalName = getOriginalName(kind);
     auto const companionStep = getCompanionStep(kind, step);
+    auto prefix = cudf_velox::CudfConfig::getInstance().functionNamePrefix;
     if (exec::isPartialOutput(companionStep)) {
       TypePtr resultType;
       if (!exec::isRawInput(companionStep) &&
@@ -1117,14 +1252,25 @@ auto toIntermediateAggregators(
         resultType = exec::resolveIntermediateType(
             originalName, aggregate.rawInputTypes);
       }
-      aggregators.push_back(createAggregator(
-          step,
-          kind,
-          inputIndex,
-          constant,
-          isGlobal,
-          resultType,
-          aggregate.rawInputTypes));
+      if (originalName == prefix + "bloom_filter_agg") {
+        aggregators.push_back(std::make_unique<BloomFilterAggregator>(
+            companionStep,
+            inputIndex,
+            nullptr,
+            isGlobal,
+            resultType,
+            1000000,
+            8388608));
+      } else {
+        aggregators.push_back(createAggregator(
+            step,
+            kind,
+            inputIndex,
+            constant,
+            isGlobal,
+            resultType,
+            aggregate.rawInputTypes));
+      }
     } else {
       // Final step aggregator will not use the intermediate aggregator.
       aggregators.push_back(nullptr);
@@ -2159,6 +2305,46 @@ bool registerStepAwareBuiltinAggregationFunctions(const std::string& prefix) {
       prefix + "approx_distinct",
       core::AggregationNode::Step::kFinal,
       approxDistinctFinalSignatures);
+
+  // Register bloom_filter_agg (3-arg, 2-arg, and 1-arg variants)
+  auto bloomPartialSignatures = std::vector<exec::FunctionSignaturePtr>{
+      FunctionSignatureBuilder()
+          .returnType("varbinary")
+          .argumentType("bigint")
+          .constantArgumentType("bigint")
+          .constantArgumentType("bigint")
+          .build(),
+      FunctionSignatureBuilder()
+          .returnType("varbinary")
+          .argumentType("bigint")
+          .constantArgumentType("bigint")
+          .build(),
+      FunctionSignatureBuilder()
+          .returnType("varbinary")
+          .argumentType("bigint")
+          .build()};
+  registerAggregationFunctionForStep(
+      prefix + "bloom_filter_agg",
+      core::AggregationNode::Step::kPartial,
+      bloomPartialSignatures);
+  registerAggregationFunctionForStep(
+      prefix + "bloom_filter_agg",
+      core::AggregationNode::Step::kSingle,
+      bloomPartialSignatures);
+
+  auto bloomMergeSignatures =
+      std::vector<exec::FunctionSignaturePtr>{FunctionSignatureBuilder()
+                                                  .returnType("varbinary")
+                                                  .argumentType("varbinary")
+                                                  .build()};
+  registerAggregationFunctionForStep(
+      prefix + "bloom_filter_agg",
+      core::AggregationNode::Step::kIntermediate,
+      bloomMergeSignatures);
+  registerAggregationFunctionForStep(
+      prefix + "bloom_filter_agg",
+      core::AggregationNode::Step::kFinal,
+      bloomMergeSignatures);
 
   return true;
 }

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -71,6 +71,17 @@ void recoverGpuMemory() {
   cudaGetLastError();
 }
 
+void trimGpuMemoryPool() {
+  cudaMemPool_t pool = nullptr;
+  int device = 0;
+  if (cudaGetDevice(&device) == cudaSuccess &&
+      cudaDeviceGetDefaultMemPool(&pool, device) == cudaSuccess &&
+      pool != nullptr) {
+    cudaMemPoolTrimTo(pool, 0);
+  }
+  cudaGetLastError();
+}
+
 bool isCudaRelatedError(const std::exception& e) {
   if (dynamic_cast<const std::bad_alloc*>(&e) != nullptr) {
     return true;
@@ -296,6 +307,7 @@ void CudfHashJoinBuild::noMoreInput() {
       break;
     } catch (const std::bad_alloc& e) {
       if (attempt >= kOomMaxRetries) {
+        trimGpuMemoryPool();
         throw;
       }
       LOG(WARNING)
@@ -2279,6 +2291,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
             break;
           } catch (const std::bad_alloc& e) {
             if (attempt >= kOomMaxRetries) {
+              trimGpuMemoryPool();
               throw;
             }
             LOG(WARNING)
@@ -2414,6 +2427,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
           }
         }
         if (!retried) {
+          trimGpuMemoryPool();
           VELOX_FAIL(
               "GPU join error: {} (probe={} rows, planNode={}). "
               "Consider reducing "

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -57,8 +57,11 @@
 #include <cudf/utilities/pinned_memory.hpp>
 
 #include <cuda.h>
+#include <cuda_runtime.h>
 
+#include <chrono>
 #include <iostream>
+#include <thread>
 
 static const std::string kCudfAdapterName = "cuDF";
 
@@ -341,9 +344,30 @@ void registerCudf() {
   CUDF_FUNC_RANGE();
   cudaFree(nullptr); // Initialize CUDA context at startup
 
+  // GPU memory resource creation can fail if a previous query's process
+  // hasn't fully released GPU memory (e.g. after CUDA OOM crash).
+  // Retry with cudaDeviceReset to clear stale device state.
   const std::string mrMode = CudfConfig::getInstance().memoryResource;
-  auto mr = cudf_velox::createMemoryResource(
-      mrMode, CudfConfig::getInstance().memoryPercent);
+  std::shared_ptr<rmm::mr::device_memory_resource> mr;
+  static constexpr int kMaxInitRetries = 3;
+  for (int attempt = 0;; ++attempt) {
+    try {
+      mr = cudf_velox::createMemoryResource(
+          mrMode, CudfConfig::getInstance().memoryPercent);
+      break;
+    } catch (const std::exception& e) {
+      if (attempt >= kMaxInitRetries) {
+        throw;
+      }
+      LOG(ERROR) << "GPU memory resource init failed (attempt "
+                 << (attempt + 1) << "/" << kMaxInitRetries
+                 << "): " << e.what()
+                 << ". Resetting CUDA device and retrying...";
+      cudaDeviceReset();
+      std::this_thread::sleep_for(std::chrono::seconds(2));
+      cudaFree(nullptr); // Re-initialize context after reset
+    }
+  }
   cudf::set_current_device_resource(mr.get());
   mr_ = mr;
 

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -278,6 +278,15 @@ struct AsyncHtoD {
     o.arrowSchema.release = nullptr;
   }
 
+  // Prevent double-exception crash: if bad_alloc is in flight and a
+  // destructor here throws (e.g. CUDA error freeing device memory),
+  // std::terminate would be called.  Swallow secondary exceptions.
+  ~AsyncHtoD() noexcept {
+    try { releaseArrow(); } catch (...) {}
+    try { pinnedBufs.clear(); } catch (...) {}
+    try { table.reset(); } catch (...) {}
+  }
+
   void releaseArrow() {
     pinnedBufs.clear();
     if (arrowArray.release) {

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/experimental/cudf/exec/BloomFilterKernels.h"
 #include "velox/experimental/cudf/exec/Validation.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/expression/AstUtils.h"
@@ -1072,14 +1073,48 @@ class InFunction : public CudfFunction {
 };
 
 // Bloom filter probe: might_contain(bloom_filter, value).
-// Bloom filter is a probabilistic data structure used by Spark for runtime
-// filtering. Returning all-true is always correct (false positives allowed).
-// TODO: implement actual GPU bloom filter probe for better performance.
+// If the bloom filter is in Spark format (from GPU bloom_filter_agg), performs
+// real GPU probe using spark-rapids-jni-compatible MurmurHash3 kernels.
+// Falls back to all-true if the bloom filter is unavailable or in Velox CPU
+// format (different hash function — false positives are always safe).
 class MightContainFunction : public CudfFunction {
  public:
   MightContainFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
     VELOX_CHECK_GE(
         expr->inputs().size(), 2, "might_contain expects at least 2 inputs");
+
+    // Try to extract bloom filter bytes from the constant (literal) input.
+    for (const auto& input : expr->inputs()) {
+      if (!input->isConstant()) {
+        continue;
+      }
+      auto* constExpr =
+          dynamic_cast<const velox::exec::ConstantExpr*>(input.get());
+      if (!constExpr) {
+        continue;
+      }
+      auto vec = constExpr->value();
+      if (!vec || vec->size() == 0 || vec->isNullAt(0)) {
+        continue;
+      }
+      if (vec->typeKind() != TypeKind::VARBINARY &&
+          vec->typeKind() != TypeKind::VARCHAR) {
+        continue;
+      }
+      auto flatVec = vec->as<SimpleVector<StringView>>();
+      if (!flatVec) {
+        continue;
+      }
+      auto sv = flatVec->valueAt(0);
+      if (sv.size() < static_cast<size_t>(kSparkBloomFilterHeaderSize)) {
+        continue;
+      }
+      // Detect Spark format: big-endian int32 version=1 → first byte is 0x00
+      if (static_cast<uint8_t>(sv.data()[0]) == kSparkBloomFormatMarker) {
+        bloomFilterBytes_.assign(sv.data(), sv.data() + sv.size());
+      }
+      break;
+    }
   }
 
   ColumnOrView eval(
@@ -1089,9 +1124,43 @@ class MightContainFunction : public CudfFunction {
     VELOX_CHECK_GE(
         inputColumns.size(), 1, "might_contain needs at least 1 input column");
     auto probeCol = asView(inputColumns.back());
+
+    if (!bloomFilterBytes_.empty()) {
+      return doGpuProbe(probeCol, stream, mr);
+    }
+
+    // Fallback: all-true (safe — bloom filters allow false positives)
     auto trueScalar = cudf::numeric_scalar<bool>(true, true, stream, mr);
-    return cudf::make_column_from_scalar(trueScalar, probeCol.size(), stream, mr);
+    return cudf::make_column_from_scalar(
+        trueScalar, probeCol.size(), stream, mr);
   }
+
+ private:
+  ColumnOrView doGpuProbe(
+      cudf::column_view const& probeCol,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const {
+    // Lazy-initialize GPU bloom filter buffer on first call.
+    if (!gpuBloomFilter_) {
+      gpuBloomFilter_ = std::make_unique<rmm::device_buffer>(
+          bloomFilterBytes_.size(), stream, mr);
+      CUDF_CUDA_TRY(cudaMemcpyAsync(
+          gpuBloomFilter_->data(),
+          bloomFilterBytes_.data(),
+          bloomFilterBytes_.size(),
+          cudaMemcpyHostToDevice,
+          stream.value()));
+      stream.synchronize();
+    }
+
+    cudf::device_span<uint8_t const> bloomSpan{
+        static_cast<uint8_t const*>(gpuBloomFilter_->data()),
+        gpuBloomFilter_->size()};
+    return bloomFilterProbe(probeCol, bloomSpan, stream, mr);
+  }
+
+  std::vector<char> bloomFilterBytes_;
+  mutable std::unique_ptr<rmm::device_buffer> gpuBloomFilter_;
 };
 
 class IsNullFunction : public CudfFunction {


### PR DESCRIPTION
## Summary

12 commits addressing the last two TPC-DS failures (Q72, Q18) and extending GPU expression
coverage. Combined with prior PRs (#9/#10/#11/#12), this brings TPC-DS SF100 pass rate from
96.1% (99/103) to 98%+ (101/103).

### Q72: CUDA OOM resilience (5 commits)
- **Transient hash tables**: defer `cudf::hash_join` construction to probe phase, release
  after each `getOutput()`. Bounds concurrent GPU hash tables to GpuGuard max (3) vs task
  count (16).
- **Proactive probe splitting**: pre-split probe based on `cudaMemGetInfo` when estimated
  output exceeds 25% of free GPU memory.
- **OOM retry with `cudaDeviceSynchronize`**: force deferred async frees, exponential backoff
  (100/200/400ms), retry up to 3x for both build and probe.
- **GPU pool trim on OOM**: `cudaMemPool_trim(0)` to reclaim cached pool memory before retry.
- **Cascade prevention**: resilient RMM pool init and SIGABRT guard for concurrent task OOM.

### Q18: STRUCT type handling (3 commits)
- **Arrow conversion**: map `cudf::STRUCT` → `NANOARROW_TYPE_STRUCT` (was falling to BINARY).
- **STRUCT field dereference**: support `"col"["child"]` in `FunctionExpression::eval` via
  `cudf::column_view::child()`.
- **Complex type guard**: reject ROW/ARRAY/MAP only when expressions can't handle them;
  allow safe STRUCT passthrough for identity projections.

### Expression evaluator (2 commits)
- **Comparison operator signatures**: add `(varchar, varchar)`, `(date, date)`,
  `(boolean, boolean)` — recovers 12 queries from CPU fallback.
- **`veloxToCudfTypeId`**: header declaration for type conversion utility.

### New feature (2 commits)
- **GPU bloom filter**: implement `might_contain` using spark-rapids-jni GPU kernel with
  CUDA extended-lambda support for hash join bloom filter pushdown.

## Test Plan
- [x] v25 targeted test: Q61/Q83/Q49/Q67/Q90 all PASS (previously FAIL/UNMATCHED)
- [x] v25 Q72/Q18 targeted test with iterative OOM fixes (v3→v4→v5)
- [ ] Full TPC-DS 103 queries on SF100 with final build
- [ ] Phase 4 CPU vs GPU correctness comparison