### PR TITLE
fix(cudf): Q18 decimal type reconciliation and multi-sort-key rank/dense_rank in CudfWindow (Q47/Q57)

### DIFF
--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -237,21 +237,8 @@ bool isSupportedCudfWindowNode(
   }
 
   // Rank-like functions require at least one sort key.
-  // rank/dense_rank require exactly one sort key (for the
-  // values column in cudf groupby scan).
-  if (hasRankLike) {
-    if (node->sortingKeys().empty()) {
-      return false;
-    }
-    for (auto const& func : functions) {
-      auto kind = parseWindowFunctionKind(
-          func.functionCall->name());
-      if (kind.has_value() && CudfWindow::isRankLike(*kind) &&
-          *kind != WindowFunctionKind::kRowNumber &&
-          node->sortingKeys().size() != 1) {
-        return false;
-      }
-    }
+  if (hasRankLike && node->sortingKeys().empty()) {
+    return false;
   }
 
   for (auto const& key : node->sortingKeys()) {
@@ -501,6 +488,29 @@ CudfWindow::toWindowBounds(
   return {preceding, following};
 }
 
+cudf::column_view CudfWindow::multiSortKeyStructView(
+    cudf::table_view const& sortedInput) const {
+  VELOX_CHECK_GE(
+      sortKeyChannels_.size(),
+      2,
+      "multiSortKeyStructView requires >= 2 sort keys");
+  sortKeyStructChildren_.clear();
+  sortKeyStructChildren_.reserve(sortKeyChannels_.size());
+  for (auto ch : sortKeyChannels_) {
+    sortKeyStructChildren_.push_back(sortedInput.column(ch));
+  }
+  // Zero-copy struct column_view: cudf's row comparator treats children
+  // as a composite key, comparing element-wise for equality.
+  return cudf::column_view(
+      cudf::data_type{cudf::type_id::STRUCT},
+      sortedInput.num_rows(),
+      nullptr,
+      nullptr,
+      0,
+      0,
+      sortKeyStructChildren_);
+}
+
 std::unique_ptr<cudf::column> CudfWindow::computeRankColumn(
     cudf::table_view const& sortedInput,
     WindowFunctionKind kind,
@@ -508,10 +518,26 @@ std::unique_ptr<cudf::column> CudfWindow::computeRankColumn(
   auto mr = cudf::get_current_device_resource_ref();
   auto method = toRankMethod(kind);
 
-  // For rank/dense_rank, use the first sort key as values.
-  // For row_number, any column works (FIRST ignores ties).
-  cudf::size_type valuesChannel =
-      sortKeyChannels_.empty() ? 0 : sortKeyChannels_[0];
+  // Build the "values" column for rank tie detection.
+  // - row_number (FIRST): ties don't matter, use any single column.
+  // - rank/dense_rank with 1 sort key: use that key directly.
+  // - rank/dense_rank with N sort keys: build a zero-copy struct
+  //   column_view over all sort keys so cudf's row equality comparator
+  //   detects ties across the full composite key.
+  cudf::column_view valuesCol = [&]() -> cudf::column_view {
+    if (sortKeyChannels_.empty()) {
+      return sortedInput.column(0);
+    }
+    if (sortKeyChannels_.size() == 1 ||
+        kind == WindowFunctionKind::kRowNumber) {
+      return sortedInput.column(sortKeyChannels_[0]);
+    }
+    // Multi-key struct: cudf's rank_scan and group_rank_scan both use
+    // row::equality::self_comparator which handles STRUCT via nested
+    // column comparison (see rank_scan.cu and group_rank_scan.cu).
+    return multiSortKeyStructView(sortedInput);
+  }();
+
   auto colOrder = sortKeyChannels_.empty()
       ? cudf::order::ASCENDING
       : sortOrders_[0];
@@ -527,7 +553,7 @@ std::unique_ptr<cudf::column> CudfWindow::computeRankColumn(
         cudf::null_policy::INCLUDE,
         nullOrd);
     return cudf::scan(
-        sortedInput.column(valuesChannel),
+        valuesCol,
         *agg,
         cudf::scan_type::INCLUSIVE,
         cudf::null_policy::INCLUDE,
@@ -538,8 +564,7 @@ std::unique_ptr<cudf::column> CudfWindow::computeRankColumn(
   auto partCols =
       selectColumns(sortedInput, partitionKeyChannels_);
   std::vector<cudf::groupby::scan_request> requests(1);
-  requests[0].values =
-      sortedInput.column(valuesChannel);
+  requests[0].values = valuesCol;
   requests[0].aggregations.push_back(
       cudf::make_rank_aggregation<
           cudf::groupby_scan_aggregation>(

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -92,6 +92,9 @@ class CudfWindow : public exec::Operator, public NvtxHelper {
   std::pair<cudf::window_bounds, cudf::window_bounds>
   toWindowBounds(const core::WindowNode::Frame& frame) const;
 
+  cudf::column_view multiSortKeyStructView(
+      cudf::table_view const& sortedInput) const;
+
   std::unique_ptr<cudf::column> computeRankColumn(
       cudf::table_view const& sortedInput,
       WindowFunctionKind kind,
@@ -117,6 +120,10 @@ class CudfWindow : public exec::Operator, public NvtxHelper {
   std::vector<cudf::order> sortOrders_;
   std::vector<cudf::null_order> sortNullOrders_;
   std::vector<WindowFunctionSpec> functionSpecs_;
+
+  // Scratch storage for the struct column_view children returned by
+  // multiSortKeyStructView. Mutable because computeRankColumn is const.
+  mutable std::vector<cudf::column_view> sortKeyStructChildren_;
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -298,6 +298,43 @@ struct AsyncHtoD {
   }
 };
 
+/// Reconcile a RowVector's declared RowType with its actual children's types.
+/// After shuffle deserialization, a RowVector may have children whose physical
+/// types differ from the declared type (e.g. decimal BIGINT vs HUGEINT when
+/// the GPU produced DECIMAL128 but the Spark schema expects smaller precision).
+/// BaseVector::create + copy requires matching typeKinds, so we reconstruct
+/// the RowType from the actual children when a mismatch is detected.
+facebook::velox::TypePtr reconcileRowType(
+    const facebook::velox::RowVectorPtr& rv) {
+  auto declaredType = rv->type();
+  if (declaredType->kind() != facebook::velox::TypeKind::ROW) {
+    return declaredType;
+  }
+  auto rowType =
+      std::dynamic_pointer_cast<const facebook::velox::RowType>(declaredType);
+  bool needsFix = false;
+  for (size_t i = 0; i < rowType->size(); ++i) {
+    auto child = rv->childAt(i);
+    if (child && child->typeKind() != rowType->childAt(i)->kind()) {
+      needsFix = true;
+      break;
+    }
+  }
+  if (!needsFix) {
+    return declaredType;
+  }
+  std::vector<std::string> names;
+  std::vector<facebook::velox::TypePtr> types;
+  names.reserve(rowType->size());
+  types.reserve(rowType->size());
+  for (size_t i = 0; i < rowType->size(); ++i) {
+    names.push_back(rowType->nameOf(i));
+    auto child = rv->childAt(i);
+    types.push_back(child ? child->type() : rowType->childAt(i));
+  }
+  return facebook::velox::ROW(std::move(names), std::move(types));
+}
+
 /// Issues the from_arrow transfer on `stream` but does NOT synchronize.
 /// The returned AsyncHtoD keeps pinned buffers alive; caller must sync
 /// the stream before destroying it.
@@ -307,8 +344,11 @@ AsyncHtoD toCudfTableNoSync(
     rmm::cuda_stream_view stream) {
   // Flatten nested encodings (e.g. dictionary-of-dictionary) that the Arrow
   // bridge cannot export.  BaseVector::copy always produces flat output.
+  // Use reconciled type so that the target matches actual children's physical
+  // types (handles decimal BIGINT/HUGEINT mismatches from shuffle).
+  auto targetType = reconcileRowType(veloxTable);
   auto flat = facebook::velox::BaseVector::create<facebook::velox::RowVector>(
-      veloxTable->type(), veloxTable->size(), pool);
+      targetType, veloxTable->size(), pool);
   flat->copy(veloxTable.get(), 0, 0, veloxTable->size());
 
   AsyncHtoD result;


### PR DESCRIPTION
## Summary

- **Q18 decimal BIGINT/HUGEINT type reconciliation**: After CPU-fallback aggregation of
  avg(decimal(12,2)), the RowVector's declared type says DECIMAL(16,6) (BIGINT) but the
  actual child vector is HUGEINT (DECIMAL128). Added reconcileRowType() in toCudfTableNoSync
  that detects and fixes type mismatches between a RowVector's declared RowType and its
  actual children's physical types.

- **Multi-sort-key rank/dense_rank in CudfWindow (Q47/Q57)**: Removed the single-sort-key
  restriction for rank()/dense_rank(). Builds a zero-copy struct column_view over all sort
  key columns so cudf's row equality comparator detects ties across the full composite key.
  Fixes Q47 (4 partition + 2 sort) and Q57 (3 partition + 2 sort) falling back to CPU.

## Affected Queries

- Q18: decimal avg aggregation output type mismatch
- Q47, Q57: multi-sort-key rank/dense_rank window functions

## Test Plan

- [ ] Build with cuDF enabled
- [ ] Run TPC-DS Q18/Q47/Q57 on SF100, verify PASS
- [ ] Verify no regression on other queries