### PR TITLE
fix(cudf): decimal aggregation STRUCT handling, Arrow decimal bitwidth, and zero-column fixes

### DIFF
--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -384,6 +384,15 @@ RowVectorPtr CudfToVelox::getOutput() {
       finished_ = noMoreInput_ && inputs_.empty();
       return nullptr;
     }
+
+    finished_ = noMoreInput_ && inputs_.empty();
+
+    if (outputType_->size() == 0) {
+      return std::make_shared<RowVector>(
+          pool(), outputType_, nullptr, tableView.num_rows(),
+          std::vector<VectorPtr>{});
+    }
+
     RowVectorPtr output =
         with_arrow::toVeloxColumn(tableView, pool(), outputType_, "", stream, cudf::get_current_device_resource_ref());
     stream.synchronize();
@@ -477,6 +486,14 @@ RowVectorPtr CudfToVelox::getOutput() {
   VELOX_CHECK_NOT_NULL(resultTable);
   if (size == 0) {
     return nullptr;
+  }
+
+  finished_ = noMoreInput_ && inputs_.empty();
+
+  if (outputType_->size() == 0) {
+    return std::make_shared<RowVector>(
+        pool(), outputType_, nullptr, size,
+        std::vector<VectorPtr>{});
   }
 
   RowVectorPtr output = with_arrow::toVeloxColumn(

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -2175,6 +2175,17 @@ RowVectorPtr CudfHashAggregation::getOutput() {
     if (isGlobal_) {
       auto stream = cudfGlobalStreamPool().get_stream();
       auto tbl = getConcatenatedTable(inputs_, inputType_, stream);
+      if (tbl->num_columns() == 0) {
+        auto mr = cudf::get_current_device_resource_ref();
+        std::vector<std::unique_ptr<cudf::column>> cols;
+        cols.push_back(cudf::make_numeric_column(
+            cudf::data_type(cudf::type_id::INT8),
+            0,
+            cudf::mask_state::UNALLOCATED,
+            stream,
+            mr));
+        tbl = std::make_unique<cudf::table>(std::move(cols));
+      }
       return doGlobalAggregation(tbl->view(), stream);
     }
     return nullptr;

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -17,6 +17,7 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/CudfFilterProject.h"
 #include "velox/experimental/cudf/exec/CudfHashAggregation.h"
+// #endregion
 #include "velox/experimental/cudf/exec/GpuGuard.h"
 #include "velox/experimental/cudf/exec/BloomFilterKernels.h"
 #include "velox/experimental/cudf/exec/DecimalAggregationKernels.h"
@@ -135,6 +136,40 @@ struct DecimalSumOrAvgAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests,
       rmm::cuda_stream_view stream) override {
+    if ((step == core::AggregationNode::Step::kFinal ||
+         step == core::AggregationNode::Step::kIntermediate) &&
+        tbl.column(inputIndex).type().id() == cudf::type_id::STRUCT) {
+      auto const& structCol = tbl.column(inputIndex);
+      // Deep copy children to standalone columns for proper alignment
+      {
+        auto rawCopy = std::make_unique<cudf::column>(
+            structCol.child(0), stream, cudf::get_current_device_resource_ref());
+        origSumType_ = rawCopy->type();
+        if (rawCopy->type().id() == cudf::type_id::DECIMAL128) {
+          sumCopy_ = cudf::cast(
+              *rawCopy,
+              cudf::data_type{cudf::type_id::DECIMAL64, rawCopy->type().scale()},
+              stream, cudf::get_current_device_resource_ref());
+        } else {
+          sumCopy_ = std::move(rawCopy);
+        }
+      }
+      countCopy_ = std::make_unique<cudf::column>(
+          structCol.child(1), stream, cudf::get_current_device_resource_ref());
+      sumIdx_ = requests.size();
+      auto& sumRequest = requests.emplace_back();
+      sumRequest.values = sumCopy_->view();
+      sumRequest.aggregations.push_back(
+          cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+      if (isAvg_ || step == core::AggregationNode::Step::kIntermediate) {
+        countIdx_ = requests.size();
+        auto& countRequest = requests.emplace_back();
+        countRequest.values = countCopy_->view();
+        countRequest.aggregations.push_back(
+            cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+      }
+      return;
+    }
     if (step == core::AggregationNode::Step::kIntermediate &&
         tbl.column(inputIndex).type().id() == cudf::type_id::STRING) {
       auto scale = resultType->isDecimal()
@@ -220,13 +255,6 @@ struct DecimalSumOrAvgAggregator : cudf_velox::CudfHashAggregation::Aggregator {
         count =
             cudf::cast(*count, cudf::data_type{cudf::type_id::INT64}, stream, cudf::get_current_device_resource_ref());
       }
-      auto const& outputType = asRowType(resultType);
-      auto const cudfSumType =
-          cudf_velox::veloxToCudfDataType(outputType->childAt(0));
-      if (col->type() != cudfSumType) {
-        col = cudf::cast(*col, cudfSumType, stream,
-                         cudf::get_current_device_resource_ref());
-      }
       auto size = col->size();
       std::vector<std::unique_ptr<cudf::column>> children;
       children.push_back(std::move(col));
@@ -245,11 +273,9 @@ struct DecimalSumOrAvgAggregator : cudf_velox::CudfHashAggregation::Aggregator {
         count =
             cudf::cast(*count, cudf::data_type{cudf::type_id::INT64}, stream, cudf::get_current_device_resource_ref());
       }
-      auto const& outputType = asRowType(resultType);
-      auto const cudfSumType =
-          cudf_velox::veloxToCudfDataType(outputType->childAt(0));
-      if (col->type() != cudfSumType) {
-        col = cudf::cast(*col, cudfSumType, stream,
+      if (origSumType_.id() == cudf::type_id::DECIMAL128 &&
+          col->type().id() == cudf::type_id::DECIMAL64) {
+        col = cudf::cast(*col, origSumType_, stream,
                          cudf::get_current_device_resource_ref());
       }
       auto size = col->size();
@@ -265,6 +291,11 @@ struct DecimalSumOrAvgAggregator : cudf_velox::CudfHashAggregation::Aggregator {
           std::move(children));
     }
     if (isAvg_ && step == core::AggregationNode::Step::kFinal) {
+      if (origSumType_.id() == cudf::type_id::DECIMAL128 &&
+          col->type().id() == cudf::type_id::DECIMAL64) {
+        col = cudf::cast(*col, origSumType_, stream,
+                         cudf::get_current_device_resource_ref());
+      }
       auto count = std::move(results[countIdx_].results[0]);
       return computeAvgColumn(std::move(col), std::move(count), stream);
     }
@@ -354,6 +385,46 @@ struct DecimalSumOrAvgAggregator : cudf_velox::CudfHashAggregation::Aggregator {
           0,
           std::move(children));
     }
+    if ((step == core::AggregationNode::Step::kFinal ||
+         step == core::AggregationNode::Step::kIntermediate) &&
+        inputCol.type().id() == cudf::type_id::STRUCT) {
+      auto const sumChild = inputCol.child(0);
+      auto const countChild = inputCol.child(1);
+      auto sumScalar = cudf::reduce(
+          sumChild, *aggRequest, sumChild.type(), stream,
+          cudf::get_current_device_resource_ref());
+      auto sumCol = cudf::make_column_from_scalar(
+          *sumScalar, 1, stream, cudf::get_current_device_resource_ref());
+      if (isAvg_ && step == core::AggregationNode::Step::kFinal) {
+        auto countScalar = cudf::reduce(
+            countChild, *aggRequest,
+            cudf::data_type{cudf::type_id::INT64}, stream,
+            cudf::get_current_device_resource_ref());
+        auto countCol = cudf::make_column_from_scalar(
+            *countScalar, 1, stream, cudf::get_current_device_resource_ref());
+        return computeAvgColumn(
+            std::move(sumCol), std::move(countCol), stream);
+      }
+      auto countScalar = cudf::reduce(
+          countChild, *aggRequest,
+          cudf::data_type{cudf::type_id::INT64}, stream,
+          cudf::get_current_device_resource_ref());
+      auto countCol = cudf::make_column_from_scalar(
+          *countScalar, 1, stream, cudf::get_current_device_resource_ref());
+      auto const cudfSumType = cudf_velox::veloxToCudfDataType(
+          asRowType(outputType)->childAt(0));
+      if (sumCol->type() != cudfSumType) {
+        sumCol = cudf::cast(*sumCol, cudfSumType, stream,
+                            cudf::get_current_device_resource_ref());
+      }
+      std::vector<std::unique_ptr<cudf::column>> children;
+      children.push_back(std::move(sumCol));
+      children.push_back(std::move(countCol));
+      return std::make_unique<cudf::column>(
+          cudf::data_type(cudf::type_id::STRUCT), 1,
+          rmm::device_buffer{}, rmm::device_buffer{}, 0,
+          std::move(children));
+    }
     if (step == core::AggregationNode::Step::kFinal &&
         inputCol.type().id() == cudf::type_id::STRING) {
       auto scale = getDecimalPrecisionScale(*outputType).second;
@@ -423,6 +494,11 @@ struct DecimalSumOrAvgAggregator : cudf_velox::CudfHashAggregation::Aggregator {
   const bool isAvg_{false};
   std::unique_ptr<cudf::column> decodedSum_;
   std::unique_ptr<cudf::column> decodedCount_;
+  std::unique_ptr<cudf::column> alignedSum_;
+  std::unique_ptr<cudf::column> sumCopy_;
+  cudf::data_type origSumType_{cudf::type_id::DECIMAL128};
+  std::unique_ptr<cudf::column> countCopy_;
+  std::unique_ptr<cudf::column> alignedCount_;
 };
 
 struct CountAggregator : cudf_velox::CudfHashAggregation::Aggregator {
@@ -1462,7 +1538,10 @@ std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator> createAggregator(
   } else if (kind.rfind(prefix + "avg", 0) == 0) {
     bool isDecimalInput =
         rawInputTypes.size() == 1 && rawInputTypes[0]->isDecimal();
-    if (isDecimalInput) {
+    bool isDecimalRowInput =
+        rawInputTypes.size() == 1 && rawInputTypes[0]->isRow() &&
+        rawInputTypes[0]->asRow().childAt(0)->isDecimal();
+    if (isDecimalInput || isDecimalRowInput || resultType->isDecimal()) {
       return std::make_unique<DecimalSumOrAvgAggregator>(
           step, inputIndex, constant, isGlobal, resultType, true);
     }
@@ -1830,6 +1909,7 @@ void CudfHashAggregation::computeIntermediateGroupbyPartial(CudfVectorPtr tbl) {
       inputTableStream);
 
   // If we already have partial output, concatenate the new results with it.
+
   if (partialOutput_) {
     // Create a vector of tables to concatenate
     std::vector<cudf::table_view> tablesToConcat;
@@ -2028,6 +2108,7 @@ CudfVectorPtr CudfHashAggregation::doGroupByAggregation(
   }
 
   auto [groupKeys, results] = groupByOwner.aggregate(requests, stream);
+
   // flatten the results
   std::vector<std::unique_ptr<cudf::column>> resultColumns;
 
@@ -2899,7 +2980,24 @@ bool canAggregationBeEvaluatedByCudf(
   }
 
   // Validate against step-specific signatures from registry
-  return matchTypedCallAgainstSignatures(call, stepIt->second);
+  if (matchTypedCallAgainstSignatures(call, stepIt->second)) {
+    return true;
+  }
+  // Allow decimal avg/sum kFinal/kIntermediate with ROW(DECIMAL, BIGINT)
+  // input even though no type-safe signature can be registered.
+  if ((companionStep == core::AggregationNode::Step::kFinal ||
+       companionStep == core::AggregationNode::Step::kIntermediate) &&
+      (originalName.size() >= 3 &&
+       (originalName.substr(originalName.size() - 3) == "avg" ||
+        originalName.substr(originalName.size() - 3) == "sum"))) {
+    if (!call.inputs().empty() && call.inputs()[0]->type()->isRow()) {
+      auto const& rowType = call.inputs()[0]->type()->asRow();
+      if (rowType.size() >= 1 && rowType.childAt(0)->isDecimal()) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 bool canBeEvaluatedByCudf(

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1273,7 +1273,12 @@ void exportToArrowImpl(
 // Parses the velox decimal format from the given arrow format.
 // The input format string should be in the form "d:precision,scale<,bitWidth>".
 // bitWidth is not required and must be 128 if provided.
-TypePtr parseDecimalFormat(const char* format) {
+struct DecimalFormatInfo {
+  TypePtr type;
+  int bitWidth;
+};
+
+DecimalFormatInfo parseDecimalFormat(const char* format) {
   std::string invalidFormatMsg =
       "Unable to convert '{}' ArrowSchema decimal format to Velox decimal";
   try {
@@ -1290,19 +1295,18 @@ TypePtr parseDecimalFormat(const char* format) {
       VELOX_USER_FAIL(invalidFormatMsg, format);
     }
 
-    // Parse "d:".
     int precision = std::stoi(&format[2], &sz);
     int scale = std::stoi(&format[firstCommaIdx + 1], &sz);
-    // If bitwidth is provided, check if it is equal to 128.
+    int bitWidth = 128;
     if (secondCommaIdx != std::string::npos) {
-      int bitWidth = std::stoi(&format[secondCommaIdx + 1], &sz);
-      VELOX_USER_CHECK_EQ(
-          bitWidth,
-          128,
-          "Conversion failed for '{}'. Velox decimal does not support custom bitwidth.",
-          format);
+      bitWidth = std::stoi(&format[secondCommaIdx + 1], &sz);
+      VELOX_USER_CHECK(
+          bitWidth == 32 || bitWidth == 64 || bitWidth == 128,
+          "Conversion failed for '{}'. Unsupported decimal bitwidth {}.",
+          format,
+          bitWidth);
     }
-    return DECIMAL(precision, scale);
+    return {DECIMAL(precision, scale), bitWidth};
   } catch (std::invalid_argument&) {
     VELOX_USER_FAIL(invalidFormatMsg, format);
   }
@@ -1367,7 +1371,7 @@ TypePtr importFromArrowImpl(
 
     case 'd':
       // decimal types.
-      return parseDecimalFormat(format);
+      return parseDecimalFormat(format).type;
 
     // Complex types.
     case '+': {
@@ -2082,6 +2086,72 @@ VectorPtr createShortDecimalVector(
       pool, type, std::move(nulls), length, values, nullCount);
 }
 
+VectorPtr createShortDecimalFromNarrow(
+    memory::MemoryPool* pool,
+    const TypePtr& type,
+    BufferPtr nulls,
+    const void* rawData,
+    int arrowBitWidth,
+    vector_size_t length,
+    int64_t nullCount) {
+  auto values = AlignedBuffer::allocate<int64_t>(length, pool);
+  auto rawValues = values->asMutable<int64_t>();
+  if (arrowBitWidth == 64) {
+    memcpy(rawValues, rawData, length * sizeof(int64_t));
+  } else if (arrowBitWidth == 32) {
+    auto src = static_cast<const int32_t*>(rawData);
+    for (vector_size_t i = 0; i < length; ++i) {
+      rawValues[i] = static_cast<int64_t>(src[i]);
+    }
+  } else {
+    auto src = static_cast<const int128_t*>(rawData);
+    for (vector_size_t i = 0; i < length; ++i) {
+      memcpy(rawValues + i, src + i, sizeof(int64_t));
+    }
+  }
+  return createFlatVector<TypeKind::BIGINT>(
+      pool, type, std::move(nulls), length, values, nullCount);
+}
+
+VectorPtr createLongDecimalFromNarrow(
+    memory::MemoryPool* pool,
+    const TypePtr& type,
+    BufferPtr nulls,
+    const void* rawData,
+    int arrowBitWidth,
+    vector_size_t length,
+    int64_t nullCount,
+    WrapInBufferViewFunc wrapInBufferView) {
+  if (arrowBitWidth == 128) {
+    auto input128 = static_cast<const int128_t*>(rawData);
+    if ((reinterpret_cast<uintptr_t>(input128) & 0xf) == 0) {
+      return createFlatVector<TypeKind::HUGEINT>(
+          pool, type, nulls, length,
+          wrapInBufferView(input128, length * type->cppSizeInBytes()),
+          nullCount);
+    }
+    auto vals128 = AlignedBuffer::allocate<int128_t>(length, pool);
+    memcpy(vals128->asMutable<int128_t>(), input128, length * sizeof(int128_t));
+    return createFlatVector<TypeKind::HUGEINT>(
+        pool, type, std::move(nulls), length, vals128, nullCount);
+  }
+  auto values = AlignedBuffer::allocate<int128_t>(length, pool);
+  auto rawValues = values->asMutable<int128_t>();
+  if (arrowBitWidth == 64) {
+    auto src = static_cast<const int64_t*>(rawData);
+    for (vector_size_t i = 0; i < length; ++i) {
+      rawValues[i] = static_cast<int128_t>(src[i]);
+    }
+  } else {
+    auto src = static_cast<const int32_t*>(rawData);
+    for (vector_size_t i = 0; i < length; ++i) {
+      rawValues[i] = static_cast<int128_t>(src[i]);
+    }
+  }
+  return createFlatVector<TypeKind::HUGEINT>(
+      pool, type, std::move(nulls), length, values, nullCount);
+}
+
 // Arrow uses two uint64_t values to represent a 128-bit decimal value. The
 // memory allocated by Arrow might not be 16-byte aligned, so we need to copy
 // the values to a new buffer to ensure 16-byte alignment.
@@ -2222,23 +2292,21 @@ VectorPtr importFromArrowImpl(
         arrowArray.length,
         arrowArray.null_count,
         isTime32);
-  } else if (type->isShortDecimal()) {
-    return createShortDecimalVector(
-        pool,
-        type,
-        nulls,
-        static_cast<const int128_t*>(arrowArray.buffers[1]),
-        arrowArray.length,
-        arrowArray.null_count);
-  } else if (type->isLongDecimal()) {
-    return createLongDecimalVector(
-        pool,
-        type,
-        nulls,
-        static_cast<const int128_t*>(arrowArray.buffers[1]),
-        arrowArray.length,
-        arrowArray.null_count,
-        wrapInBufferView);
+  } else if (type->isShortDecimal() || type->isLongDecimal()) {
+    int decBitWidth = 128;
+    if (arrowSchema.format && arrowSchema.format[0] == 'd') {
+      auto info = parseDecimalFormat(arrowSchema.format);
+      decBitWidth = info.bitWidth;
+    }
+    if (type->isShortDecimal()) {
+      return createShortDecimalFromNarrow(
+          pool, type, nulls, arrowArray.buffers[1], decBitWidth,
+          arrowArray.length, arrowArray.null_count);
+    } else {
+      return createLongDecimalFromNarrow(
+          pool, type, nulls, arrowArray.buffers[1], decBitWidth,
+          arrowArray.length, arrowArray.null_count, wrapInBufferView);
+    }
   } else if (type->isRow()) {
     // Row/structs.
     return createRowVector(


### PR DESCRIPTION
## Summary

- **STRUCT-encoded decimal avg/sum in aggregation**: When kFinal/kIntermediate
  receives STRUCT-encoded decimal avg partial state (from CPU fallback),
  decompose the struct into sum+count children and feed them as separate
  aggregation requests. Also allow ROW(DECIMAL, BIGINT) input to pass
  canAggregationBeEvaluatedByCudf validation for avg/sum.

- **Arrow decimal bitwidth import**: Support importing Arrow decimals with
  32-bit and 64-bit bitwidths (not just 128-bit). Adds
  createShortDecimalFromNarrow/createLongDecimalFromNarrow for widening
  conversions from smaller Arrow decimal representations.

- **Zero-column table handling**: Fix crashes in CudfToVelox::getOutput()
  and global aggregation when the result table has zero columns.

## Affected Queries

- Q18: decimal avg STRUCT-encoded partial state
- Queries with decimal columns exported via Arrow with non-128-bit width
- Queries with zero-column intermediate results

## Test Plan

- [ ] Build with cuDF enabled
- [ ] Run TPC-DS 103 queries on SF100
- [ ] Verify Q18 and previously failing queries now PASS
- [ ] Verify no regression on other queries