### PR TITLE
fix(cudf): react CudfWindow to support group-aware computation batch by batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -320,6 +320,9 @@ src/amalgamation/
 .settings
 ~
 
+# clangd in IDE
+.clangd
+
 #docs
 velox/docs/sphinx/source/README_generated_*
 velox/docs/bindings/python/_generate/*

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -42,7 +42,9 @@ set_target_properties(velox_cudf_exec PROPERTIES CUDA_STANDARD 20 CUDA_STANDARD_
 
 target_link_libraries(
   velox_cudf_exec
-  PUBLIC cudf::cudf
+  PUBLIC
+    cudf::cudf
+    CURL::libcurl
   PRIVATE
     velox_cudf_kernels
     arrow

--- a/velox/experimental/cudf/exec/CudfExpand.cpp
+++ b/velox/experimental/cudf/exec/CudfExpand.cpp
@@ -63,9 +63,8 @@ std::unique_ptr<cudf::scalar> createScalarDispatch(
   } else if constexpr (cudf::is_fixed_width<T>()) {
     if (type->isDate()) {
       using CudfDateType = cudf::timestamp_D;
-      return std::make_unique<
-          cudf::timestamp_scalar<CudfDateType>>(
-          value, true, stream, mr);
+      return std::make_unique<cudf::timestamp_scalar<CudfDateType>>(
+          static_cast<CudfDateType::rep>(value), true, stream, mr);
     }
     return std::make_unique<cudf::numeric_scalar<T>>(
         value, true, stream, mr);

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -15,16 +15,22 @@
  */
 
 #include "velox/experimental/cudf/exec/CudfWindow.h"
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/GpuGuard.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
 #include <cudf/column/column_factories.hpp>
+#include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/groupby.hpp>
 #include <cudf/reduction.hpp>
+#include <cudf/search.hpp>
+#include <cudf/stream_compaction.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/unary.hpp>
+
+#include <glog/logging.h>
 
 namespace {
 
@@ -296,10 +302,18 @@ CudfWindow::CudfWindow(
           operatorId,
           fmt::format("[{}]", windowNode->id())),
       windowNode_(windowNode),
-      inputType_(windowNode->sources()[0]->outputType()) {
+      inputType_(windowNode->sources()[0]->outputType()),
+      isFlushByPartition_(
+          windowNode->inputsSorted() &&
+          !windowNode->partitionKeys().empty()) {
+  std::vector<std::string> partitionKeyNames;
+  std::vector<TypePtr> partitionKeyTypes;
+
   // Parse partition key channels.
   partitionKeyChannels_.reserve(
       windowNode->partitionKeys().size());
+  partitionKeyOrders_.reserve(windowNode->partitionKeys().size());
+  partitionKeyNullOrders_.reserve(windowNode->partitionKeys().size());
   for (auto const& key : windowNode->partitionKeys()) {
     auto ch = exec::exprToChannel(key.get(), inputType_);
     VELOX_CHECK_NE(
@@ -308,6 +322,14 @@ CudfWindow::CudfWindow(
         "Window partition key must be a column");
     partitionKeyChannels_.push_back(
         static_cast<cudf::size_type>(ch));
+    partitionKeyOrders_.push_back(cudf::order::ASCENDING);
+    partitionKeyNullOrders_.push_back(cudf::null_order::BEFORE);
+    partitionKeyNames.push_back(fmt::format("pk{}", ch));
+    partitionKeyTypes.push_back(inputType_->childAt(ch));
+  }
+  if (!partitionKeyTypes.empty()) {
+    partitionKeyType_ =
+        facebook::velox::ROW(std::move(partitionKeyNames), std::move(partitionKeyTypes));
   }
 
   // Parse sort key channels and orders.
@@ -375,7 +397,14 @@ void CudfWindow::addInput(RowVectorPtr input) {
   auto cudfInput =
       std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput);
-  inputs_.push_back(std::move(cudfInput));
+
+  GpuGuard gpuGuard;
+  auto stream = cudfGlobalStreamPool().get_stream();
+  cudf::detail::join_streams(
+      std::vector<rmm::cuda_stream_view>{cudfInput->stream()}, stream);
+
+  cacheNextBatch(std::move(cudfInput), stream);
+  refreshFinished();
 }
 
 void CudfWindow::noMoreInput() {
@@ -383,42 +412,283 @@ void CudfWindow::noMoreInput() {
 
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
   GpuGuard gpuGuard;
-
-  if (inputs_.empty()) {
-    return;
-  }
-
   auto stream = cudfGlobalStreamPool().get_stream();
-  auto inputTable =
-      getConcatenatedTable(inputs_, inputType_, stream);
-  inputs_.clear();
-
-  auto outputTable =
-      computeOutputTable(std::move(inputTable), stream);
-  output_ = std::make_shared<CudfVector>(
-      pool(),
-      outputType_,
-      outputTable->num_rows(),
-      std::move(outputTable),
-      stream);
+  if (isFlushByPartition_) {
+    if (!cachedInputs_.empty()) {
+      VLOG(1) << "CudfWindow planNodeId=" << windowNode_->id()
+              << " flushing remaining cached input at noMoreInput: batches="
+              << cachedInputs_.size() << " rows=" << cachedRows_
+              << " bytes=" << cachedBytes_;
+    }
+    cachedRows_ = 0;
+    cachedBytes_ = 0;
+  }
+  flushCachedInput(stream, false);
+  refreshFinished();
 }
 
 RowVectorPtr CudfWindow::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
-  if (finished_ || !noMoreInput_) {
+  if (outputQueue_.empty()) {
+    refreshFinished();
     return nullptr;
   }
-  finished_ = true;
-  if (!output_ || output_->size() == 0) {
-    return nullptr;
-  }
-  return output_;
+  auto output = outputQueue_.front();
+  outputQueue_.pop_front();
+  refreshFinished();
+  return output;
 }
 
 void CudfWindow::close() {
   exec::Operator::close();
-  inputs_.clear();
-  output_.reset();
+  cachedInputs_.clear();
+  outputQueue_.clear();
+  cachedRows_ = 0;
+  cachedBytes_ = 0;
+  isFinished_ = true;
+}
+
+CudfVectorPtr CudfWindow::materializeTableView(
+    cudf::table_view view,
+    const RowTypePtr& type,
+    rmm::cuda_stream_view stream) const {
+  auto mr = cudf::get_current_device_resource_ref();
+  return wrapOwnedTable(
+      std::make_unique<cudf::table>(view, stream, mr), type, stream);
+}
+
+CudfVectorPtr CudfWindow::wrapOwnedTable(
+    std::unique_ptr<cudf::table> table,
+    const RowTypePtr& type,
+    rmm::cuda_stream_view stream) const {
+  auto size = static_cast<vector_size_t>(table->num_rows());
+  return std::make_shared<CudfVector>(
+      pool(), type, size, std::move(table), stream);
+}
+
+cudf::table_view CudfWindow::extractPartitionKeyRow(
+    cudf::table_view input,
+    cudf::size_type row,
+    rmm::cuda_stream_view stream) const {
+  auto partitionKeys = cudf::table_view(selectColumns(input, partitionKeyChannels_));
+  return cudf::slice(partitionKeys, {row, row + 1}, stream).front();
+}
+
+bool CudfWindow::isSamePartitionKey(
+    cudf::table_view lhs,
+    cudf::table_view rhs,
+    rmm::cuda_stream_view stream) const {
+  auto mr = cudf::get_current_device_resource_ref();
+  std::vector<cudf::table_view> tableViews{lhs, rhs};
+  auto combined = cudf::concatenate(tableViews, stream, mr);
+  return cudf::distinct_count(
+             combined->view(), cudf::null_equality::EQUAL, stream) == 1;
+}
+
+cudf::size_type CudfWindow::trailingPartitionStartRow(
+    cudf::table_view input,
+    rmm::cuda_stream_view stream) const {
+  VELOX_CHECK_GT(input.num_rows(), 0);
+  VELOX_CHECK(
+      !partitionKeyChannels_.empty(),
+      "Trailing partition split requires partition keys");
+
+  auto mr = cudf::get_current_device_resource_ref();
+  auto partitionTable = cudf::table_view(selectColumns(input, partitionKeyChannels_));
+  auto lastKey = extractPartitionKeyRow(input, input.num_rows() - 1, stream);
+  auto lowerBound = cudf::lower_bound(
+      partitionTable,
+      lastKey,
+      partitionKeyOrders_,
+      partitionKeyNullOrders_,
+      stream,
+      mr);
+  VELOX_CHECK_EQ(lowerBound->size(), 1);
+  auto lowerBoundScalar = cudf::get_element(lowerBound->view(), 0, stream, mr);
+  VELOX_CHECK(lowerBoundScalar->is_valid(stream));
+  return static_cast<cudf::numeric_scalar<cudf::size_type>*>(lowerBoundScalar.get())
+      ->value(stream);
+}
+
+bool CudfWindow::batchTargetReached(
+    vector_size_t rows,
+    uint64_t bytes) const {
+  const auto& config = CudfConfig::getInstance();
+  if (config.gpuTargetBatchBytes > 0) {
+    return bytes > static_cast<uint64_t>(config.gpuTargetBatchBytes);
+  }
+  if (config.gpuTargetBatchRows == 0) {
+    return true;
+  }
+  return rows > static_cast<vector_size_t>(config.gpuTargetBatchRows);
+}
+
+void CudfWindow::enqueueOutputTable(
+    std::unique_ptr<cudf::table> outputTable,
+    rmm::cuda_stream_view stream) {
+  if (!outputTable || outputTable->num_rows() == 0) {
+    return;
+  }
+  outputQueue_.push_back(wrapOwnedTable(std::move(outputTable), outputType_, stream));
+}
+
+void CudfWindow::cacheNextBatch(
+    CudfVectorPtr input,
+    rmm::cuda_stream_view stream) {
+  VELOX_CHECK_NOT_NULL(input);
+  cachedInputs_.push_back(std::move(input));
+
+  if (!isFlushByPartition_) {
+    return;
+  }
+
+  cachedRows_ += cachedInputs_.back()->size();
+  cachedBytes_ += cachedInputs_.back()->estimateFlatSize();
+  if (batchTargetReached(cachedRows_, cachedBytes_)) {
+    const auto& config = CudfConfig::getInstance();
+    VLOG(1) << "CudfWindow planNodeId=" << windowNode_->id()
+            << " triggering partition-aware flush attempt: batches="
+            << cachedInputs_.size() << " rows=" << cachedRows_
+            << " bytes=" << cachedBytes_
+            << " targetRows=" << config.gpuTargetBatchRows
+            << " targetBytes=" << config.gpuTargetBatchBytes;
+    flushCachedInput(stream, true);
+  }
+}
+
+void CudfWindow::flushCachedInput(
+    rmm::cuda_stream_view stream,
+    bool isPartitionAware) {
+  if (cachedInputs_.empty()) {
+    return;
+  }
+
+  auto cachedInputs = std::move(cachedInputs_);
+  cachedInputs_.clear();
+  cachedRows_ = 0;
+  cachedBytes_ = 0;
+
+  std::vector<CudfVectorPtr> nextCachedInputs;
+  auto inputTable = isPartitionAware
+      ? preparePartitionAwareFlush(
+            std::move(cachedInputs), stream, nextCachedInputs)
+      : getConcatenatedTable(cachedInputs, inputType_, stream);
+  cachedInputs.clear();
+
+  if (inputTable && inputTable->num_rows() > 0) {
+    auto outputTable = computeOutputTable(std::move(inputTable), stream);
+    enqueueOutputTable(std::move(outputTable), stream);
+  }
+
+  for (auto& cachedInput : nextCachedInputs) {
+    cachedRows_ += cachedInput->size();
+    cachedBytes_ += cachedInput->estimateFlatSize();
+    cachedInputs_.push_back(std::move(cachedInput));
+  }
+}
+
+std::unique_ptr<cudf::table> CudfWindow::preparePartitionAwareFlush(
+    std::vector<CudfVectorPtr> cachedInputs,
+    rmm::cuda_stream_view stream,
+    std::vector<CudfVectorPtr>& nextCachedInputs) {
+  // Start from the optimistic assumption that everything except the last cached
+  // batch is flushable. The primary goal is to keep this flush close to the
+  // batch-size threshold that triggered in cacheNextBatch(). Once batch-size
+  // control forces a split, we also have to verify that the split point does
+  // not land in the middle of a partition.
+  auto mr = cudf::get_current_device_resource_ref();
+  auto splitTrailingPartition =
+      [&](std::unique_ptr<cudf::table> inputTable) -> std::unique_ptr<cudf::table> {
+    auto processView = inputTable->view();
+    auto trailingStart = trailingPartitionStartRow(processView, stream);
+    if (trailingStart == 0) {
+      // The whole flush candidate belongs to that trailing partition, so keep it
+      // all cached and emit nothing this round.
+      VLOG(1) << "CudfWindow planNodeId=" << windowNode_->id()
+              << " deferring flush because the current candidate belongs to a "
+                 "single trailing partition: rows="
+              << processView.num_rows() << " batches="
+              << cachedInputs.size() << " heldBackTailBatches="
+              << nextCachedInputs.size();
+      nextCachedInputs.insert(
+          nextCachedInputs.begin(),
+          wrapOwnedTable(std::move(inputTable), inputType_, stream));
+      return nullptr;
+    }
+
+    // Split the candidate into a flushable prefix and a trailing partition tail.
+    auto slices = cudf::split(processView, {trailingStart}, stream);
+    auto processSlice = slices[0];
+    auto trailingSlice = slices[1];
+    VLOG(1) << "CudfWindow planNodeId=" << windowNode_->id()
+            << " splitting partition-aware flush candidate at row "
+            << trailingStart << ": flushRows=" << processSlice.num_rows()
+            << " cachedTailRows=" << trailingSlice.num_rows();
+    auto trailingInput =
+        materializeTableView(trailingSlice, inputType_, stream);
+    nextCachedInputs.insert(nextCachedInputs.begin(), std::move(trailingInput));
+    auto outputTable = std::make_unique<cudf::table>(processSlice, stream, mr);
+    inputTable.reset();
+    return outputTable;
+  };
+
+  std::vector<CudfVectorPtr> processInputs;
+  if (cachedInputs.size() == 1) {
+    // With only one cached batch, we still need to honor partition integrity.
+    // If this batch contains only one partition, keep pulling more input until
+    // a partition boundary shows up, even if that means going past the nominal
+    // batch-size threshold.
+    processInputs = std::move(cachedInputs);
+  } else {
+    auto lastInput = std::move(cachedInputs.back());
+    cachedInputs.pop_back();
+    processInputs = std::move(cachedInputs);
+    nextCachedInputs.push_back(std::move(lastInput));
+  }
+
+  auto inputTable = getConcatenatedTable(processInputs, inputType_, stream);
+  processInputs.clear();
+  if (inputTable->num_rows() == 0) {
+    return nullptr;
+  }
+
+  if (nextCachedInputs.empty()) {
+    if (noMoreInput_) {
+      return inputTable;
+    }
+
+    // No tail batch has been held back yet, but the current candidate may still
+    // end in the middle of a partition and need to keep that trailing partition cached.
+    return splitTrailingPartition(std::move(inputTable));
+  }
+
+  auto processView = inputTable->view();
+  // Batch-size control picked a tentative flush boundary. Compare the last
+  // partition key in that flush candidate with the first key in the still-
+  // cached tail. If they differ, the batch-size split already lands on a
+  // partition boundary and the whole candidate table is safe to emit.
+  // The cached tail may have been produced on a different stream.
+  cudf::detail::join_streams(
+      std::vector<rmm::cuda_stream_view>{nextCachedInputs.front()->stream()},
+      stream);
+  auto lastProcessKey = extractPartitionKeyRow(
+      processView, processView.num_rows() - 1, stream);
+  auto firstCachedKey =
+      extractPartitionKeyRow(nextCachedInputs.front()->getTableView(), 0, stream);
+
+  if (!isSamePartitionKey(lastProcessKey, firstCachedKey, stream)) {
+    return inputTable;
+  }
+
+  // Batch-size control landed in the middle of a partition. Peel that trailing
+  // partition back out so the next flush still computes the full partition in
+  // one shot.
+  return splitTrailingPartition(std::move(inputTable));
+}
+
+void CudfWindow::refreshFinished() {
+  isFinished_ =
+      noMoreInput_ && outputQueue_.empty() && cachedInputs_.empty();
 }
 
 std::unique_ptr<cudf::rolling_aggregation>
@@ -715,6 +985,9 @@ std::unique_ptr<cudf::table> CudfWindow::computeOutputTable(
     resultCols.push_back(std::move(col));
   }
 
+  // The result columns no longer depend on the temporary sorted table.
+  sortedTable.reset();
+
   // Scatter results back to original order if we sorted.
   if (sortedOrder) {
     for (auto& col : resultCols) {
@@ -732,6 +1005,7 @@ std::unique_ptr<cudf::table> CudfWindow::computeOutputTable(
           mr);
       col = std::move(scattered->release()[0]);
     }
+    sortedOrder.reset();
   }
 
   // Assemble output: all input columns + result columns.

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -25,6 +25,8 @@
 #include <cudf/rolling.hpp>
 #include <cudf/types.hpp>
 
+#include <deque>
+
 namespace facebook::velox::cudf_velox {
 
 enum class WindowFunctionKind {
@@ -47,19 +49,24 @@ bool isSupportedCudfWindowNode(
 /// (sum, min, max, count, avg) via cudf::grouped_rolling_window.
 class CudfWindow : public exec::Operator, public NvtxHelper {
  public:
+  /// Builds a cuDF-backed window operator for one Velox WindowNode.
   CudfWindow(
       int32_t operatorId,
       exec::DriverCtx* driverCtx,
       const std::shared_ptr<const core::WindowNode>& windowNode);
 
   bool needsInput() const override {
-    return !noMoreInput_;
+    return !noMoreInput_ && outputQueue_.empty();
   }
 
+  /// Accepts one GPU batch from upstream and routes it to the sorted or
+  /// blocking path.
   void addInput(RowVectorPtr input) override;
 
+  /// Drains any cached input into final output batches once upstream is done.
   void noMoreInput() override;
 
+  /// Returns one ready output batch at a time.
   RowVectorPtr getOutput() override;
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -67,11 +74,14 @@ class CudfWindow : public exec::Operator, public NvtxHelper {
   }
 
   bool isFinished() override {
-    return finished_;
+    refreshFinished();
+    return isFinished_;
   }
 
+  /// Releases cached input and output state.
   void close() override;
 
+  /// Returns true for rank-like functions that do not consume a value column.
   static bool isRankLike(WindowFunctionKind kind);
 
  private:
@@ -84,38 +94,126 @@ class CudfWindow : public exec::Operator, public NvtxHelper {
     cudf::null_policy countNullPolicy;
   };
 
+  /// Maps a parsed window function kind to the cuDF rank method enum.
   static cudf::rank_method toRankMethod(WindowFunctionKind kind);
 
+  /// Creates the cuDF rolling aggregation object for one aggregate window
+  /// function.
   std::unique_ptr<cudf::rolling_aggregation>
   makeRollingAggregation(const WindowFunctionSpec& spec) const;
 
+  /// Converts a Velox frame definition into cuDF window bounds.
   std::pair<cudf::window_bounds, cudf::window_bounds>
   toWindowBounds(const core::WindowNode::Frame& frame) const;
 
+  /// Builds a temporary struct view for multi-column ORDER BY rank operations.
   cudf::column_view multiSortKeyStructView(
       cudf::table_view const& sortedInput) const;
 
+  /// Computes one rank-like output column on already sorted input.
   std::unique_ptr<cudf::column> computeRankColumn(
       cudf::table_view const& sortedInput,
       WindowFunctionKind kind,
       rmm::cuda_stream_view stream) const;
 
+  /// Computes one aggregate window output column on already sorted input.
   std::unique_ptr<cudf::column> computeAggregateColumn(
       cudf::table_view const& sortedInput,
       const WindowFunctionSpec& spec,
       rmm::cuda_stream_view stream) const;
 
+  /// Runs the full window computation for one input table and appends the
+  /// resulting window columns.
   std::unique_ptr<cudf::table> computeOutputTable(
       std::unique_ptr<cudf::table> input,
       rmm::cuda_stream_view stream) const;
 
+  /// Materializes a table_view into an owning CudfVector on the target stream.
+  CudfVectorPtr materializeTableView(
+      cudf::table_view view,
+      const RowTypePtr& type,
+      rmm::cuda_stream_view stream) const;
+
+  /// Wraps an owning cuDF table into a CudfVector without copying the GPU data.
+  CudfVectorPtr wrapOwnedTable(
+      std::unique_ptr<cudf::table> table,
+      const RowTypePtr& type,
+      rmm::cuda_stream_view stream) const;
+
+  /// Extracts one partition-key row from the input table as a 1-row table_view
+  /// so boundary partitions can be compared without materializing an owning table.
+  cudf::table_view extractPartitionKeyRow(
+      cudf::table_view input,
+      cudf::size_type row,
+      rmm::cuda_stream_view stream) const;
+
+  /// Returns true if two 1-row partition-key table views belong to the same
+  /// logical partition.
+  bool isSamePartitionKey(
+      cudf::table_view lhs,
+      cudf::table_view rhs,
+      rmm::cuda_stream_view stream) const;
+
+  /// Finds the start row of the trailing partition in a sorted table.
+  cudf::size_type trailingPartitionStartRow(
+      cudf::table_view input,
+      rmm::cuda_stream_view stream) const;
+
+  /// Checks whether the buffered input has exceeded the configured GPU batch
+  /// target.
+  bool batchTargetReached(vector_size_t rows, uint64_t bytes) const;
+
+  /// Wraps one computed cuDF table into the output queue if it is non-empty.
+  void enqueueOutputTable(
+      std::unique_ptr<cudf::table> outputTable,
+      rmm::cuda_stream_view stream);
+
+  /// Caches one input batch. In the partition-aware path, the size target is
+  /// only a trigger to attempt a flush; partition completeness still wins, so
+  /// whole partitions may stay cached past the nominal threshold.
+  void cacheNextBatch(
+      CudfVectorPtr input,
+      rmm::cuda_stream_view stream);
+
+  /// Flushes cached input into output. In the partition-aware path, keeps the
+  /// trailing boundary partition cached for the next batch.
+  void flushCachedInput(
+      rmm::cuda_stream_view stream,
+      bool isPartitionAware);
+
+  /// Builds the next flushable input table for the partition-aware path.
+  /// If the current flush candidate does not yet end on a partition boundary,
+  /// the trailing partition rows stay in `nextCachedInputs` for the next round.
+  std::unique_ptr<cudf::table> preparePartitionAwareFlush(
+      std::vector<CudfVectorPtr> cachedInputs,
+      rmm::cuda_stream_view stream,
+      std::vector<CudfVectorPtr>& nextCachedInputs);
+
+  /// Refreshes the finished flag from cached input and queued output state.
+  void refreshFinished();
+
   std::shared_ptr<const core::WindowNode> windowNode_;
   RowTypePtr inputType_;
-  std::vector<CudfVectorPtr> inputs_;
-  CudfVectorPtr output_;
-  bool finished_{false};
+  RowTypePtr partitionKeyType_;
+  const bool isFlushByPartition_;
+
+  /// Shared cache for both modes: unsorted input accumulates here until the
+  /// final blocking flush, while sorted input uses it as the rolling cache for
+  /// prefix flushing and boundary-partition carry-over.
+  std::vector<CudfVectorPtr> cachedInputs_;
+
+  /// Approximate size of the currently cached sorted input. Unsorted mode does
+  /// not consult these counters when deciding when to flush.
+  vector_size_t cachedRows_{0};
+  uint64_t cachedBytes_{0};
+
+  /// Output batches ready to be returned from getOutput().
+  std::deque<CudfVectorPtr> outputQueue_;
+  bool isFinished_{false};
 
   std::vector<cudf::size_type> partitionKeyChannels_;
+  std::vector<cudf::order> partitionKeyOrders_;
+  std::vector<cudf::null_order> partitionKeyNullOrders_;
   std::vector<cudf::size_type> sortKeyChannels_;
   std::vector<cudf::order> sortOrders_;
   std::vector<cudf::null_order> sortNullOrders_;

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(velox_cudf_nested_loop_join_test Main.cpp NestedLoopJoinTest.cpp)
 add_executable(velox_cudf_limit_test Main.cpp LimitTest.cpp)
 add_executable(velox_cudf_local_partition_test Main.cpp LocalPartitionTest.cpp)
 add_executable(velox_cudf_order_by_test Main.cpp OrderByTest.cpp)
+add_executable(velox_cudf_window_test Main.cpp WindowTest.cpp)
 if(VELOX_ENABLE_S3)
   add_executable(velox_cudf_s3_read_test Main.cpp S3ReadTest.cpp)
 endif()
@@ -118,6 +119,12 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+add_test(
+  NAME velox_cudf_window_test
+  COMMAND velox_cudf_window_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 if(VELOX_ENABLE_S3)
   add_test(
     NAME velox_cudf_s3_read_test
@@ -185,6 +192,7 @@ set_tests_properties(velox_cudf_nested_loop_join_test PROPERTIES LABELS cuda_dri
 set_tests_properties(velox_cudf_limit_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_local_partition_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_order_by_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
+set_tests_properties(velox_cudf_window_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 if(VELOX_ENABLE_S3)
   set_tests_properties(velox_cudf_s3_read_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 endif()
@@ -327,6 +335,18 @@ target_link_libraries(
 
 target_link_libraries(
   velox_cudf_order_by_test
+  velox_cudf_exec
+  velox_cudf_gpu_guard_stub
+  velox_exec
+  velox_exec_test_lib
+  velox_test_util
+  gtest
+  gtest_main
+  fmt::fmt
+)
+
+target_link_libraries(
+  velox_cudf_window_test
   velox_cudf_exec
   velox_cudf_gpu_guard_stub
   velox_exec

--- a/velox/experimental/cudf/tests/WindowTest.cpp
+++ b/velox/experimental/cudf/tests/WindowTest.cpp
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfConversion.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+class ScopedCudfBatchConfig {
+ public:
+  ScopedCudfBatchConfig(int32_t rows, int64_t bytes)
+      : config_(cudf_velox::CudfConfig::getInstance()),
+        savedRows_(config_.gpuTargetBatchRows),
+        savedBytes_(config_.gpuTargetBatchBytes) {
+    config_.gpuTargetBatchRows = rows;
+    config_.gpuTargetBatchBytes = bytes;
+  }
+
+  ~ScopedCudfBatchConfig() {
+    config_.gpuTargetBatchRows = savedRows_;
+    config_.gpuTargetBatchBytes = savedBytes_;
+  }
+
+ private:
+  cudf_velox::CudfConfig& config_;
+  int32_t savedRows_;
+  int64_t savedBytes_;
+};
+
+class CudfWindowTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
+    window::prestosql::registerAllWindowFunctions();
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    OperatorTestBase::TearDown();
+  }
+
+  bool wasCudfWindowUsed(const std::shared_ptr<Task>& task) const {
+    for (const auto& pipelineStats : task->taskStats().pipelineStats) {
+      for (const auto& operatorStats : pipelineStats.operatorStats) {
+        if (operatorStats.operatorType == "CudfWindow") {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  uint64_t cudfWindowOutputVectors(const std::shared_ptr<Task>& task) const {
+    uint64_t outputVectors = 0;
+    for (const auto& pipelineStats : task->taskStats().pipelineStats) {
+      for (const auto& operatorStats : pipelineStats.operatorStats) {
+        if (operatorStats.operatorType == "CudfWindow") {
+          outputVectors += operatorStats.outputVectors;
+        }
+      }
+    }
+    return outputVectors;
+  }
+
+  RowVectorPtr copyResultsWithSingleRowGpuBatches(
+      const core::PlanNodePtr& plan,
+      std::shared_ptr<Task>& task) {
+    return copyResultsWithGpuBatchSizeRows(plan, 1, task);
+  }
+
+  RowVectorPtr copyResultsWithGpuBatchSizeRows(
+      const core::PlanNodePtr& plan,
+      int32_t gpuBatchSizeRows,
+      std::shared_ptr<Task>& task) {
+    return AssertQueryBuilder(duckDbQueryRunner_)
+        .plan(plan)
+        .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, gpuBatchSizeRows)
+        .copyResults(pool(), task);
+  }
+
+  std::vector<RowVectorPtr> copyResultBatchesWithSingleRowGpuBatches(
+      const core::PlanNodePtr& plan) {
+    return copyResultBatchesWithGpuBatchSizeRows(plan, 1);
+  }
+
+  std::vector<RowVectorPtr> copyResultBatchesWithGpuBatchSizeRows(
+      const core::PlanNodePtr& plan,
+      int32_t gpuBatchSizeRows) {
+    return AssertQueryBuilder(duckDbQueryRunner_)
+        .plan(plan)
+        .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, gpuBatchSizeRows)
+        .copyResultBatches(pool());
+  }
+
+  void assertBatchSizes(
+      const std::vector<RowVectorPtr>& batches,
+      const std::vector<vector_size_t>& expectedSizes) const {
+    ASSERT_EQ(expectedSizes.size(), batches.size());
+    for (auto i = 0; i < expectedSizes.size(); ++i) {
+      EXPECT_EQ(expectedSizes[i], batches[i]->size());
+    }
+  }
+
+  RowVectorPtr makeExpectedWindowResult(
+      std::vector<int32_t> partitionKeys,
+      std::vector<int32_t> sortingKeys,
+      std::vector<int64_t> values,
+      std::vector<int64_t> rowNumbers) {
+    return makeRowVector(
+        {"p", "s", "v", "rn"},
+        {makeFlatVector<int32_t>(std::move(partitionKeys)),
+         makeFlatVector<int32_t>(std::move(sortingKeys)),
+         makeFlatVector<int64_t>(std::move(values)),
+         makeFlatVector<int64_t>(std::move(rowNumbers))});
+  }
+
+  RowVectorPtr makeExpectedRunningSumResult(
+      std::vector<int32_t> partitionKeys,
+      std::vector<int32_t> sortingKeys,
+      std::vector<int64_t> values,
+      std::vector<int64_t> runningSums) {
+    return makeRowVector(
+        {"p", "s", "v", "sum_v"},
+        {makeFlatVector<int32_t>(std::move(partitionKeys)),
+         makeFlatVector<int32_t>(std::move(sortingKeys)),
+         makeFlatVector<int64_t>(std::move(values)),
+         makeFlatVector<int64_t>(std::move(runningSums))});
+  }
+};
+
+TEST_F(CudfWindowTest, sortedStreamingCoalescesCompletePartitions) {
+  ScopedCudfBatchConfig scopedConfig(/*rows*/ 5, /*bytes*/ 0);
+
+  // Small adjacent partitions should be coalesced into one output batch while
+  // preserving full partition boundaries.
+  std::vector<RowVectorPtr> vectors{
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1, 1, 1}),
+           makeFlatVector<int32_t>({1, 2, 3, 4}),
+           makeFlatVector<int64_t>({10, 20, 30, 40})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1, 2}),
+           makeFlatVector<int32_t>({5, 6, 1}),
+           makeFlatVector<int64_t>({50, 60, 70})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({2, 3, 3, 4}),
+           makeFlatVector<int32_t>({2, 1, 2, 1}),
+           makeFlatVector<int64_t>({80, 90, 100, 110})})};
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .streamingWindow(
+                      {"row_number() over (partition by p order by s) as rn"})
+                  .planNode();
+
+  std::shared_ptr<Task> task;
+  auto result = copyResultsWithSingleRowGpuBatches(plan, task);
+  auto expected = makeExpectedWindowResult(
+      {1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 4},
+      {1, 2, 3, 4, 5, 6, 1, 2, 1, 2, 1},
+      {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110},
+      {1, 2, 3, 4, 5, 6, 1, 2, 1, 2, 1});
+  facebook::velox::test::assertEqualVectors(expected, result);
+
+  auto resultBatches = copyResultBatchesWithSingleRowGpuBatches(plan);
+  assertBatchSizes(resultBatches, {6, 5});
+
+  ASSERT_TRUE(wasCudfWindowUsed(task));
+  EXPECT_EQ(2, cudfWindowOutputVectors(task));
+}
+
+TEST_F(CudfWindowTest, sortedStreamingCachesTrailingPartition) {
+  ScopedCudfBatchConfig scopedConfig(/*rows*/ 4, /*bytes*/ 0);
+
+  // When the threshold is crossed in the middle of a partition, that trailing
+  // partition must stay cached for the next output batch.
+  std::vector<RowVectorPtr> vectors{
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1}),
+           makeFlatVector<int32_t>({1, 2}),
+           makeFlatVector<int64_t>({10, 20})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 2}),
+           makeFlatVector<int32_t>({3, 1}),
+           makeFlatVector<int64_t>({30, 40})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({2, 3}),
+           makeFlatVector<int32_t>({2, 1}),
+           makeFlatVector<int64_t>({50, 60})})};
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .streamingWindow(
+                      {"row_number() over (partition by p order by s) as rn"})
+                  .planNode();
+
+  std::shared_ptr<Task> task;
+  auto result = copyResultsWithSingleRowGpuBatches(plan, task);
+  auto expected = makeExpectedWindowResult(
+      {1, 1, 1, 2, 2, 3},
+      {1, 2, 3, 1, 2, 1},
+      {10, 20, 30, 40, 50, 60},
+      {1, 2, 3, 1, 2, 1});
+  facebook::velox::test::assertEqualVectors(expected, result);
+
+  auto resultBatches = copyResultBatchesWithSingleRowGpuBatches(plan);
+  assertBatchSizes(resultBatches, {3, 3});
+
+  ASSERT_TRUE(wasCudfWindowUsed(task));
+  EXPECT_EQ(2, cudfWindowOutputVectors(task));
+}
+
+TEST_F(CudfWindowTest, sortedStreamingKeepsOversizedPartitionIntact) {
+  ScopedCudfBatchConfig scopedConfig(/*rows*/ 4, /*bytes*/ 0);
+
+  // A single partition may exceed the target batch size, but it still has to
+  // be emitted intact rather than split across outputs.
+  std::vector<RowVectorPtr> vectors{
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1, 1}),
+           makeFlatVector<int32_t>({1, 2, 3}),
+           makeFlatVector<int64_t>({10, 20, 30})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1, 1}),
+           makeFlatVector<int32_t>({4, 5, 6}),
+           makeFlatVector<int64_t>({40, 50, 60})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({2, 2}),
+           makeFlatVector<int32_t>({1, 2}),
+           makeFlatVector<int64_t>({70, 80})})};
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .streamingWindow(
+                      {"row_number() over (partition by p order by s) as rn"})
+                  .planNode();
+
+  std::shared_ptr<Task> task;
+  auto result = copyResultsWithSingleRowGpuBatches(plan, task);
+  auto expected = makeExpectedWindowResult(
+      {1, 1, 1, 1, 1, 1, 2, 2},
+      {1, 2, 3, 4, 5, 6, 1, 2},
+      {10, 20, 30, 40, 50, 60, 70, 80},
+      {1, 2, 3, 4, 5, 6, 1, 2});
+  facebook::velox::test::assertEqualVectors(expected, result);
+
+  auto resultBatches = copyResultBatchesWithSingleRowGpuBatches(plan);
+  assertBatchSizes(resultBatches, {6, 2});
+
+  ASSERT_TRUE(wasCudfWindowUsed(task));
+  EXPECT_EQ(2, cudfWindowOutputVectors(task));
+}
+
+TEST_F(
+    CudfWindowTest,
+    sortedStreamingWaitsForPartitionBoundaryAcrossBatches) {
+  ScopedCudfBatchConfig scopedConfig(/*rows*/ 3, /*bytes*/ 0);
+
+  // If the first oversized cached batch contains only one partition, the
+  // partition-aware path must keep pulling more input until that partition
+  // ends, even though the nominal row target was already exceeded.
+  std::vector<RowVectorPtr> vectors{
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1, 1, 1}),
+           makeFlatVector<int32_t>({1, 2, 3, 4}),
+           makeFlatVector<int64_t>({10, 20, 30, 40})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1, 1, 1}),
+           makeFlatVector<int32_t>({5, 6, 7, 8}),
+           makeFlatVector<int64_t>({50, 60, 70, 80})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({2, 2}),
+           makeFlatVector<int32_t>({1, 2}),
+           makeFlatVector<int64_t>({90, 100})})};
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .streamingWindow(
+                      {"row_number() over (partition by p order by s) as rn"})
+                  .planNode();
+
+  std::shared_ptr<Task> task;
+  auto result = copyResultsWithGpuBatchSizeRows(plan, /*gpuBatchSizeRows*/ 4, task);
+  auto expected = makeExpectedWindowResult(
+      {1, 1, 1, 1, 1, 1, 1, 1, 2, 2},
+      {1, 2, 3, 4, 5, 6, 7, 8, 1, 2},
+      {10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+      {1, 2, 3, 4, 5, 6, 7, 8, 1, 2});
+  facebook::velox::test::assertEqualVectors(expected, result);
+
+  auto resultBatches =
+      copyResultBatchesWithGpuBatchSizeRows(plan, /*gpuBatchSizeRows*/ 4);
+  assertBatchSizes(resultBatches, {8, 2});
+
+  ASSERT_TRUE(wasCudfWindowUsed(task));
+  EXPECT_EQ(2, cudfWindowOutputVectors(task));
+}
+
+TEST_F(
+    CudfWindowTest,
+    sortedStreamingSplitsSingleCachedBatchAtInternalPartitionBoundary) {
+  ScopedCudfBatchConfig scopedConfig(/*rows*/ 3, /*bytes*/ 0);
+
+  // If one oversized cached batch already contains multiple partitions, emit
+  // the flushable prefix immediately and cache only the trailing partition.
+  std::vector<RowVectorPtr> vectors{
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1, 2, 2, 3, 3}),
+           makeFlatVector<int32_t>({1, 2, 1, 2, 1, 2}),
+           makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60})})};
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .streamingWindow(
+                      {"row_number() over (partition by p order by s) as rn"})
+                  .planNode();
+
+  std::shared_ptr<Task> task;
+  auto result = copyResultsWithGpuBatchSizeRows(plan, /*gpuBatchSizeRows*/ 4, task);
+  auto expected = makeExpectedWindowResult(
+      {1, 1, 2, 2, 3, 3},
+      {1, 2, 1, 2, 1, 2},
+      {10, 20, 30, 40, 50, 60},
+      {1, 2, 1, 2, 1, 2});
+  facebook::velox::test::assertEqualVectors(expected, result);
+
+  auto resultBatches =
+      copyResultBatchesWithGpuBatchSizeRows(plan, /*gpuBatchSizeRows*/ 4);
+  assertBatchSizes(resultBatches, {4, 2});
+
+  ASSERT_TRUE(wasCudfWindowUsed(task));
+  EXPECT_EQ(2, cudfWindowOutputVectors(task));
+}
+
+TEST_F(CudfWindowTest, sortedStreamingRunningSumUsesAggregatePath) {
+  ScopedCudfBatchConfig scopedConfig(/*rows*/ 5, /*bytes*/ 0);
+
+  // Aggregate windows should keep the same partition-aware flush behavior while
+  // producing correct running sums.
+  std::vector<RowVectorPtr> vectors{
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1, 1, 1}),
+           makeFlatVector<int32_t>({1, 2, 3, 4}),
+           makeFlatVector<int64_t>({10, 20, 30, 40})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 1, 2}),
+           makeFlatVector<int32_t>({5, 6, 1}),
+           makeFlatVector<int64_t>({50, 60, 70})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({2, 3, 3, 4}),
+           makeFlatVector<int32_t>({2, 1, 2, 1}),
+           makeFlatVector<int64_t>({80, 90, 100, 110})})};
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .streamingWindow(
+                      {"sum(v) over (partition by p order by s rows between "
+                       "unbounded preceding and current row) as sum_v"})
+                  .planNode();
+
+  std::shared_ptr<Task> task;
+  auto result = copyResultsWithSingleRowGpuBatches(plan, task);
+  auto expected = makeExpectedRunningSumResult(
+      {1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 4},
+      {1, 2, 3, 4, 5, 6, 1, 2, 1, 2, 1},
+      {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110},
+      {10, 30, 60, 100, 150, 210, 70, 150, 90, 190, 110});
+  facebook::velox::test::assertEqualVectors(expected, result);
+
+  auto resultBatches = copyResultBatchesWithSingleRowGpuBatches(plan);
+  assertBatchSizes(resultBatches, {6, 5});
+
+  ASSERT_TRUE(wasCudfWindowUsed(task));
+  EXPECT_EQ(2, cudfWindowOutputVectors(task));
+}
+
+TEST_F(CudfWindowTest, unsortedInputKeepsBlockingBehavior) {
+  ScopedCudfBatchConfig scopedConfig(/*rows*/ 2, /*bytes*/ 0);
+
+  // Unsorted input should keep the legacy blocking behavior and emit one
+  // output batch after full materialization.
+  std::vector<RowVectorPtr> vectors{
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({2, 1, 3}),
+           makeFlatVector<int32_t>({2, 2, 1}),
+           makeFlatVector<int64_t>({80, 20, 100})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({1, 2, 1}),
+           makeFlatVector<int32_t>({1, 1, 3}),
+           makeFlatVector<int64_t>({10, 70, 30})}),
+      makeRowVector(
+          {"p", "s", "v"},
+          {makeFlatVector<int32_t>({4, 3, 1}),
+           makeFlatVector<int32_t>({1, 2, 4}),
+           makeFlatVector<int64_t>({110, 110, 40})})};
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .window({"row_number() over (partition by p order by s) as rn"})
+                  .planNode();
+
+  std::shared_ptr<Task> task;
+  auto result = copyResultsWithSingleRowGpuBatches(plan, task);
+  auto expected = makeExpectedWindowResult(
+      {2, 1, 3, 1, 2, 1, 4, 3, 1},
+      {2, 2, 1, 1, 1, 3, 1, 2, 4},
+      {80, 20, 100, 10, 70, 30, 110, 110, 40},
+      {2, 2, 1, 1, 1, 3, 1, 2, 4});
+  facebook::velox::test::assertEqualVectors(expected, result);
+
+  ASSERT_TRUE(wasCudfWindowUsed(task));
+  EXPECT_EQ(1, cudfWindowOutputVectors(task));
+}
+
+} // namespace


### PR DESCRIPTION
Refine the sorted CudfWindow cache/flush path to preserve full partitions across batch boundaries with lower GPU memory pressure, and fix CudfExpand date constants to build cuDF timestamp scalars with the correct underlying representation.

Made-with: Cursor