### PR TITLE
GPU semaphore redesign

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
@@ -19,6 +19,8 @@
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Counters.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
 
+#include <algorithm>
+
 #include <aws/core/Aws.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
@@ -35,6 +37,57 @@ namespace {
 Aws::IOStreamFactory AwsWriteableStreamFactory(void* data, int64_t nbytes) {
   return [=]() { return Aws::New<StringViewStream>("", data, nbytes); };
 }
+
+// A streambuf that scatters sequential bytes into multiple target buffers.
+// Bytes falling in null (gap) ranges are consumed but discarded.
+class ScatterBuf : public std::streambuf {
+ public:
+  explicit ScatterBuf(const std::vector<folly::Range<char*>>& buffers)
+      : buffers_(buffers) {}
+
+ protected:
+  std::streamsize xsputn(const char_type* s, std::streamsize count) override {
+    std::streamsize consumed = 0;
+    while (consumed < count && rangeIdx_ < buffers_.size()) {
+      const auto& range = buffers_[rangeIdx_];
+      auto remaining =
+          static_cast<std::streamsize>(range.size()) - rangePos_;
+      auto n = std::min(remaining, count - consumed);
+      if (range.data()) {
+        ::memcpy(range.data() + rangePos_, s + consumed, n);
+      }
+      consumed += n;
+      rangePos_ += n;
+      if (rangePos_ >= static_cast<std::streamsize>(range.size())) {
+        ++rangeIdx_;
+        rangePos_ = 0;
+      }
+    }
+    return consumed;
+  }
+
+  int_type overflow(int_type ch) override {
+    if (traits_type::eq_int_type(ch, traits_type::eof())) {
+      return traits_type::not_eof(ch);
+    }
+    char_type c = traits_type::to_char_type(ch);
+    return xsputn(&c, 1) == 1 ? ch : traits_type::eof();
+  }
+
+ private:
+  const std::vector<folly::Range<char*>>& buffers_;
+  size_t rangeIdx_ = 0;
+  std::streamsize rangePos_ = 0;
+};
+
+// An iostream wrapping ScatterBuf for use as an Aws::IOStream.
+// Follows the StringViewStream pattern: the streambuf is embedded via
+// multiple inheritance to avoid a separate heap allocation.
+class ScatterStream : ScatterBuf, public std::iostream {
+ public:
+  explicit ScatterStream(const std::vector<folly::Range<char*>>& buffers)
+      : ScatterBuf(buffers), std::iostream(this) {}
+};
 
 } // namespace
 
@@ -96,27 +149,26 @@ class S3ReadFile ::Impl {
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
       const FileIoContext& context) const {
-    // 'buffers' contains Ranges(data, size)  with some gaps (data = nullptr) in
-    // between. This call must populate the ranges (except gap ranges)
-    // sequentially starting from 'offset'. AWS S3 GetObject does not support
-    // multi-range. AWS S3 also charges by number of read requests and not size.
-    // The idea here is to use a single read spanning all the ranges and then
-    // populate individual ranges. We pre-allocate a buffer to support this.
-    size_t length = 0;
-    for (const auto range : buffers) {
-      length += range.size();
-    }
-    // TODO: allocate from a memory pool
-    std::string result(length, 0);
-    preadInternal(offset, length, static_cast<char*>(result.data()));
-    size_t resultOffset = 0;
-    for (auto range : buffers) {
+    // 'buffers' contains Ranges(data, size) with gaps (data == nullptr).
+    // AWS S3 GetObject does not support multi-range, so we issue a single
+    // GET spanning all ranges.  A ScatterStream writes the response
+    // directly into the caller's buffers, eliminating the temporary
+    // allocation + memcpy that the previous implementation required.
+    size_t totalSpan = 0;
+    size_t bytesNeeded = 0;
+    for (const auto& range : buffers) {
+      totalSpan += range.size();
       if (range.data()) {
-        memcpy(range.data(), &(result.data()[resultOffset]), range.size());
+        bytesNeeded += range.size();
       }
-      resultOffset += range.size();
     }
-    return length;
+    if (bytesNeeded == 0) {
+      return 0;
+    }
+    preadInternal(offset, totalSpan, [&buffers]() {
+      return Aws::New<ScatterStream>("S3ScatterStream", buffers);
+    });
+    return bytesNeeded;
   }
 
   uint64_t size() const {
@@ -138,20 +190,19 @@ class S3ReadFile ::Impl {
   }
 
  private:
-  // The assumption here is that "position" has space for at least "length"
-  // bytes.
-  void preadInternal(uint64_t offset, uint64_t length, char* position) const {
-    // Read the desired range of bytes.
+  // Issues an S3 GET for [offset, offset+length) using the given stream
+  // factory to receive the response body.
+  void preadInternal(
+      uint64_t offset,
+      uint64_t length,
+      Aws::IOStreamFactory streamFactory) const {
     Aws::S3::Model::GetObjectRequest request;
-    Aws::S3::Model::GetObjectResult result;
-
     request.SetBucket(awsString(bucket_));
     request.SetKey(awsString(key_));
     std::stringstream ss;
     ss << "bytes=" << offset << "-" << offset + length - 1;
     request.SetRange(awsString(ss.str()));
-    request.SetResponseStreamFactory(
-        AwsWriteableStreamFactory(position, length));
+    request.SetResponseStreamFactory(std::move(streamFactory));
     RECORD_METRIC_VALUE(kMetricS3ActiveConnections);
     RECORD_METRIC_VALUE(kMetricS3GetObjectCalls);
     auto outcome = client_->GetObject(request);
@@ -161,6 +212,11 @@ class S3ReadFile ::Impl {
     RECORD_METRIC_VALUE(kMetricS3GetObjectRetries, outcome.GetRetryCount());
     RECORD_METRIC_VALUE(kMetricS3ActiveConnections, -1);
     VELOX_CHECK_AWS_OUTCOME(outcome, "Failed to get S3 object", bucket_, key_);
+  }
+
+  // Convenience overload: reads into a pre-allocated contiguous buffer.
+  void preadInternal(uint64_t offset, uint64_t length, char* position) const {
+    preadInternal(offset, length, AwsWriteableStreamFactory(position, length));
   }
 
   Aws::S3::S3Client* client_;

--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
@@ -130,7 +130,7 @@ class S3ReadFile ::Impl {
   }
 
   bool shouldCoalesce() const {
-    return false;
+    return true;
   }
 
   std::string getName() const {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
@@ -225,7 +225,11 @@ class S3ReadFile ::Impl {
   int64_t length_ = -1;
 };
 
-S3ReadFile::S3ReadFile(std::string_view path, Aws::S3::S3Client* client) {
+S3ReadFile::S3ReadFile(
+    std::string_view path,
+    Aws::S3::S3Client* client,
+    folly::Executor* executor)
+    : executor_(executor) {
   impl_ = std::make_shared<Impl>(path, client);
 }
 
@@ -255,6 +259,35 @@ uint64_t S3ReadFile::preadv(
     const std::vector<folly::Range<char*>>& buffers,
     const FileIoContext& context) const {
   return impl_->preadv(offset, buffers, context);
+}
+
+folly::SemiFuture<uint64_t> S3ReadFile::preadvAsync(
+    uint64_t offset,
+    const std::vector<folly::Range<char*>>& buffers,
+    const FileIoContext& context) const {
+  if (!executor_) {
+    return ReadFile::preadvAsync(offset, buffers, context);
+  }
+  auto impl = impl_; // prevent Impl destruction while async in-flight
+  auto [promise, future] = folly::makePromiseContract<uint64_t>();
+  executor_->add([impl,
+                  _promise = std::move(promise),
+                  _offset = offset,
+                  _buffers = buffers,
+                  _context = context]() mutable {
+    try {
+      auto result = impl->preadv(_offset, _buffers, _context);
+      _promise.setValue(result);
+    } catch (...) {
+      _promise.setException(
+          folly::exception_wrapper(std::current_exception()));
+    }
+  });
+  return std::move(future);
+}
+
+bool S3ReadFile::hasPreadvAsync() const {
+  return executor_ != nullptr;
 }
 
 uint64_t S3ReadFile::size() const {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.h
@@ -27,7 +27,10 @@ namespace facebook::velox::filesystems {
 /// Implementation of s3 read file.
 class S3ReadFile : public ReadFile {
  public:
-  S3ReadFile(std::string_view path, Aws::S3::S3Client* client);
+  S3ReadFile(
+      std::string_view path,
+      Aws::S3::S3Client* client,
+      folly::Executor* executor = nullptr);
 
   ~S3ReadFile() override;
 
@@ -46,6 +49,13 @@ class S3ReadFile : public ReadFile {
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
       const FileIoContext& context = {}) const final;
+
+  folly::SemiFuture<uint64_t> preadvAsync(
+      uint64_t offset,
+      const std::vector<folly::Range<char*>>& buffers,
+      const FileIoContext& context = {}) const override;
+
+  bool hasPreadvAsync() const override;
 
   uint64_t size() const final;
 
@@ -66,6 +76,7 @@ class S3ReadFile : public ReadFile {
 
   class Impl;
   std::shared_ptr<Impl> impl_;
+  folly::Executor* executor_ = nullptr;
 };
 
 } // namespace facebook::velox::filesystems

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/common/DirectBufferedInput.h"
+#include <folly/futures/Future.h>
 #include "velox/common/memory/Allocation.h"
 #include "velox/common/process/TraceContext.h"
 #include "velox/common/testutil/TestValue.h"
@@ -326,10 +327,72 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
     size += request.loadSize;
   }
 
+  // Total bytes across all buffers (data + gap ranges).
+  int64_t totalBytes = 0;
+  for (const auto& buf : buffers) {
+    totalBytes += buf.size();
+  }
+
+  constexpr int64_t kParallelReadThreshold = 16 << 20; // 16 MB
+  constexpr int64_t kParallelChunkSize = 8 << 20; // 8 MB per sub-read
+
   uint64_t usecs = 0;
   {
     MicrosecondTimer timer(&usecs);
-    input_->read(buffers, requests_[0].region.offset, LogType::FILE);
+
+    if (totalBytes > kParallelReadThreshold && input_->hasReadAsync()) {
+      // Split the buffer list into chunks and issue parallel sub-reads.
+      const int64_t startOffset = requests_[0].region.offset;
+      std::vector<folly::SemiFuture<uint64_t>> futures;
+
+      int64_t chunkStart = 0; // byte position within the buffer sequence
+      size_t bufIdx = 0; // current index into 'buffers'
+      int64_t bufConsumed = 0; // bytes already consumed in buffers[bufIdx]
+
+      while (chunkStart < totalBytes) {
+        const int64_t chunkEnd =
+            std::min(chunkStart + kParallelChunkSize, totalBytes);
+        int64_t remaining = chunkEnd - chunkStart;
+
+        // Build sub-buffer list for this chunk by slicing the master list.
+        std::vector<folly::Range<char*>> chunkBuffers;
+        while (remaining > 0 && bufIdx < buffers.size()) {
+          const auto& buf = buffers[bufIdx];
+          const int64_t available =
+              static_cast<int64_t>(buf.size()) - bufConsumed;
+          const int64_t take = std::min(remaining, available);
+
+          if (buf.data() == nullptr) {
+            // Gap range — create a null sub-range of 'take' bytes.
+            chunkBuffers.push_back(folly::Range<char*>(
+                nullptr,
+                reinterpret_cast<char*>(static_cast<uint64_t>(take))));
+          } else {
+            chunkBuffers.push_back(
+                folly::Range<char*>(buf.data() + bufConsumed, take));
+          }
+
+          bufConsumed += take;
+          remaining -= take;
+          if (bufConsumed >= static_cast<int64_t>(buf.size())) {
+            ++bufIdx;
+            bufConsumed = 0;
+          }
+        }
+
+        futures.push_back(input_->readAsync(
+            chunkBuffers, startOffset + chunkStart, LogType::FILE));
+        chunkStart = chunkEnd;
+      }
+
+      // Wait for all parallel sub-reads to complete.
+      auto results = folly::collectAll(std::move(futures)).wait().value();
+      for (auto& result : results) {
+        result.throwUnlessValue();
+      }
+    } else {
+      input_->read(buffers, requests_[0].region.offset, LogType::FILE);
+    }
   }
 
   ioStatistics_->read().increment(size + overread);

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -171,7 +171,7 @@ class DirectBufferedInput : public BufferedInput {
   bool shouldPreload(int32_t numPages = 0) override;
 
   bool shouldPrefetchStripes() const override {
-    return false;
+    return true;
   }
 
   void setNumStripes(int32_t numStripes) override {

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -216,7 +216,7 @@ FilterEstimate estimateFilterSelectivity(
     return {1.0, "no-stats"};
   }
 
-  if (!dwio::common::testFilter(
+  if (!common::testFilter(
           &filter,
           const_cast<dwio::common::ColumnStatistics*>(stats),
           totalRows,
@@ -862,7 +862,8 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
                             << succinctBytes(lastFilteredBytes)
                             << ", targetBytes="
                             << succinctBytes(effectiveTarget)
-                            << ", " << gpuMemorySnapshotString();
+                            << ", "
+                            << gpuMemoryBreakdownString(accumulatedBytes_);
                 }
                 break;
               }
@@ -876,7 +877,8 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
                      << ", preFilterBytes=" << succinctBytes(lastTableBytes)
                      << ", filteredBytes=" << succinctBytes(lastFilteredBytes)
                      << ", targetBytes=" << succinctBytes(effectiveTarget)
-                     << ", " << gpuMemorySnapshotString();
+                     << ", "
+                     << gpuMemoryBreakdownString(accumulatedBytes_);
           throw;
         }
       }
@@ -912,7 +914,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
                    << e.what()
                    << ", split=" << split_->filePath
                    << ", targetBytes=" << succinctBytes(targetBytes)
-                   << ", " << gpuMemorySnapshotString();
+                   << ", " << gpuMemoryBreakdownString(0);
         throw;
       }
     }();
@@ -924,7 +926,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
                 << (cudfTable ? cudfTable->num_rows() : 0)
                 << ", tableBytes=" << succinctBytes(lastTableBytes)
                 << ", targetBytes=" << succinctBytes(targetBytes)
-                << ", " << gpuMemorySnapshotString();
+                << ", " << gpuMemoryBreakdownString(lastTableBytes);
     }
   } else {
     // Chunked experimental reader: process row groups in batches.
@@ -948,7 +950,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
                        << e.what()
                        << ", split=" << split_->filePath
                        << ", targetBytes=" << succinctBytes(targetBytes)
-                       << ", " << gpuMemorySnapshotString();
+                       << ", " << gpuMemoryBreakdownString(0);
             throw;
           }
         }();
@@ -959,7 +961,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
                       << cudfTable->num_rows()
                       << ", tableBytes=" << succinctBytes(lastTableBytes)
                       << ", targetBytes=" << succinctBytes(targetBytes)
-                      << ", " << gpuMemorySnapshotString();
+                      << ", " << gpuMemoryBreakdownString(lastTableBytes);
           }
           break;
         }
@@ -1013,14 +1015,14 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
                   << (cudfTable ? cudfTable->num_rows() : 0)
                   << ", filteredBytes=" << succinctBytes(lastFilteredBytes)
                   << ", preFilterBytes=" << succinctBytes(lastTableBytes)
-                  << ", " << gpuMemorySnapshotString();
+                  << ", " << gpuMemoryBreakdownString(lastFilteredBytes);
       }
     } catch (const std::exception& e) {
       LOG(ERROR) << "CudfHiveDataSource::next filter failed: " << e.what()
                  << ", split=" << split_->filePath
                  << ", preFilterBytes=" << succinctBytes(lastTableBytes)
                  << ", targetBytes=" << succinctBytes(targetBytes)
-                 << ", " << gpuMemorySnapshotString();
+                 << ", " << gpuMemoryBreakdownString(lastTableBytes);
       throw;
     }
   }

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -1854,6 +1854,11 @@ std::unique_ptr<cudf::table> CudfHiveDataSource::readNextExperimentalBatch(
       columnChunkByteRanges.size());
   std::vector<std::future<size_t>> ioFutures{};
   ioFutures.reserve(columnChunkByteRanges.size());
+  // Keep pinned host buffers alive until async H2D copies complete.
+  // PinnedHostBuffer uses a pool allocator, so freed memory is immediately
+  // reusable by other threads. Without holding them here, the DMA engine
+  // may read from recycled addresses, causing SIGSEGV under concurrency.
+  std::vector<std::unique_ptr<cudf::io::datasource::buffer>> hostBuffers;
   std::for_each(
       thrust::counting_iterator<size_t>(0),
       thrust::counting_iterator(columnChunkByteRanges.size()),
@@ -1890,6 +1895,7 @@ std::unique_ptr<cudf::table> CudfHiveDataSource::readNextExperimentalBatch(
               byteRange.size(),
               cudaMemcpyHostToDevice,
               stream_.value()));
+          hostBuffers.push_back(std::move(hostBuffer));
         }
       });
 
@@ -1900,6 +1906,12 @@ std::unique_ptr<cudf::table> CudfHiveDataSource::readNextExperimentalBatch(
   std::for_each(ioFutures.begin(), ioFutures.end(), [](auto& future) {
     future.get();
   });
+  // Wait for all async H2D copies to complete before releasing pinned host
+  // buffers. The DMA engine may still be reading from them.
+  if (!hostBuffers.empty()) {
+    stream_.synchronize();
+    hostBuffers.clear();
+  }
 
   std::vector<cudf::device_span<uint8_t const>> columnChunkData;
   columnChunkData.reserve(columnChunkBuffers.size());

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -30,22 +30,17 @@
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include "velox/common/caching/CacheTTLController.h"
-#include "velox/common/base/Exceptions.h"
 #include "velox/common/time/Timer.h"
 #include "velox/connectors/hive/BufferedInputBuilder.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
-#include "velox/dwio/common/ScanSpec.h"
-#include "velox/dwio/parquet/reader/Metadata.h"
-#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
 #include "velox/expression/FieldReference.h"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
-#include <cudf/null_mask.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/io/text/byte_range_info.hpp>
 #include <cudf/io/types.hpp>
@@ -56,602 +51,17 @@
 
 #include <cuda_runtime.h>
 
-#include <thrift/protocol/TCompactProtocol.h>
-#include <thrift/transport/TBufferTransports.h>
-
-#include <algorithm>
-#include <cmath>
 #include <future>
-#include <iostream>
 #include <limits>
 #include <memory>
-#include <sstream>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
 
 namespace facebook::velox::cudf_velox::connector::hive {
 
-using cudf_velox::endGpuRegion;
 using cudf_velox::GpuGuard;
 
 using namespace facebook::velox::connector;
 using namespace facebook::velox::connector::hive;
-
-namespace {
-
-namespace pqthrift = facebook::velox::parquet::thrift;
-
-struct FilterEstimate {
-  double selectivity{1.0};
-  std::string note{"unknown"};
-};
-
-struct RowGroupBudgetEstimate {
-  int rowGroupIndex{0};
-  int64_t rows{0};
-  int64_t compressedBytes{0};
-  int64_t uncompressedBytes{0};
-  double pushdownSelectivity{1.0};
-  uint64_t postReadBytes{0};
-  uint64_t predictedPeakBytes{0};
-  std::string notes;
-};
-
-double clamp01(double value) {
-  return std::max(0.0, std::min(1.0, value));
-}
-
-std::string topLevelColumnName(const std::vector<std::string>& pathInSchema) {
-  return pathInSchema.empty() ? "" : pathInSchema.front();
-}
-
-uint64_t filterMaskBytesEstimate(int64_t rows) {
-  if (rows <= 0) {
-    return 0;
-  }
-  return static_cast<uint64_t>(rows) +
-      cudf::bitmask_allocation_size_bytes(rows);
-}
-
-RowTypePtr buildScanBudgetType(
-    const std::shared_ptr<const hive::HiveTableHandle>& tableHandle,
-    const RowTypePtr& fallbackType,
-    const std::vector<std::string>& readColumnNames) {
-  if (!tableHandle || !tableHandle->dataColumns()) {
-    return fallbackType;
-  }
-
-  std::vector<std::string> names;
-  std::vector<TypePtr> types;
-  names.reserve(readColumnNames.size());
-  types.reserve(readColumnNames.size());
-  for (const auto& name : readColumnNames) {
-    auto parsedType = tableHandle->dataColumns()->findChild(name);
-    if (!parsedType) {
-      continue;
-    }
-    names.push_back(name);
-    types.push_back(parsedType);
-  }
-  return names.empty() ? fallbackType : ROW(std::move(names), std::move(types));
-}
-
-pqthrift::FileMetaData parseParquetFooterMetadata(
-    cudf::io::datasource* dataSource) {
-  VELOX_CHECK_NOT_NULL(dataSource, "Null datasource for footer metadata");
-
-  using namespace cudf::io::parquet;
-  constexpr auto headerLen = sizeof(file_header_s);
-  constexpr auto enderLen = sizeof(file_ender_s);
-  constexpr uint32_t parquetMagic =
-      (('P' << 0) | ('A' << 8) | ('R' << 16) | ('1' << 24));
-
-  const size_t len = dataSource->size();
-  VELOX_CHECK_GT(len, headerLen + enderLen, "Incorrect data source");
-
-  const auto headerBuffer = dataSource->host_read(0, headerLen);
-  const auto enderBuffer = dataSource->host_read(len - enderLen, enderLen);
-  const auto header =
-      reinterpret_cast<const file_header_s*>(headerBuffer->data());
-  const auto ender =
-      reinterpret_cast<const file_ender_s*>(enderBuffer->data());
-  VELOX_CHECK(
-      header->magic == parquetMagic && ender->magic == parquetMagic,
-      "Corrupted header or footer");
-  VELOX_CHECK(
-      ender->footer_len != 0 &&
-          ender->footer_len <= (len - headerLen - enderLen),
-      "Incorrect footer length");
-
-  auto footerBuffer = dataSource->host_read(
-      len - ender->footer_len - enderLen, ender->footer_len);
-  pqthrift::FileMetaData metadata;
-  auto transport =
-      std::make_shared<apache::thrift::transport::TMemoryBuffer>(
-          const_cast<uint8_t*>(footerBuffer->data()),
-          static_cast<uint32_t>(ender->footer_len),
-          apache::thrift::transport::TMemoryBuffer::OBSERVE);
-  apache::thrift::protocol::TCompactProtocolT<
-      apache::thrift::transport::TMemoryBuffer>
-      protocol(transport);
-  metadata.read(&protocol);
-  return metadata;
-}
-
-std::pair<double, double> nullAndNonNullFractions(
-    const dwio::common::ColumnStatistics* stats,
-    uint64_t totalRows) {
-  if (!stats || totalRows == 0) {
-    return {0.0, 1.0};
-  }
-
-  if (auto valueCount = stats->getNumberOfValues(); valueCount.has_value()) {
-    const auto nonNullCount =
-        std::min<uint64_t>(valueCount.value(), totalRows);
-    const double nonNullFraction =
-        static_cast<double>(nonNullCount) / static_cast<double>(totalRows);
-    return {1.0 - nonNullFraction, nonNullFraction};
-  }
-  return {0.0, 1.0};
-}
-
-double finalizeNonNullSelectivity(
-    double nonNullSelectivity,
-    const common::Filter& filter,
-    double nullFraction,
-    double nonNullFraction) {
-  auto result = clamp01(nonNullSelectivity) * nonNullFraction;
-  if (filter.testNull()) {
-    result = clamp01(result + nullFraction);
-  }
-  return clamp01(result);
-}
-
-FilterEstimate estimateFilterSelectivity(
-    const common::Filter& filter,
-    const dwio::common::ColumnStatistics* stats,
-    uint64_t totalRows,
-    const TypePtr& type) {
-  if (!stats || totalRows == 0) {
-    return {1.0, "no-stats"};
-  }
-
-  if (!common::testFilter(
-          &filter,
-          const_cast<dwio::common::ColumnStatistics*>(stats),
-          totalRows,
-          type)) {
-    return {0.0, "stats-pruned"};
-  }
-
-  const auto [nullFraction, nonNullFraction] =
-      nullAndNonNullFractions(stats, totalRows);
-
-  switch (filter.kind()) {
-    case common::FilterKind::kIsNull:
-      return {nullFraction > 0 ? nullFraction : 0.0, "is-null"};
-    case common::FilterKind::kIsNotNull:
-      return {nonNullFraction, "is-not-null"};
-    case common::FilterKind::kBoolValue: {
-      auto* boolStats =
-          dynamic_cast<const dwio::common::BooleanColumnStatistics*>(stats);
-      auto* boolFilter = dynamic_cast<const common::BoolValue*>(&filter);
-      if (boolStats && boolFilter) {
-        if (auto trueCount = boolStats->getTrueCount();
-            trueCount.has_value()) {
-          const auto matched = boolFilter->testBool(true)
-              ? trueCount.value()
-              : boolStats->getFalseCount().value_or(0);
-          return {
-              clamp01(
-                  static_cast<double>(matched) /
-                  static_cast<double>(totalRows)),
-              "bool-counts"};
-        }
-      }
-      return {0.5, "bool-heuristic"};
-    }
-    case common::FilterKind::kBigintRange: {
-      auto* intStats =
-          dynamic_cast<const dwio::common::IntegerColumnStatistics*>(stats);
-      auto* range = dynamic_cast<const common::BigintRange*>(&filter);
-      if (intStats && range && intStats->getMinimum() && intStats->getMaximum()) {
-        const auto statsMin = intStats->getMinimum().value();
-        const auto statsMax = intStats->getMaximum().value();
-        if (statsMin == statsMax) {
-          const double nonNullSel = range->testInt64(statsMin) ? 1.0 : 0.0;
-          return {
-              finalizeNonNullSelectivity(
-                  nonNullSel, filter, nullFraction, nonNullFraction),
-              "int-const"};
-        }
-        const auto overlapLow = std::max<int64_t>(statsMin, range->lower());
-        const auto overlapHigh = std::min<int64_t>(statsMax, range->upper());
-        if (overlapHigh < overlapLow) {
-          return {0.0, "int-disjoint"};
-        }
-        const long double statsSpan =
-            static_cast<long double>(statsMax) -
-            static_cast<long double>(statsMin) + 1.0L;
-        const long double overlapSpan =
-            static_cast<long double>(overlapHigh) -
-            static_cast<long double>(overlapLow) + 1.0L;
-        const double nonNullSel =
-            statsSpan > 0 ? static_cast<double>(overlapSpan / statsSpan) : 1.0;
-        return {
-            finalizeNonNullSelectivity(
-                nonNullSel, filter, nullFraction, nonNullFraction),
-            "int-range"};
-      }
-      return {1.0, "int-no-minmax"};
-    }
-    case common::FilterKind::kBigintValuesUsingBitmask: {
-      auto* intStats =
-          dynamic_cast<const dwio::common::IntegerColumnStatistics*>(stats);
-      auto* valuesFilter =
-          dynamic_cast<const common::BigintValuesUsingBitmask*>(&filter);
-      if (intStats && valuesFilter && intStats->getMinimum() &&
-          intStats->getMaximum()) {
-        const auto statsMin = intStats->getMinimum().value();
-        const auto statsMax = intStats->getMaximum().value();
-        if (statsMin == statsMax) {
-          const double nonNullSel = valuesFilter->testInt64(statsMin) ? 1.0 : 0.0;
-          return {
-              finalizeNonNullSelectivity(
-                  nonNullSel, filter, nullFraction, nonNullFraction),
-              "int-set-const"};
-        }
-        size_t matches = 0;
-        for (const auto& value : valuesFilter->values()) {
-          if (value >= statsMin && value <= statsMax) {
-            ++matches;
-          }
-        }
-        if (matches == 0) {
-          return {0.0, "int-set-disjoint"};
-        }
-        const long double statsSpan =
-            static_cast<long double>(statsMax) -
-            static_cast<long double>(statsMin) + 1.0L;
-        const double nonNullSel = std::max(
-            static_cast<double>(1.0L / std::max<long double>(1.0L, statsSpan)),
-            static_cast<double>(matches / std::max<long double>(1.0L, statsSpan)));
-        return {
-            finalizeNonNullSelectivity(
-                nonNullSel, filter, nullFraction, nonNullFraction),
-            "int-set"};
-      }
-      return {1.0, "int-set-no-minmax"};
-    }
-    case common::FilterKind::kDoubleRange:
-    case common::FilterKind::kFloatRange: {
-      auto* doubleStats =
-          dynamic_cast<const dwio::common::DoubleColumnStatistics*>(stats);
-      auto* range = dynamic_cast<const common::AbstractRange*>(&filter);
-      if (doubleStats && range && doubleStats->getMinimum() &&
-          doubleStats->getMaximum()) {
-        const auto statsMin = doubleStats->getMinimum().value();
-        const auto statsMax = doubleStats->getMaximum().value();
-        if (statsMin == statsMax) {
-          const double nonNullSel = filter.testDouble(statsMin) ? 1.0 : 0.0;
-          return {
-              finalizeNonNullSelectivity(
-                  nonNullSel, filter, nullFraction, nonNullFraction),
-              "fp-const"};
-        }
-        double lower = std::numeric_limits<double>::lowest();
-        double upper = std::numeric_limits<double>::max();
-        if (!range->lowerUnbounded()) {
-          if (auto* doubleRange =
-                  dynamic_cast<const common::FloatingPointRange<double>*>(
-                      &filter)) {
-            lower = doubleRange->lower();
-          } else if (
-              auto* floatRange =
-                  dynamic_cast<const common::FloatingPointRange<float>*>(
-                      &filter)) {
-            lower = floatRange->lower();
-          }
-        }
-        if (!range->upperUnbounded()) {
-          if (auto* doubleRange =
-                  dynamic_cast<const common::FloatingPointRange<double>*>(
-                      &filter)) {
-            upper = doubleRange->upper();
-          } else if (
-              auto* floatRange =
-                  dynamic_cast<const common::FloatingPointRange<float>*>(
-                      &filter)) {
-            upper = floatRange->upper();
-          }
-        }
-        const auto overlapLow = std::max(statsMin, lower);
-        const auto overlapHigh = std::min(statsMax, upper);
-        if (overlapHigh < overlapLow) {
-          return {0.0, "fp-disjoint"};
-        }
-        const auto statsSpan = std::max(statsMax - statsMin, 1e-12);
-        const auto overlapSpan = std::max(overlapHigh - overlapLow, 0.0);
-        const double nonNullSel = clamp01(overlapSpan / statsSpan);
-        return {
-            finalizeNonNullSelectivity(
-                nonNullSel, filter, nullFraction, nonNullFraction),
-            "fp-range"};
-      }
-      return {1.0, "fp-no-minmax"};
-    }
-    case common::FilterKind::kBytesRange: {
-      auto* stringStats =
-          dynamic_cast<const dwio::common::StringColumnStatistics*>(stats);
-      auto* range = dynamic_cast<const common::BytesRange*>(&filter);
-      if (stringStats && range && stringStats->getMinimum() &&
-          stringStats->getMaximum()) {
-        const auto& statsMin = stringStats->getMinimum().value();
-        const auto& statsMax = stringStats->getMaximum().value();
-        if (statsMin == statsMax) {
-          const double nonNullSel =
-              filter.testBytes(statsMin.data(), statsMin.size()) ? 1.0 : 0.0;
-          return {
-              finalizeNonNullSelectivity(
-                  nonNullSel, filter, nullFraction, nonNullFraction),
-              "string-const"};
-        }
-        if (!range->lowerUnbounded() && !range->upperUnbounded() &&
-            !range->lowerExclusive() && !range->upperExclusive() &&
-            range->lower() == range->upper()) {
-          const double nonNullSel =
-              std::max(1.0 / static_cast<double>(std::max<uint64_t>(1, totalRows)),
-                       0.01);
-          return {
-              finalizeNonNullSelectivity(
-                  nonNullSel, filter, nullFraction, nonNullFraction),
-              "string-single"};
-        }
-        const bool coversWholeSpan =
-            (range->lowerUnbounded() || range->lower() <= statsMin) &&
-            (range->upperUnbounded() || range->upper() >= statsMax);
-        const double nonNullSel = coversWholeSpan ? 1.0 : 0.25;
-        return {
-            finalizeNonNullSelectivity(
-                nonNullSel, filter, nullFraction, nonNullFraction),
-            coversWholeSpan ? "string-cover" : "string-range-heuristic"};
-      }
-      return {1.0, "string-no-minmax"};
-    }
-    case common::FilterKind::kBytesValues: {
-      auto* stringStats =
-          dynamic_cast<const dwio::common::StringColumnStatistics*>(stats);
-      auto* valuesFilter = dynamic_cast<const common::BytesValues*>(&filter);
-      if (stringStats && valuesFilter && stringStats->getMinimum() &&
-          stringStats->getMaximum()) {
-        const auto& statsMin = stringStats->getMinimum().value();
-        const auto& statsMax = stringStats->getMaximum().value();
-        size_t matches = 0;
-        for (const auto& value : valuesFilter->values()) {
-          if (value >= statsMin && value <= statsMax) {
-            ++matches;
-          }
-        }
-        if (matches == 0) {
-          return {0.0, "string-set-disjoint"};
-        }
-        if (statsMin == statsMax) {
-          const double nonNullSel =
-              valuesFilter->values().contains(statsMin) ? 1.0 : 0.0;
-          return {
-              finalizeNonNullSelectivity(
-                  nonNullSel, filter, nullFraction, nonNullFraction),
-              "string-set-const"};
-        }
-        const double nonNullSel = clamp01(std::max(
-            1.0 / static_cast<double>(std::max<uint64_t>(1, totalRows)),
-            std::min(1.0, static_cast<double>(matches) * 0.05)));
-        return {
-            finalizeNonNullSelectivity(
-                nonNullSel, filter, nullFraction, nonNullFraction),
-            "string-set"};
-      }
-      return {1.0, "string-set-no-minmax"};
-    }
-    default:
-      return {1.0, "unsupported-kind"};
-  }
-}
-
-std::vector<RowGroupBudgetEstimate> estimateRowGroupBudgets(
-    const pqthrift::FileMetaData& footer,
-    const RowTypePtr& scanBudgetType,
-    const std::vector<std::string>& readColumnNames,
-    const common::SubfieldFilters& subfieldFilters,
-    bool hasRemainingFilter) {
-  std::unordered_set<std::string> selectedColumns(
-      readColumnNames.begin(), readColumnNames.end());
-  std::unordered_map<std::string, TypePtr> scanTypes;
-  if (scanBudgetType) {
-    for (int i = 0; i < scanBudgetType->size(); ++i) {
-      scanTypes.emplace(scanBudgetType->nameOf(i), scanBudgetType->childAt(i));
-    }
-  }
-
-  std::vector<RowGroupBudgetEstimate> estimates;
-  estimates.reserve(footer.row_groups.size());
-  for (size_t rgIndex = 0; rgIndex < footer.row_groups.size(); ++rgIndex) {
-    const auto& rowGroup = footer.row_groups[rgIndex];
-    if (rowGroup.num_rows <= 0) {
-      continue;
-    }
-
-    int64_t compressedBytes = 0;
-    int64_t uncompressedBytes = 0;
-    double pushdownSelectivity = 1.0;
-    std::vector<std::string> notes;
-
-    for (const auto& column : rowGroup.columns) {
-      const auto columnName = topLevelColumnName(column.meta_data.path_in_schema);
-      if (!selectedColumns.empty() && !selectedColumns.count(columnName)) {
-        continue;
-      }
-      compressedBytes += column.meta_data.total_compressed_size;
-      uncompressedBytes += column.meta_data.total_uncompressed_size;
-    }
-
-    for (const auto& [subfield, filterPtr] : subfieldFilters) {
-      if (!filterPtr) {
-        continue;
-      }
-      const auto columnName = subfield.toString();
-      auto typeIt = scanTypes.find(columnName);
-      if (typeIt == scanTypes.end()) {
-        notes.push_back(columnName + "=no-type");
-        continue;
-      }
-
-      const pqthrift::ColumnChunk* matchingChunk = nullptr;
-      for (const auto& column : rowGroup.columns) {
-        if (topLevelColumnName(column.meta_data.path_in_schema) == columnName) {
-          matchingChunk = &column;
-          break;
-        }
-      }
-      if (!matchingChunk) {
-        notes.push_back(columnName + "=no-chunk");
-        continue;
-      }
-
-      facebook::velox::parquet::ColumnChunkMetaDataPtr chunkMeta(matchingChunk);
-      if (!chunkMeta.hasStatistics()) {
-        notes.push_back(columnName + "=no-stats");
-        continue;
-      }
-
-      auto stats =
-          chunkMeta.getColumnStatistics(typeIt->second, rowGroup.num_rows);
-      auto estimate = estimateFilterSelectivity(
-          *filterPtr, stats.get(), rowGroup.num_rows, typeIt->second);
-      pushdownSelectivity =
-          clamp01(pushdownSelectivity * estimate.selectivity);
-      notes.push_back(fmt::format(
-          "{}={:.2f}({})", columnName, estimate.selectivity, estimate.note));
-    }
-
-    const auto decodedInputBytes =
-        static_cast<uint64_t>(std::max<int64_t>(0, uncompressedBytes));
-    const auto postReadBytes = static_cast<uint64_t>(std::llround(
-        static_cast<long double>(decodedInputBytes) * pushdownSelectivity));
-    const auto pushdownMaskBytes =
-        subfieldFilters.empty() ? 0 : filterMaskBytesEstimate(rowGroup.num_rows);
-    const auto remainingMaskBytes =
-        hasRemainingFilter ? filterMaskBytesEstimate(rowGroup.num_rows) : 0;
-    const auto scanReaderPeakBytes = subfieldFilters.empty()
-        ? decodedInputBytes
-        : decodedInputBytes + postReadBytes + pushdownMaskBytes;
-    const auto remainingFilterPeakBytes = hasRemainingFilter
-        ? postReadBytes + postReadBytes + remainingMaskBytes
-        : postReadBytes;
-
-    RowGroupBudgetEstimate estimate;
-    estimate.rowGroupIndex = static_cast<int>(rgIndex);
-    estimate.rows = rowGroup.num_rows;
-    estimate.compressedBytes = compressedBytes;
-    estimate.uncompressedBytes = uncompressedBytes;
-    estimate.pushdownSelectivity = pushdownSelectivity;
-    estimate.postReadBytes = postReadBytes;
-    estimate.predictedPeakBytes =
-        std::max(scanReaderPeakBytes, remainingFilterPeakBytes);
-    if (notes.empty()) {
-      estimate.notes = "no-pushdown-filters";
-    } else {
-      std::ostringstream out;
-      for (size_t i = 0; i < notes.size(); ++i) {
-        if (i > 0) {
-          out << ",";
-        }
-        out << notes[i];
-      }
-      estimate.notes = out.str();
-    }
-    estimates.push_back(std::move(estimate));
-  }
-
-  std::sort(
-      estimates.begin(),
-      estimates.end(),
-      [](const RowGroupBudgetEstimate& lhs, const RowGroupBudgetEstimate& rhs) {
-        return lhs.predictedPeakBytes > rhs.predictedPeakBytes;
-      });
-  return estimates;
-}
-
-void maybeLogFooterBudgetEstimate(
-    cudf::io::datasource* dataSource,
-    const std::string& filePath,
-    const RowTypePtr& scanBudgetType,
-    const std::vector<std::string>& readColumnNames,
-    const common::SubfieldFilters& subfieldFilters,
-    bool hasRemainingFilter,
-    uint64_t splitStart,
-    uint64_t splitSize,
-    int64_t targetBytes) {
-  if (!dataSource) {
-    return;
-  }
-
-  try {
-    auto footer = parseParquetFooterMetadata(dataSource);
-    auto budgets = estimateRowGroupBudgets(
-        footer,
-        scanBudgetType,
-        readColumnNames,
-        subfieldFilters,
-        hasRemainingFilter);
-    if (budgets.empty()) {
-      return;
-    }
-
-    int64_t totalCompressedBytes = 0;
-    int64_t totalUncompressedBytes = 0;
-    for (const auto& budget : budgets) {
-      totalCompressedBytes += budget.compressedBytes;
-      totalUncompressedBytes += budget.uncompressedBytes;
-    }
-
-    std::ostringstream topBudgets;
-    const auto topN = std::min<size_t>(3, budgets.size());
-    for (size_t i = 0; i < topN; ++i) {
-      if (i > 0) {
-        topBudgets << "; ";
-      }
-      const auto& budget = budgets[i];
-      topBudgets << "rg" << budget.rowGroupIndex
-                 << "{rows=" << budget.rows
-                 << ", comp=" << succinctBytes(budget.compressedBytes)
-                 << ", uncomp=" << succinctBytes(budget.uncompressedBytes)
-                 << ", postRead=" << succinctBytes(budget.postReadBytes)
-                 << ", sel=" << fmt::format("{:.2f}", budget.pushdownSelectivity)
-                 << ", peak=" << succinctBytes(budget.predictedPeakBytes)
-                 << ", notes=" << budget.notes << "}";
-    }
-
-    LOG(INFO) << "CudfHiveDataSource::footer budget: file=" << filePath
-              << ", splitStart=" << splitStart
-              << ", splitSize="
-              << (splitSize == std::numeric_limits<uint64_t>::max()
-                      ? std::string("full")
-                      : succinctBytes(splitSize))
-              << ", targetBytes=" << succinctBytes(targetBytes)
-              << ", rowGroups=" << budgets.size()
-              << ", totalCompressed=" << succinctBytes(totalCompressedBytes)
-              << ", totalUncompressed=" << succinctBytes(totalUncompressedBytes)
-              << ", remainingFilter=" << hasRemainingFilter
-              << ", topBudgets=[" << topBudgets.str() << "]";
-  } catch (const std::exception& e) {
-    LOG(WARNING) << "CudfHiveDataSource::footer budget estimation failed for "
-                 << filePath << ": " << e.what();
-  }
-}
-
-} // namespace
 
 CudfHiveDataSource::CudfHiveDataSource(
     const RowTypePtr& outputType,
@@ -797,15 +207,6 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
 
   const bool hasCoalescedFiles = !pendingFiles_.empty();
   const auto targetBytes = CudfConfig::getInstance().gpuTargetBatchBytes;
-  const bool debugEnabled = CudfConfig::getInstance().debugEnabled;
-  uint64_t lastTableBytes = 0;
-  uint64_t lastFilteredBytes = 0;
-
-  std::cerr << "GPU_MEM_SNAPSHOT [scan-entry] "
-               << gpuMemorySnapshotString()
-               << " split=" << split_->filePath
-               << " targetBytes=" << succinctBytes(targetBytes)
-               << std::endl;
 
   // GPU guard for single-file and experimental paths; emplaced before first
   // GPU operation and held through common post-processing.
@@ -833,64 +234,36 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
                    << std::endl;
       auto coalesceLoopStartUs = getCurrentTimeMicro();
       while (splitReader_->has_next()) {
-        try {
-          auto tableWithMetadata = splitReader_->read_chunk();
-          if (tableWithMetadata.tbl && tableWithMetadata.tbl->num_rows() > 0) {
-            auto& tbl = tableWithMetadata.tbl;
-            lastTableBytes = estimateTableBytes(tbl);
-            if (remainingFilterExprSet_) {
-              auto cols = tbl->release();
-              const auto originalNumColumns = cols.size();
-              auto filterResult = cudfExpressionEvaluator_->eval(
-                  cols, stream_, cudf::get_current_device_resource_ref());
-              std::vector<std::unique_ptr<cudf::column>> origCols;
-              origCols.reserve(originalNumColumns);
-              std::move(
-                  cols.begin(),
-                  cols.begin() + originalNumColumns,
-                  std::back_inserter(origCols));
-              auto origTable =
-                  std::make_unique<cudf::table>(std::move(origCols));
-              tbl = cudf::apply_boolean_mask(
-                  *origTable,
-                  asView(filterResult),
-                  stream_,
-                  cudf::get_current_device_resource_ref());
-            }
-            if (tbl->num_rows() > 0) {
-              auto tableBytes = estimateTableBytes(tbl);
-              lastFilteredBytes = tableBytes;
-              accumulatedTables_.push_back(std::move(tbl));
-              accumulatedBytes_ += tableBytes;
-              if (accumulatedBytes_ >= effectiveTarget) {
-                if (debugEnabled) {
-                  LOG(INFO) << "CudfHiveDataSource::next coalesced threshold: "
-                            << "accumulatedBytes="
-                            << succinctBytes(accumulatedBytes_)
-                            << ", preFilterBytes="
-                            << succinctBytes(lastTableBytes)
-                            << ", filteredBytes="
-                            << succinctBytes(lastFilteredBytes)
-                            << ", targetBytes="
-                            << succinctBytes(effectiveTarget)
-                            << ", "
-                            << gpuMemoryBreakdownString(accumulatedBytes_);
-                }
-                break;
-              }
+        auto tableWithMetadata = splitReader_->read_chunk();
+        if (tableWithMetadata.tbl && tableWithMetadata.tbl->num_rows() > 0) {
+          auto& tbl = tableWithMetadata.tbl;
+          if (remainingFilterExprSet_) {
+            auto cols = tbl->release();
+            const auto originalNumColumns = cols.size();
+            auto filterResult = cudfExpressionEvaluator_->eval(
+                cols, stream_, cudf::get_current_device_resource_ref());
+            std::vector<std::unique_ptr<cudf::column>> origCols;
+            origCols.reserve(originalNumColumns);
+            std::move(
+                cols.begin(),
+                cols.begin() + originalNumColumns,
+                std::back_inserter(origCols));
+            auto origTable =
+                std::make_unique<cudf::table>(std::move(origCols));
+            tbl = cudf::apply_boolean_mask(
+                *origTable,
+                asView(filterResult),
+                stream_,
+                cudf::get_current_device_resource_ref());
+          }
+          if (tbl->num_rows() > 0) {
+            auto tableBytes = estimateTableBytes(tbl);
+            accumulatedTables_.push_back(std::move(tbl));
+            accumulatedBytes_ += tableBytes;
+            if (accumulatedBytes_ >= effectiveTarget) {
+              break;
             }
           }
-        } catch (const std::exception& e) {
-          LOG(ERROR) << "CudfHiveDataSource::next coalesced read failed: "
-                     << e.what()
-                     << ", split=" << split_->filePath
-                     << ", accumulatedBytes=" << succinctBytes(accumulatedBytes_)
-                     << ", preFilterBytes=" << succinctBytes(lastTableBytes)
-                     << ", filteredBytes=" << succinctBytes(lastFilteredBytes)
-                     << ", targetBytes=" << succinctBytes(effectiveTarget)
-                     << ", "
-                     << gpuMemoryBreakdownString(accumulatedBytes_);
-          throw;
         }
       }
       totalCoalesceBufferTimeNs_.fetch_add(
@@ -899,7 +272,6 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
       auto result = flushAccumulated();
       gpuTimer_.stop(stream_);
       if (result == nullptr) {
-        endGpuRegion();
         return nullptr;
       }
       TotalScanTimeCallbackData* callbackData =
@@ -935,14 +307,6 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     }();
     cudfTable = std::move(tableWithMetadata.tbl);
     metadata = std::move(tableWithMetadata.metadata);
-    lastTableBytes = estimateTableBytes(cudfTable);
-    if (debugEnabled) {
-      LOG(INFO) << "CudfHiveDataSource::next post-read: rows="
-                << (cudfTable ? cudfTable->num_rows() : 0)
-                << ", tableBytes=" << succinctBytes(lastTableBytes)
-                << ", targetBytes=" << succinctBytes(targetBytes)
-                << ", " << gpuMemoryBreakdownString(lastTableBytes);
-    }
   } else {
     // Chunked experimental reader: process row groups in batches.
     // Loops across coalesced files when the current file is exhausted.
@@ -957,33 +321,13 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
       }
 
       if (exptNextRGIndex_ < exptFilteredRowGroups_.size()) {
-        cudfTable = [&]() {
-          try {
-            return readNextExperimentalBatch(metadata);
-          } catch (const std::exception& e) {
-            LOG(ERROR) << "CudfHiveDataSource::next experimental batch failed: "
-                       << e.what()
-                       << ", split=" << split_->filePath
-                       << ", targetBytes=" << succinctBytes(targetBytes)
-                       << ", " << gpuMemoryBreakdownString(0);
-            throw;
-          }
-        }();
+        cudfTable = readNextExperimentalBatch(metadata);
         if (cudfTable && cudfTable->num_rows() > 0) {
-          lastTableBytes = estimateTableBytes(cudfTable);
-          if (debugEnabled) {
-            LOG(INFO) << "CudfHiveDataSource::next experimental post-read: rows="
-                      << cudfTable->num_rows()
-                      << ", tableBytes=" << succinctBytes(lastTableBytes)
-                      << ", targetBytes=" << succinctBytes(targetBytes)
-                      << ", " << gpuMemoryBreakdownString(lastTableBytes);
-          }
           break;
         }
       }
 
       if (!hasCoalescedFiles || !advanceToNextCoalescedFile()) {
-        endGpuRegion();
         return nullptr;
       }
     }
@@ -1002,44 +346,27 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
   // Apply remaining filter if present
   if (remainingFilterExprSet_) {
     MicrosecondTimer filterTimer(&filterTimeUs);
-    try {
-      auto cudfTableColumns = cudfTable->release();
-      const auto originalNumColumns = cudfTableColumns.size();
-      // Filter may need addtional computed columns which are added to
-      // cudfTableColumns
-      auto filterResult = cudfExpressionEvaluator_->eval(
-          cudfTableColumns, stream_, cudf::get_current_device_resource_ref());
-      // discard computed columns
-      std::vector<std::unique_ptr<cudf::column>> originalColumns;
-      originalColumns.reserve(originalNumColumns);
-      std::move(
-          cudfTableColumns.begin(),
-          cudfTableColumns.begin() + originalNumColumns,
-          std::back_inserter(originalColumns));
-      auto originalTable =
-          std::make_unique<cudf::table>(std::move(originalColumns));
-      // Keep only rows where the filter is true
-      cudfTable = cudf::apply_boolean_mask(
-          *originalTable,
-          asView(filterResult),
-          stream_,
-          cudf::get_current_device_resource_ref());
-      lastFilteredBytes = estimateTableBytes(cudfTable);
-      if (debugEnabled) {
-        LOG(INFO) << "CudfHiveDataSource::next post-filter: rows="
-                  << (cudfTable ? cudfTable->num_rows() : 0)
-                  << ", filteredBytes=" << succinctBytes(lastFilteredBytes)
-                  << ", preFilterBytes=" << succinctBytes(lastTableBytes)
-                  << ", " << gpuMemoryBreakdownString(lastFilteredBytes);
-      }
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "CudfHiveDataSource::next filter failed: " << e.what()
-                 << ", split=" << split_->filePath
-                 << ", preFilterBytes=" << succinctBytes(lastTableBytes)
-                 << ", targetBytes=" << succinctBytes(targetBytes)
-                 << ", " << gpuMemoryBreakdownString(lastTableBytes);
-      throw;
-    }
+    auto cudfTableColumns = cudfTable->release();
+    const auto originalNumColumns = cudfTableColumns.size();
+    // Filter may need addtional computed columns which are added to
+    // cudfTableColumns
+    auto filterResult = cudfExpressionEvaluator_->eval(
+        cudfTableColumns, stream_, cudf::get_current_device_resource_ref());
+    // discard computed columns
+    std::vector<std::unique_ptr<cudf::column>> originalColumns;
+    originalColumns.reserve(originalNumColumns);
+    std::move(
+        cudfTableColumns.begin(),
+        cudfTableColumns.begin() + originalNumColumns,
+        std::back_inserter(originalColumns));
+    auto originalTable =
+        std::make_unique<cudf::table>(std::move(originalColumns));
+    // Keep only rows where the filter is true
+    cudfTable = cudf::apply_boolean_mask(
+        *originalTable,
+        asView(filterResult),
+        stream_,
+        cudf::get_current_device_resource_ref());
   }
   totalRemainingFilterTime_.fetch_add(
       filterTimeUs * 1000, std::memory_order_relaxed);
@@ -1359,18 +686,6 @@ void CudfHiveDataSource::setupCudfDataSourceAndOptions() {
 CudfParquetReaderPtr CudfHiveDataSource::createSplitReader() {
   setupCudfDataSourceAndOptions();
   stream_ = cudfGlobalStreamPool().get_stream();
-  if (CudfConfig::getInstance().debugEnabled) {
-    maybeLogFooterBudgetEstimate(
-        dataSource_.get(),
-        split_->filePath,
-        buildScanBudgetType(tableHandle_, outputType_, readColumnNames_),
-        readColumnNames_,
-        subfieldFilters_,
-        remainingFilterExprSet_ != nullptr,
-        split_->start,
-        split_->size(),
-        CudfConfig::getInstance().gpuTargetBatchBytes);
-  }
 
   // Create a parquet reader
   return std::make_unique<cudf::io::chunked_parquet_reader>(
@@ -1658,29 +973,6 @@ bool CudfHiveDataSource::advanceToNextCoalescedFile() {
                 pageIndexBytes->data(), pageIndexBytes->size()});
       }
     } else {
-      if (CudfConfig::getInstance().debugEnabled) {
-        auto footerSource = std::move(makeDataSourcesFromSourceInfo(
-                                          cudf::io::source_info(
-                                              cudf::host_span<const std::byte>(
-                                                  reinterpret_cast<
-                                                      const std::byte*>(
-                                                      currentFilePinnedBuffer_
-                                                          ->data()),
-                                                  currentFilePinnedBuffer_
-                                                      ->size())))
-                                          .front());
-        maybeLogFooterBudgetEstimate(
-            footerSource.get(),
-            fileRange.filePath,
-            buildScanBudgetType(tableHandle_, outputType_, readColumnNames_),
-            readColumnNames_,
-            subfieldFilters_,
-            remainingFilterExprSet_ != nullptr,
-            isSelectiveBuffer ? 0 : asyncRead.start,
-            isSelectiveBuffer ? currentFilePinnedBuffer_->size()
-                              : asyncRead.length,
-            CudfConfig::getInstance().gpuTargetBatchBytes);
-      }
       splitReader_ = std::make_unique<cudf::io::chunked_parquet_reader>(
           cudfHiveConfig_->maxChunkReadLimit(),
           cudfHiveConfig_->maxPassReadLimit(),
@@ -1708,18 +1000,6 @@ bool CudfHiveDataSource::advanceToNextCoalescedFile() {
       }
     } else {
       setupCudfDataSourceAndOptions();
-      if (CudfConfig::getInstance().debugEnabled) {
-        maybeLogFooterBudgetEstimate(
-            dataSource_.get(),
-            fileRange.filePath,
-            buildScanBudgetType(tableHandle_, outputType_, readColumnNames_),
-            readColumnNames_,
-            subfieldFilters_,
-            remainingFilterExprSet_ != nullptr,
-            split_->start,
-            split_->size(),
-            CudfConfig::getInstance().gpuTargetBatchBytes);
-      }
       splitReader_ = std::make_unique<cudf::io::chunked_parquet_reader>(
           cudfHiveConfig_->maxChunkReadLimit(),
           cudfHiveConfig_->maxPassReadLimit(),
@@ -1854,11 +1134,6 @@ std::unique_ptr<cudf::table> CudfHiveDataSource::readNextExperimentalBatch(
       columnChunkByteRanges.size());
   std::vector<std::future<size_t>> ioFutures{};
   ioFutures.reserve(columnChunkByteRanges.size());
-  // Keep pinned host buffers alive until async H2D copies complete.
-  // PinnedHostBuffer uses a pool allocator, so freed memory is immediately
-  // reusable by other threads. Without holding them here, the DMA engine
-  // may read from recycled addresses, causing SIGSEGV under concurrency.
-  std::vector<std::unique_ptr<cudf::io::datasource::buffer>> hostBuffers;
   std::for_each(
       thrust::counting_iterator<size_t>(0),
       thrust::counting_iterator(columnChunkByteRanges.size()),
@@ -1895,7 +1170,6 @@ std::unique_ptr<cudf::table> CudfHiveDataSource::readNextExperimentalBatch(
               byteRange.size(),
               cudaMemcpyHostToDevice,
               stream_.value()));
-          hostBuffers.push_back(std::move(hostBuffer));
         }
       });
 
@@ -1906,12 +1180,6 @@ std::unique_ptr<cudf::table> CudfHiveDataSource::readNextExperimentalBatch(
   std::for_each(ioFutures.begin(), ioFutures.end(), [](auto& future) {
     future.get();
   });
-  // Wait for all async H2D copies to complete before releasing pinned host
-  // buffers. The DMA engine may still be reading from them.
-  if (!hostBuffers.empty()) {
-    stream_.synchronize();
-    hostBuffers.clear();
-  }
 
   std::vector<cudf::device_span<uint8_t const>> columnChunkData;
   columnChunkData.reserve(columnChunkBuffers.size());

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -37,11 +37,15 @@
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/common/ScanSpec.h"
+#include "velox/dwio/parquet/reader/Metadata.h"
+#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
 #include "velox/expression/FieldReference.h"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/null_mask.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/io/text/byte_range_info.hpp>
 #include <cudf/io/types.hpp>
@@ -52,10 +56,18 @@
 
 #include <cuda_runtime.h>
 
+#include <thrift/protocol/TCompactProtocol.h>
+#include <thrift/transport/TBufferTransports.h>
+
+#include <algorithm>
+#include <cmath>
 #include <future>
 #include <limits>
 #include <memory>
+#include <sstream>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace facebook::velox::cudf_velox::connector::hive {
 
@@ -64,6 +76,581 @@ using cudf_velox::GpuGuard;
 
 using namespace facebook::velox::connector;
 using namespace facebook::velox::connector::hive;
+
+namespace {
+
+namespace pqthrift = facebook::velox::parquet::thrift;
+
+struct FilterEstimate {
+  double selectivity{1.0};
+  std::string note{"unknown"};
+};
+
+struct RowGroupBudgetEstimate {
+  int rowGroupIndex{0};
+  int64_t rows{0};
+  int64_t compressedBytes{0};
+  int64_t uncompressedBytes{0};
+  double pushdownSelectivity{1.0};
+  uint64_t postReadBytes{0};
+  uint64_t predictedPeakBytes{0};
+  std::string notes;
+};
+
+double clamp01(double value) {
+  return std::max(0.0, std::min(1.0, value));
+}
+
+std::string topLevelColumnName(const std::vector<std::string>& pathInSchema) {
+  return pathInSchema.empty() ? "" : pathInSchema.front();
+}
+
+uint64_t filterMaskBytesEstimate(int64_t rows) {
+  if (rows <= 0) {
+    return 0;
+  }
+  return static_cast<uint64_t>(rows) +
+      cudf::bitmask_allocation_size_bytes(rows);
+}
+
+RowTypePtr buildScanBudgetType(
+    const std::shared_ptr<const hive::HiveTableHandle>& tableHandle,
+    const RowTypePtr& fallbackType,
+    const std::vector<std::string>& readColumnNames) {
+  if (!tableHandle || !tableHandle->dataColumns()) {
+    return fallbackType;
+  }
+
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  names.reserve(readColumnNames.size());
+  types.reserve(readColumnNames.size());
+  for (const auto& name : readColumnNames) {
+    auto parsedType = tableHandle->dataColumns()->findChild(name);
+    if (!parsedType) {
+      continue;
+    }
+    names.push_back(name);
+    types.push_back(parsedType);
+  }
+  return names.empty() ? fallbackType : ROW(std::move(names), std::move(types));
+}
+
+pqthrift::FileMetaData parseParquetFooterMetadata(
+    cudf::io::datasource* dataSource) {
+  VELOX_CHECK_NOT_NULL(dataSource, "Null datasource for footer metadata");
+
+  using namespace cudf::io::parquet;
+  constexpr auto headerLen = sizeof(file_header_s);
+  constexpr auto enderLen = sizeof(file_ender_s);
+  constexpr uint32_t parquetMagic =
+      (('P' << 0) | ('A' << 8) | ('R' << 16) | ('1' << 24));
+
+  const size_t len = dataSource->size();
+  VELOX_CHECK_GT(len, headerLen + enderLen, "Incorrect data source");
+
+  const auto headerBuffer = dataSource->host_read(0, headerLen);
+  const auto enderBuffer = dataSource->host_read(len - enderLen, enderLen);
+  const auto header =
+      reinterpret_cast<const file_header_s*>(headerBuffer->data());
+  const auto ender =
+      reinterpret_cast<const file_ender_s*>(enderBuffer->data());
+  VELOX_CHECK(
+      header->magic == parquetMagic && ender->magic == parquetMagic,
+      "Corrupted header or footer");
+  VELOX_CHECK(
+      ender->footer_len != 0 &&
+          ender->footer_len <= (len - headerLen - enderLen),
+      "Incorrect footer length");
+
+  auto footerBuffer = dataSource->host_read(
+      len - ender->footer_len - enderLen, ender->footer_len);
+  pqthrift::FileMetaData metadata;
+  auto transport =
+      std::make_shared<apache::thrift::transport::TMemoryBuffer>(
+          const_cast<uint8_t*>(footerBuffer->data()),
+          static_cast<uint32_t>(ender->footer_len),
+          apache::thrift::transport::TMemoryBuffer::OBSERVE);
+  apache::thrift::protocol::TCompactProtocolT<
+      apache::thrift::transport::TMemoryBuffer>
+      protocol(transport);
+  metadata.read(&protocol);
+  return metadata;
+}
+
+std::pair<double, double> nullAndNonNullFractions(
+    const dwio::common::ColumnStatistics* stats,
+    uint64_t totalRows) {
+  if (!stats || totalRows == 0) {
+    return {0.0, 1.0};
+  }
+
+  if (auto valueCount = stats->getNumberOfValues(); valueCount.has_value()) {
+    const auto nonNullCount =
+        std::min<uint64_t>(valueCount.value(), totalRows);
+    const double nonNullFraction =
+        static_cast<double>(nonNullCount) / static_cast<double>(totalRows);
+    return {1.0 - nonNullFraction, nonNullFraction};
+  }
+  return {0.0, 1.0};
+}
+
+double finalizeNonNullSelectivity(
+    double nonNullSelectivity,
+    const common::Filter& filter,
+    double nullFraction,
+    double nonNullFraction) {
+  auto result = clamp01(nonNullSelectivity) * nonNullFraction;
+  if (filter.testNull()) {
+    result = clamp01(result + nullFraction);
+  }
+  return clamp01(result);
+}
+
+FilterEstimate estimateFilterSelectivity(
+    const common::Filter& filter,
+    const dwio::common::ColumnStatistics* stats,
+    uint64_t totalRows,
+    const TypePtr& type) {
+  if (!stats || totalRows == 0) {
+    return {1.0, "no-stats"};
+  }
+
+  if (!dwio::common::testFilter(
+          &filter,
+          const_cast<dwio::common::ColumnStatistics*>(stats),
+          totalRows,
+          type)) {
+    return {0.0, "stats-pruned"};
+  }
+
+  const auto [nullFraction, nonNullFraction] =
+      nullAndNonNullFractions(stats, totalRows);
+
+  switch (filter.kind()) {
+    case common::FilterKind::kIsNull:
+      return {nullFraction > 0 ? nullFraction : 0.0, "is-null"};
+    case common::FilterKind::kIsNotNull:
+      return {nonNullFraction, "is-not-null"};
+    case common::FilterKind::kBoolValue: {
+      auto* boolStats =
+          dynamic_cast<const dwio::common::BooleanColumnStatistics*>(stats);
+      auto* boolFilter = dynamic_cast<const common::BoolValue*>(&filter);
+      if (boolStats && boolFilter) {
+        if (auto trueCount = boolStats->getTrueCount();
+            trueCount.has_value()) {
+          const auto matched = boolFilter->testBool(true)
+              ? trueCount.value()
+              : boolStats->getFalseCount().value_or(0);
+          return {
+              clamp01(
+                  static_cast<double>(matched) /
+                  static_cast<double>(totalRows)),
+              "bool-counts"};
+        }
+      }
+      return {0.5, "bool-heuristic"};
+    }
+    case common::FilterKind::kBigintRange: {
+      auto* intStats =
+          dynamic_cast<const dwio::common::IntegerColumnStatistics*>(stats);
+      auto* range = dynamic_cast<const common::BigintRange*>(&filter);
+      if (intStats && range && intStats->getMinimum() && intStats->getMaximum()) {
+        const auto statsMin = intStats->getMinimum().value();
+        const auto statsMax = intStats->getMaximum().value();
+        if (statsMin == statsMax) {
+          const double nonNullSel = range->testInt64(statsMin) ? 1.0 : 0.0;
+          return {
+              finalizeNonNullSelectivity(
+                  nonNullSel, filter, nullFraction, nonNullFraction),
+              "int-const"};
+        }
+        const auto overlapLow = std::max<int64_t>(statsMin, range->lower());
+        const auto overlapHigh = std::min<int64_t>(statsMax, range->upper());
+        if (overlapHigh < overlapLow) {
+          return {0.0, "int-disjoint"};
+        }
+        const long double statsSpan =
+            static_cast<long double>(statsMax) -
+            static_cast<long double>(statsMin) + 1.0L;
+        const long double overlapSpan =
+            static_cast<long double>(overlapHigh) -
+            static_cast<long double>(overlapLow) + 1.0L;
+        const double nonNullSel =
+            statsSpan > 0 ? static_cast<double>(overlapSpan / statsSpan) : 1.0;
+        return {
+            finalizeNonNullSelectivity(
+                nonNullSel, filter, nullFraction, nonNullFraction),
+            "int-range"};
+      }
+      return {1.0, "int-no-minmax"};
+    }
+    case common::FilterKind::kBigintValuesUsingBitmask: {
+      auto* intStats =
+          dynamic_cast<const dwio::common::IntegerColumnStatistics*>(stats);
+      auto* valuesFilter =
+          dynamic_cast<const common::BigintValuesUsingBitmask*>(&filter);
+      if (intStats && valuesFilter && intStats->getMinimum() &&
+          intStats->getMaximum()) {
+        const auto statsMin = intStats->getMinimum().value();
+        const auto statsMax = intStats->getMaximum().value();
+        if (statsMin == statsMax) {
+          const double nonNullSel = valuesFilter->testInt64(statsMin) ? 1.0 : 0.0;
+          return {
+              finalizeNonNullSelectivity(
+                  nonNullSel, filter, nullFraction, nonNullFraction),
+              "int-set-const"};
+        }
+        size_t matches = 0;
+        for (const auto& value : valuesFilter->values()) {
+          if (value >= statsMin && value <= statsMax) {
+            ++matches;
+          }
+        }
+        if (matches == 0) {
+          return {0.0, "int-set-disjoint"};
+        }
+        const long double statsSpan =
+            static_cast<long double>(statsMax) -
+            static_cast<long double>(statsMin) + 1.0L;
+        const double nonNullSel = std::max(
+            static_cast<double>(1.0L / std::max<long double>(1.0L, statsSpan)),
+            static_cast<double>(matches / std::max<long double>(1.0L, statsSpan)));
+        return {
+            finalizeNonNullSelectivity(
+                nonNullSel, filter, nullFraction, nonNullFraction),
+            "int-set"};
+      }
+      return {1.0, "int-set-no-minmax"};
+    }
+    case common::FilterKind::kDoubleRange:
+    case common::FilterKind::kFloatRange: {
+      auto* doubleStats =
+          dynamic_cast<const dwio::common::DoubleColumnStatistics*>(stats);
+      auto* range = dynamic_cast<const common::AbstractRange*>(&filter);
+      if (doubleStats && range && doubleStats->getMinimum() &&
+          doubleStats->getMaximum()) {
+        const auto statsMin = doubleStats->getMinimum().value();
+        const auto statsMax = doubleStats->getMaximum().value();
+        if (statsMin == statsMax) {
+          const double nonNullSel = filter.testDouble(statsMin) ? 1.0 : 0.0;
+          return {
+              finalizeNonNullSelectivity(
+                  nonNullSel, filter, nullFraction, nonNullFraction),
+              "fp-const"};
+        }
+        double lower = std::numeric_limits<double>::lowest();
+        double upper = std::numeric_limits<double>::max();
+        if (!range->lowerUnbounded()) {
+          if (auto* doubleRange =
+                  dynamic_cast<const common::FloatingPointRange<double>*>(
+                      &filter)) {
+            lower = doubleRange->lower();
+          } else if (
+              auto* floatRange =
+                  dynamic_cast<const common::FloatingPointRange<float>*>(
+                      &filter)) {
+            lower = floatRange->lower();
+          }
+        }
+        if (!range->upperUnbounded()) {
+          if (auto* doubleRange =
+                  dynamic_cast<const common::FloatingPointRange<double>*>(
+                      &filter)) {
+            upper = doubleRange->upper();
+          } else if (
+              auto* floatRange =
+                  dynamic_cast<const common::FloatingPointRange<float>*>(
+                      &filter)) {
+            upper = floatRange->upper();
+          }
+        }
+        const auto overlapLow = std::max(statsMin, lower);
+        const auto overlapHigh = std::min(statsMax, upper);
+        if (overlapHigh < overlapLow) {
+          return {0.0, "fp-disjoint"};
+        }
+        const auto statsSpan = std::max(statsMax - statsMin, 1e-12);
+        const auto overlapSpan = std::max(overlapHigh - overlapLow, 0.0);
+        const double nonNullSel = clamp01(overlapSpan / statsSpan);
+        return {
+            finalizeNonNullSelectivity(
+                nonNullSel, filter, nullFraction, nonNullFraction),
+            "fp-range"};
+      }
+      return {1.0, "fp-no-minmax"};
+    }
+    case common::FilterKind::kBytesRange: {
+      auto* stringStats =
+          dynamic_cast<const dwio::common::StringColumnStatistics*>(stats);
+      auto* range = dynamic_cast<const common::BytesRange*>(&filter);
+      if (stringStats && range && stringStats->getMinimum() &&
+          stringStats->getMaximum()) {
+        const auto& statsMin = stringStats->getMinimum().value();
+        const auto& statsMax = stringStats->getMaximum().value();
+        if (statsMin == statsMax) {
+          const double nonNullSel =
+              filter.testBytes(statsMin.data(), statsMin.size()) ? 1.0 : 0.0;
+          return {
+              finalizeNonNullSelectivity(
+                  nonNullSel, filter, nullFraction, nonNullFraction),
+              "string-const"};
+        }
+        if (!range->lowerUnbounded() && !range->upperUnbounded() &&
+            !range->lowerExclusive() && !range->upperExclusive() &&
+            range->lower() == range->upper()) {
+          const double nonNullSel =
+              std::max(1.0 / static_cast<double>(std::max<uint64_t>(1, totalRows)),
+                       0.01);
+          return {
+              finalizeNonNullSelectivity(
+                  nonNullSel, filter, nullFraction, nonNullFraction),
+              "string-single"};
+        }
+        const bool coversWholeSpan =
+            (range->lowerUnbounded() || range->lower() <= statsMin) &&
+            (range->upperUnbounded() || range->upper() >= statsMax);
+        const double nonNullSel = coversWholeSpan ? 1.0 : 0.25;
+        return {
+            finalizeNonNullSelectivity(
+                nonNullSel, filter, nullFraction, nonNullFraction),
+            coversWholeSpan ? "string-cover" : "string-range-heuristic"};
+      }
+      return {1.0, "string-no-minmax"};
+    }
+    case common::FilterKind::kBytesValues: {
+      auto* stringStats =
+          dynamic_cast<const dwio::common::StringColumnStatistics*>(stats);
+      auto* valuesFilter = dynamic_cast<const common::BytesValues*>(&filter);
+      if (stringStats && valuesFilter && stringStats->getMinimum() &&
+          stringStats->getMaximum()) {
+        const auto& statsMin = stringStats->getMinimum().value();
+        const auto& statsMax = stringStats->getMaximum().value();
+        size_t matches = 0;
+        for (const auto& value : valuesFilter->values()) {
+          if (value >= statsMin && value <= statsMax) {
+            ++matches;
+          }
+        }
+        if (matches == 0) {
+          return {0.0, "string-set-disjoint"};
+        }
+        if (statsMin == statsMax) {
+          const double nonNullSel =
+              valuesFilter->values().contains(statsMin) ? 1.0 : 0.0;
+          return {
+              finalizeNonNullSelectivity(
+                  nonNullSel, filter, nullFraction, nonNullFraction),
+              "string-set-const"};
+        }
+        const double nonNullSel = clamp01(std::max(
+            1.0 / static_cast<double>(std::max<uint64_t>(1, totalRows)),
+            std::min(1.0, static_cast<double>(matches) * 0.05)));
+        return {
+            finalizeNonNullSelectivity(
+                nonNullSel, filter, nullFraction, nonNullFraction),
+            "string-set"};
+      }
+      return {1.0, "string-set-no-minmax"};
+    }
+    default:
+      return {1.0, "unsupported-kind"};
+  }
+}
+
+std::vector<RowGroupBudgetEstimate> estimateRowGroupBudgets(
+    const pqthrift::FileMetaData& footer,
+    const RowTypePtr& scanBudgetType,
+    const std::vector<std::string>& readColumnNames,
+    const common::SubfieldFilters& subfieldFilters,
+    bool hasRemainingFilter) {
+  std::unordered_set<std::string> selectedColumns(
+      readColumnNames.begin(), readColumnNames.end());
+  std::unordered_map<std::string, TypePtr> scanTypes;
+  if (scanBudgetType) {
+    for (int i = 0; i < scanBudgetType->size(); ++i) {
+      scanTypes.emplace(scanBudgetType->nameOf(i), scanBudgetType->childAt(i));
+    }
+  }
+
+  std::vector<RowGroupBudgetEstimate> estimates;
+  estimates.reserve(footer.row_groups.size());
+  for (size_t rgIndex = 0; rgIndex < footer.row_groups.size(); ++rgIndex) {
+    const auto& rowGroup = footer.row_groups[rgIndex];
+    if (rowGroup.num_rows <= 0) {
+      continue;
+    }
+
+    int64_t compressedBytes = 0;
+    int64_t uncompressedBytes = 0;
+    double pushdownSelectivity = 1.0;
+    std::vector<std::string> notes;
+
+    for (const auto& column : rowGroup.columns) {
+      const auto columnName = topLevelColumnName(column.meta_data.path_in_schema);
+      if (!selectedColumns.empty() && !selectedColumns.count(columnName)) {
+        continue;
+      }
+      compressedBytes += column.meta_data.total_compressed_size;
+      uncompressedBytes += column.meta_data.total_uncompressed_size;
+    }
+
+    for (const auto& [subfield, filterPtr] : subfieldFilters) {
+      if (!filterPtr) {
+        continue;
+      }
+      const auto columnName = subfield.toString();
+      auto typeIt = scanTypes.find(columnName);
+      if (typeIt == scanTypes.end()) {
+        notes.push_back(columnName + "=no-type");
+        continue;
+      }
+
+      const pqthrift::ColumnChunk* matchingChunk = nullptr;
+      for (const auto& column : rowGroup.columns) {
+        if (topLevelColumnName(column.meta_data.path_in_schema) == columnName) {
+          matchingChunk = &column;
+          break;
+        }
+      }
+      if (!matchingChunk) {
+        notes.push_back(columnName + "=no-chunk");
+        continue;
+      }
+
+      facebook::velox::parquet::ColumnChunkMetaDataPtr chunkMeta(matchingChunk);
+      if (!chunkMeta.hasStatistics()) {
+        notes.push_back(columnName + "=no-stats");
+        continue;
+      }
+
+      auto stats =
+          chunkMeta.getColumnStatistics(typeIt->second, rowGroup.num_rows);
+      auto estimate = estimateFilterSelectivity(
+          *filterPtr, stats.get(), rowGroup.num_rows, typeIt->second);
+      pushdownSelectivity =
+          clamp01(pushdownSelectivity * estimate.selectivity);
+      notes.push_back(fmt::format(
+          "{}={:.2f}({})", columnName, estimate.selectivity, estimate.note));
+    }
+
+    const auto decodedInputBytes =
+        static_cast<uint64_t>(std::max<int64_t>(0, uncompressedBytes));
+    const auto postReadBytes = static_cast<uint64_t>(std::llround(
+        static_cast<long double>(decodedInputBytes) * pushdownSelectivity));
+    const auto pushdownMaskBytes =
+        subfieldFilters.empty() ? 0 : filterMaskBytesEstimate(rowGroup.num_rows);
+    const auto remainingMaskBytes =
+        hasRemainingFilter ? filterMaskBytesEstimate(rowGroup.num_rows) : 0;
+    const auto scanReaderPeakBytes = subfieldFilters.empty()
+        ? decodedInputBytes
+        : decodedInputBytes + postReadBytes + pushdownMaskBytes;
+    const auto remainingFilterPeakBytes = hasRemainingFilter
+        ? postReadBytes + postReadBytes + remainingMaskBytes
+        : postReadBytes;
+
+    RowGroupBudgetEstimate estimate;
+    estimate.rowGroupIndex = static_cast<int>(rgIndex);
+    estimate.rows = rowGroup.num_rows;
+    estimate.compressedBytes = compressedBytes;
+    estimate.uncompressedBytes = uncompressedBytes;
+    estimate.pushdownSelectivity = pushdownSelectivity;
+    estimate.postReadBytes = postReadBytes;
+    estimate.predictedPeakBytes =
+        std::max(scanReaderPeakBytes, remainingFilterPeakBytes);
+    if (notes.empty()) {
+      estimate.notes = "no-pushdown-filters";
+    } else {
+      std::ostringstream out;
+      for (size_t i = 0; i < notes.size(); ++i) {
+        if (i > 0) {
+          out << ",";
+        }
+        out << notes[i];
+      }
+      estimate.notes = out.str();
+    }
+    estimates.push_back(std::move(estimate));
+  }
+
+  std::sort(
+      estimates.begin(),
+      estimates.end(),
+      [](const RowGroupBudgetEstimate& lhs, const RowGroupBudgetEstimate& rhs) {
+        return lhs.predictedPeakBytes > rhs.predictedPeakBytes;
+      });
+  return estimates;
+}
+
+void maybeLogFooterBudgetEstimate(
+    cudf::io::datasource* dataSource,
+    const std::string& filePath,
+    const RowTypePtr& scanBudgetType,
+    const std::vector<std::string>& readColumnNames,
+    const common::SubfieldFilters& subfieldFilters,
+    bool hasRemainingFilter,
+    uint64_t splitStart,
+    uint64_t splitSize,
+    int64_t targetBytes) {
+  if (!dataSource) {
+    return;
+  }
+
+  try {
+    auto footer = parseParquetFooterMetadata(dataSource);
+    auto budgets = estimateRowGroupBudgets(
+        footer,
+        scanBudgetType,
+        readColumnNames,
+        subfieldFilters,
+        hasRemainingFilter);
+    if (budgets.empty()) {
+      return;
+    }
+
+    int64_t totalCompressedBytes = 0;
+    int64_t totalUncompressedBytes = 0;
+    for (const auto& budget : budgets) {
+      totalCompressedBytes += budget.compressedBytes;
+      totalUncompressedBytes += budget.uncompressedBytes;
+    }
+
+    std::ostringstream topBudgets;
+    const auto topN = std::min<size_t>(3, budgets.size());
+    for (size_t i = 0; i < topN; ++i) {
+      if (i > 0) {
+        topBudgets << "; ";
+      }
+      const auto& budget = budgets[i];
+      topBudgets << "rg" << budget.rowGroupIndex
+                 << "{rows=" << budget.rows
+                 << ", comp=" << succinctBytes(budget.compressedBytes)
+                 << ", uncomp=" << succinctBytes(budget.uncompressedBytes)
+                 << ", postRead=" << succinctBytes(budget.postReadBytes)
+                 << ", sel=" << fmt::format("{:.2f}", budget.pushdownSelectivity)
+                 << ", peak=" << succinctBytes(budget.predictedPeakBytes)
+                 << ", notes=" << budget.notes << "}";
+    }
+
+    LOG(INFO) << "CudfHiveDataSource::footer budget: file=" << filePath
+              << ", splitStart=" << splitStart
+              << ", splitSize="
+              << (splitSize == std::numeric_limits<uint64_t>::max()
+                      ? std::string("full")
+                      : succinctBytes(splitSize))
+              << ", targetBytes=" << succinctBytes(targetBytes)
+              << ", rowGroups=" << budgets.size()
+              << ", totalCompressed=" << succinctBytes(totalCompressedBytes)
+              << ", totalUncompressed=" << succinctBytes(totalUncompressedBytes)
+              << ", remainingFilter=" << hasRemainingFilter
+              << ", topBudgets=[" << topBudgets.str() << "]";
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "CudfHiveDataSource::footer budget estimation failed for "
+                 << filePath << ": " << e.what();
+  }
+}
+
+} // namespace
 
 CudfHiveDataSource::CudfHiveDataSource(
     const RowTypePtr& outputType,
@@ -755,6 +1342,18 @@ void CudfHiveDataSource::setupCudfDataSourceAndOptions() {
 CudfParquetReaderPtr CudfHiveDataSource::createSplitReader() {
   setupCudfDataSourceAndOptions();
   stream_ = cudfGlobalStreamPool().get_stream();
+  if (CudfConfig::getInstance().debugEnabled) {
+    maybeLogFooterBudgetEstimate(
+        dataSource_.get(),
+        split_->filePath,
+        buildScanBudgetType(tableHandle_, outputType_, readColumnNames_),
+        readColumnNames_,
+        subfieldFilters_,
+        remainingFilterExprSet_ != nullptr,
+        split_->start,
+        split_->size(),
+        CudfConfig::getInstance().gpuTargetBatchBytes);
+  }
 
   // Create a parquet reader
   return std::make_unique<cudf::io::chunked_parquet_reader>(
@@ -1042,6 +1641,29 @@ bool CudfHiveDataSource::advanceToNextCoalescedFile() {
                 pageIndexBytes->data(), pageIndexBytes->size()});
       }
     } else {
+      if (CudfConfig::getInstance().debugEnabled) {
+        auto footerSource = std::move(makeDataSourcesFromSourceInfo(
+                                          cudf::io::source_info(
+                                              cudf::host_span<const std::byte>(
+                                                  reinterpret_cast<
+                                                      const std::byte*>(
+                                                      currentFilePinnedBuffer_
+                                                          ->data()),
+                                                  currentFilePinnedBuffer_
+                                                      ->size())))
+                                          .front());
+        maybeLogFooterBudgetEstimate(
+            footerSource.get(),
+            fileRange.filePath,
+            buildScanBudgetType(tableHandle_, outputType_, readColumnNames_),
+            readColumnNames_,
+            subfieldFilters_,
+            remainingFilterExprSet_ != nullptr,
+            isSelectiveBuffer ? 0 : asyncRead.start,
+            isSelectiveBuffer ? currentFilePinnedBuffer_->size()
+                              : asyncRead.length,
+            CudfConfig::getInstance().gpuTargetBatchBytes);
+      }
       splitReader_ = std::make_unique<cudf::io::chunked_parquet_reader>(
           cudfHiveConfig_->maxChunkReadLimit(),
           cudfHiveConfig_->maxPassReadLimit(),
@@ -1069,6 +1691,18 @@ bool CudfHiveDataSource::advanceToNextCoalescedFile() {
       }
     } else {
       setupCudfDataSourceAndOptions();
+      if (CudfConfig::getInstance().debugEnabled) {
+        maybeLogFooterBudgetEstimate(
+            dataSource_.get(),
+            fileRange.filePath,
+            buildScanBudgetType(tableHandle_, outputType_, readColumnNames_),
+            readColumnNames_,
+            subfieldFilters_,
+            remainingFilterExprSet_ != nullptr,
+            split_->start,
+            split_->size(),
+            CudfConfig::getInstance().gpuTargetBatchBytes);
+      }
       splitReader_ = std::make_unique<cudf::io::chunked_parquet_reader>(
           cudfHiveConfig_->maxChunkReadLimit(),
           cudfHiveConfig_->maxPassReadLimit(),

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -1170,6 +1170,10 @@ std::unique_ptr<cudf::table> CudfHiveDataSource::readNextExperimentalBatch(
               byteRange.size(),
               cudaMemcpyHostToDevice,
               stream_.value()));
+          // Sync before hostBuffer goes out of scope — cudaMemcpyAsync
+          // reads from pinned host memory asynchronously, and the pool
+          // allocator recycles the address immediately on free.
+          stream_.synchronize();
         }
       });
 

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -59,6 +59,7 @@
 namespace facebook::velox::cudf_velox::connector::hive {
 
 using cudf_velox::beginGpuRegion;
+using cudf_velox::endGpuRegion;
 using cudf_velox::GpuGuard;
 
 using namespace facebook::velox::connector;
@@ -270,6 +271,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
       auto result = flushAccumulated();
       gpuTimer_.stop(stream_);
       if (result == nullptr) {
+        endGpuRegion();
         return nullptr;
       }
       TotalScanTimeCallbackData* callbackData =
@@ -313,6 +315,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
       }
 
       if (!hasCoalescedFiles || !advanceToNextCoalescedFile()) {
+        endGpuRegion();
         return nullptr;
       }
     }

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -58,7 +58,6 @@
 
 namespace facebook::velox::cudf_velox::connector::hive {
 
-using cudf_velox::beginGpuRegion;
 using cudf_velox::endGpuRegion;
 using cudf_velox::GpuGuard;
 
@@ -228,7 +227,6 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
       const auto effectiveTarget = (targetBytes > 0)
           ? targetBytes
           : std::numeric_limits<int64_t>::max();
-      beginGpuRegion();
       GpuGuard coalescedGpuGuard;
       gpuTimer_.start(stream_);
       auto coalesceLoopStartUs = getCurrentTimeMicro();
@@ -287,7 +285,6 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     if (not splitReader_->has_next()) {
       return nullptr;
     }
-    beginGpuRegion();
     gpuGuard.emplace();
     gpuTimer_.start(stream_);
     auto tableWithMetadata = splitReader_->read_chunk();
@@ -299,7 +296,6 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     VELOX_CHECK_NOT_NULL(
         exptSplitReader_, "Experimental cudf split reader not present");
 
-    beginGpuRegion();
     gpuGuard.emplace();
     gpuTimer_.start(stream_);
     while (true) {

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -30,6 +30,7 @@
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include "velox/common/caching/CacheTTLController.h"
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/time/Timer.h"
 #include "velox/connectors/hive/BufferedInputBuilder.h"
 #include "velox/connectors/hive/FileHandle.h"
@@ -208,6 +209,9 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
 
   const bool hasCoalescedFiles = !pendingFiles_.empty();
   const auto targetBytes = CudfConfig::getInstance().gpuTargetBatchBytes;
+  const bool debugEnabled = CudfConfig::getInstance().debugEnabled;
+  uint64_t lastTableBytes = 0;
+  uint64_t lastFilteredBytes = 0;
 
   // GPU guard for single-file and experimental paths; emplaced before first
   // GPU operation and held through common post-processing.
@@ -231,36 +235,62 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
       gpuTimer_.start(stream_);
       auto coalesceLoopStartUs = getCurrentTimeMicro();
       while (splitReader_->has_next()) {
-        auto tableWithMetadata = splitReader_->read_chunk();
-        if (tableWithMetadata.tbl && tableWithMetadata.tbl->num_rows() > 0) {
-          auto& tbl = tableWithMetadata.tbl;
-          if (remainingFilterExprSet_) {
-            auto cols = tbl->release();
-            const auto originalNumColumns = cols.size();
-            auto filterResult = cudfExpressionEvaluator_->eval(
-                cols, stream_, cudf::get_current_device_resource_ref());
-            std::vector<std::unique_ptr<cudf::column>> origCols;
-            origCols.reserve(originalNumColumns);
-            std::move(
-                cols.begin(),
-                cols.begin() + originalNumColumns,
-                std::back_inserter(origCols));
-            auto origTable =
-                std::make_unique<cudf::table>(std::move(origCols));
-            tbl = cudf::apply_boolean_mask(
-                *origTable,
-                asView(filterResult),
-                stream_,
-                cudf::get_current_device_resource_ref());
-          }
-          if (tbl->num_rows() > 0) {
-            auto tableBytes = estimateTableBytes(tbl);
-            accumulatedTables_.push_back(std::move(tbl));
-            accumulatedBytes_ += tableBytes;
-            if (accumulatedBytes_ >= effectiveTarget) {
-              break;
+        try {
+          auto tableWithMetadata = splitReader_->read_chunk();
+          if (tableWithMetadata.tbl && tableWithMetadata.tbl->num_rows() > 0) {
+            auto& tbl = tableWithMetadata.tbl;
+            lastTableBytes = estimateTableBytes(tbl);
+            if (remainingFilterExprSet_) {
+              auto cols = tbl->release();
+              const auto originalNumColumns = cols.size();
+              auto filterResult = cudfExpressionEvaluator_->eval(
+                  cols, stream_, cudf::get_current_device_resource_ref());
+              std::vector<std::unique_ptr<cudf::column>> origCols;
+              origCols.reserve(originalNumColumns);
+              std::move(
+                  cols.begin(),
+                  cols.begin() + originalNumColumns,
+                  std::back_inserter(origCols));
+              auto origTable =
+                  std::make_unique<cudf::table>(std::move(origCols));
+              tbl = cudf::apply_boolean_mask(
+                  *origTable,
+                  asView(filterResult),
+                  stream_,
+                  cudf::get_current_device_resource_ref());
+            }
+            if (tbl->num_rows() > 0) {
+              auto tableBytes = estimateTableBytes(tbl);
+              lastFilteredBytes = tableBytes;
+              accumulatedTables_.push_back(std::move(tbl));
+              accumulatedBytes_ += tableBytes;
+              if (accumulatedBytes_ >= effectiveTarget) {
+                if (debugEnabled) {
+                  LOG(INFO) << "CudfHiveDataSource::next coalesced threshold: "
+                            << "accumulatedBytes="
+                            << succinctBytes(accumulatedBytes_)
+                            << ", preFilterBytes="
+                            << succinctBytes(lastTableBytes)
+                            << ", filteredBytes="
+                            << succinctBytes(lastFilteredBytes)
+                            << ", targetBytes="
+                            << succinctBytes(effectiveTarget)
+                            << ", " << gpuMemorySnapshotString();
+                }
+                break;
+              }
             }
           }
+        } catch (const std::exception& e) {
+          LOG(ERROR) << "CudfHiveDataSource::next coalesced read failed: "
+                     << e.what()
+                     << ", split=" << split_->filePath
+                     << ", accumulatedBytes=" << succinctBytes(accumulatedBytes_)
+                     << ", preFilterBytes=" << succinctBytes(lastTableBytes)
+                     << ", filteredBytes=" << succinctBytes(lastFilteredBytes)
+                     << ", targetBytes=" << succinctBytes(effectiveTarget)
+                     << ", " << gpuMemorySnapshotString();
+          throw;
         }
       }
       totalCoalesceBufferTimeNs_.fetch_add(
@@ -287,9 +317,28 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     }
     gpuGuard.emplace();
     gpuTimer_.start(stream_);
-    auto tableWithMetadata = splitReader_->read_chunk();
+    auto tableWithMetadata = [&]() {
+      try {
+        return splitReader_->read_chunk();
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "CudfHiveDataSource::next read_chunk failed: "
+                   << e.what()
+                   << ", split=" << split_->filePath
+                   << ", targetBytes=" << succinctBytes(targetBytes)
+                   << ", " << gpuMemorySnapshotString();
+        throw;
+      }
+    }();
     cudfTable = std::move(tableWithMetadata.tbl);
     metadata = std::move(tableWithMetadata.metadata);
+    lastTableBytes = estimateTableBytes(cudfTable);
+    if (debugEnabled) {
+      LOG(INFO) << "CudfHiveDataSource::next post-read: rows="
+                << (cudfTable ? cudfTable->num_rows() : 0)
+                << ", tableBytes=" << succinctBytes(lastTableBytes)
+                << ", targetBytes=" << succinctBytes(targetBytes)
+                << ", " << gpuMemorySnapshotString();
+    }
   } else {
     // Chunked experimental reader: process row groups in batches.
     // Loops across coalesced files when the current file is exhausted.
@@ -304,8 +353,27 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
       }
 
       if (exptNextRGIndex_ < exptFilteredRowGroups_.size()) {
-        cudfTable = readNextExperimentalBatch(metadata);
+        cudfTable = [&]() {
+          try {
+            return readNextExperimentalBatch(metadata);
+          } catch (const std::exception& e) {
+            LOG(ERROR) << "CudfHiveDataSource::next experimental batch failed: "
+                       << e.what()
+                       << ", split=" << split_->filePath
+                       << ", targetBytes=" << succinctBytes(targetBytes)
+                       << ", " << gpuMemorySnapshotString();
+            throw;
+          }
+        }();
         if (cudfTable && cudfTable->num_rows() > 0) {
+          lastTableBytes = estimateTableBytes(cudfTable);
+          if (debugEnabled) {
+            LOG(INFO) << "CudfHiveDataSource::next experimental post-read: rows="
+                      << cudfTable->num_rows()
+                      << ", tableBytes=" << succinctBytes(lastTableBytes)
+                      << ", targetBytes=" << succinctBytes(targetBytes)
+                      << ", " << gpuMemorySnapshotString();
+          }
           break;
         }
       }
@@ -330,27 +398,44 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
   // Apply remaining filter if present
   if (remainingFilterExprSet_) {
     MicrosecondTimer filterTimer(&filterTimeUs);
-    auto cudfTableColumns = cudfTable->release();
-    const auto originalNumColumns = cudfTableColumns.size();
-    // Filter may need addtional computed columns which are added to
-    // cudfTableColumns
-    auto filterResult = cudfExpressionEvaluator_->eval(
-        cudfTableColumns, stream_, cudf::get_current_device_resource_ref());
-    // discard computed columns
-    std::vector<std::unique_ptr<cudf::column>> originalColumns;
-    originalColumns.reserve(originalNumColumns);
-    std::move(
-        cudfTableColumns.begin(),
-        cudfTableColumns.begin() + originalNumColumns,
-        std::back_inserter(originalColumns));
-    auto originalTable =
-        std::make_unique<cudf::table>(std::move(originalColumns));
-    // Keep only rows where the filter is true
-    cudfTable = cudf::apply_boolean_mask(
-        *originalTable,
-        asView(filterResult),
-        stream_,
-        cudf::get_current_device_resource_ref());
+    try {
+      auto cudfTableColumns = cudfTable->release();
+      const auto originalNumColumns = cudfTableColumns.size();
+      // Filter may need addtional computed columns which are added to
+      // cudfTableColumns
+      auto filterResult = cudfExpressionEvaluator_->eval(
+          cudfTableColumns, stream_, cudf::get_current_device_resource_ref());
+      // discard computed columns
+      std::vector<std::unique_ptr<cudf::column>> originalColumns;
+      originalColumns.reserve(originalNumColumns);
+      std::move(
+          cudfTableColumns.begin(),
+          cudfTableColumns.begin() + originalNumColumns,
+          std::back_inserter(originalColumns));
+      auto originalTable =
+          std::make_unique<cudf::table>(std::move(originalColumns));
+      // Keep only rows where the filter is true
+      cudfTable = cudf::apply_boolean_mask(
+          *originalTable,
+          asView(filterResult),
+          stream_,
+          cudf::get_current_device_resource_ref());
+      lastFilteredBytes = estimateTableBytes(cudfTable);
+      if (debugEnabled) {
+        LOG(INFO) << "CudfHiveDataSource::next post-filter: rows="
+                  << (cudfTable ? cudfTable->num_rows() : 0)
+                  << ", filteredBytes=" << succinctBytes(lastFilteredBytes)
+                  << ", preFilterBytes=" << succinctBytes(lastTableBytes)
+                  << ", " << gpuMemorySnapshotString();
+      }
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "CudfHiveDataSource::next filter failed: " << e.what()
+                 << ", split=" << split_->filePath
+                 << ", preFilterBytes=" << succinctBytes(lastTableBytes)
+                 << ", targetBytes=" << succinctBytes(targetBytes)
+                 << ", " << gpuMemorySnapshotString();
+      throw;
+    }
   }
   totalRemainingFilterTime_.fetch_add(
       filterTimeUs * 1000, std::memory_order_relaxed);

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -800,6 +800,11 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
   uint64_t lastTableBytes = 0;
   uint64_t lastFilteredBytes = 0;
 
+  LOG(WARNING) << "GPU_MEM_SNAPSHOT [scan-entry] "
+               << gpuMemorySnapshotString()
+               << " split=" << split_->filePath
+               << " targetBytes=" << succinctBytes(targetBytes);
+
   // GPU guard for single-file and experimental paths; emplaced before first
   // GPU operation and held through common post-processing.
   std::optional<GpuGuard> gpuGuard;
@@ -820,6 +825,9 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
           : std::numeric_limits<int64_t>::max();
       GpuGuard coalescedGpuGuard;
       gpuTimer_.start(stream_);
+      LOG(WARNING) << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
+                   << gpuMemorySnapshotString()
+                   << " (coalesced path, GPU lock acquired)";
       auto coalesceLoopStartUs = getCurrentTimeMicro();
       while (splitReader_->has_next()) {
         try {
@@ -906,6 +914,9 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     }
     gpuGuard.emplace();
     gpuTimer_.start(stream_);
+    LOG(WARNING) << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
+                 << gpuMemorySnapshotString()
+                 << " (single-file path, GPU lock acquired)";
     auto tableWithMetadata = [&]() {
       try {
         return splitReader_->read_chunk();

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -58,6 +58,7 @@
 
 namespace facebook::velox::cudf_velox::connector::hive {
 
+using cudf_velox::beginGpuRegion;
 using cudf_velox::GpuGuard;
 
 using namespace facebook::velox::connector;
@@ -226,6 +227,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
       const auto effectiveTarget = (targetBytes > 0)
           ? targetBytes
           : std::numeric_limits<int64_t>::max();
+      beginGpuRegion();
       GpuGuard coalescedGpuGuard;
       gpuTimer_.start(stream_);
       auto coalesceLoopStartUs = getCurrentTimeMicro();
@@ -283,6 +285,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     if (not splitReader_->has_next()) {
       return nullptr;
     }
+    beginGpuRegion();
     gpuGuard.emplace();
     gpuTimer_.start(stream_);
     auto tableWithMetadata = splitReader_->read_chunk();
@@ -294,6 +297,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     VELOX_CHECK_NOT_NULL(
         exptSplitReader_, "Experimental cudf split reader not present");
 
+    beginGpuRegion();
     gpuGuard.emplace();
     gpuTimer_.start(stream_);
     while (true) {

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -800,7 +800,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
   uint64_t lastTableBytes = 0;
   uint64_t lastFilteredBytes = 0;
 
-  LOG(WARNING) << "GPU_MEM_SNAPSHOT [scan-entry] "
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [scan-entry] "
                << gpuMemorySnapshotString()
                << " split=" << split_->filePath
                << " targetBytes=" << succinctBytes(targetBytes);
@@ -825,7 +825,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
           : std::numeric_limits<int64_t>::max();
       GpuGuard coalescedGpuGuard;
       gpuTimer_.start(stream_);
-      LOG(WARNING) << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
+      LOG(ERROR) << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
                    << gpuMemorySnapshotString()
                    << " (coalesced path, GPU lock acquired)";
       auto coalesceLoopStartUs = getCurrentTimeMicro();
@@ -914,7 +914,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     }
     gpuGuard.emplace();
     gpuTimer_.start(stream_);
-    LOG(WARNING) << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
+    LOG(ERROR) << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
                  << gpuMemorySnapshotString()
                  << " (single-file path, GPU lock acquired)";
     auto tableWithMetadata = [&]() {

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -62,6 +62,7 @@
 #include <algorithm>
 #include <cmath>
 #include <future>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <sstream>
@@ -800,10 +801,11 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
   uint64_t lastTableBytes = 0;
   uint64_t lastFilteredBytes = 0;
 
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [scan-entry] "
+  std::cerr << "GPU_MEM_SNAPSHOT [scan-entry] "
                << gpuMemorySnapshotString()
                << " split=" << split_->filePath
-               << " targetBytes=" << succinctBytes(targetBytes);
+               << " targetBytes=" << succinctBytes(targetBytes)
+               << std::endl;
 
   // GPU guard for single-file and experimental paths; emplaced before first
   // GPU operation and held through common post-processing.
@@ -825,9 +827,10 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
           : std::numeric_limits<int64_t>::max();
       GpuGuard coalescedGpuGuard;
       gpuTimer_.start(stream_);
-      LOG(ERROR) << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
+      std::cerr << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
                    << gpuMemorySnapshotString()
-                   << " (coalesced path, GPU lock acquired)";
+                   << " (coalesced path, GPU lock acquired)"
+                   << std::endl;
       auto coalesceLoopStartUs = getCurrentTimeMicro();
       while (splitReader_->has_next()) {
         try {
@@ -914,9 +917,10 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     }
     gpuGuard.emplace();
     gpuTimer_.start(stream_);
-    LOG(ERROR) << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
+    std::cerr << "GPU_MEM_SNAPSHOT [scan-post-GpuGuard] "
                  << gpuMemorySnapshotString()
-                 << " (single-file path, GPU lock acquired)";
+                 << " (single-file path, GPU lock acquired)"
+                 << std::endl;
     auto tableWithMetadata = [&]() {
       try {
         return splitReader_->read_chunk();

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSourceHelpers.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSourceHelpers.cpp
@@ -191,6 +191,12 @@ std::future<size_t> BufferedInputDataSource::device_read_async(
                           hostBuffer->size(),
                           cudaMemcpyHostToDevice,
                           stream.value()));
+                      // Wait for the async H2D copy to complete before
+                      // hostBuffer goes out of scope. PinnedHostBuffer uses a
+                      // pool allocator, so freed memory is immediately reusable
+                      // by other threads — the DMA engine would read from
+                      // recycled addresses without this sync.
+                      CUDF_CUDA_TRY(cudaStreamSynchronize(stream.value()));
                       return hostBuffer->size();
                     });
   return toStdFuture(std::move(future));

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(
   velox_cudf_exec
   CudfAssignUniqueId.cpp
   CudfConversion.cpp
+  GpuGuard.cpp
   CudfFilterProject.cpp
   CudfHashAggregation.cpp
   CudfHashJoin.cpp

--- a/velox/experimental/cudf/exec/CudfAssignUniqueId.cpp
+++ b/velox/experimental/cudf/exec/CudfAssignUniqueId.cpp
@@ -140,6 +140,13 @@ std::unique_ptr<cudf::column> CudfAssignUniqueId::generateIdColumn(
 
   auto list_sequence = cudf::lists::sequences(
       d_starts_column_view, d_sizes_column_view, stream, mr);
+  // Wait for async operations before starts/sizes vectors and device buffers
+  // go out of scope. The device_buffer constructors at lines 122-125 do async
+  // H2D from the host vectors, and sequences() launches async kernels reading
+  // from d_starts/d_sizes_buffer. Without sync, the RMM pool may recycle the
+  // device memory while kernels are still reading, causing SIGSEGV under
+  // concurrent GPU tasks.
+  stream.synchronize();
   // Discard offsets.
   return std::move(list_sequence->release().children[1]);
 }

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -288,6 +288,16 @@ std::optional<uint64_t> CudfToVelox::averageRowSize() {
 RowVectorPtr CudfToVelox::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
   GpuGuard gpuGuard;
+  // Ensure endGpuRegion() is called on ALL exit paths, including
+  // exceptions from toVeloxColumn() or getConcatenatedTable().
+  // Without this, an exception bypasses explicit endGpuRegion() calls,
+  // ~GpuGuard only calls unlockGpu() (not endGpuRegion()), and the
+  // leaked gpuRegionActive=true causes per-operator permit churn that
+  // deadlocks under contention. endGpuRegion() is idempotent so the
+  // double-call on normal paths is harmless.
+  SCOPE_EXIT {
+    endGpuRegion();
+  };
   std::cerr << "GPU_MEM_SNAPSHOT [CudfToVelox-D2H] "
                << gpuMemorySnapshotString()
                << " inputs=" << inputs_.size()

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -197,8 +197,6 @@ RowVectorPtr CudfFromVelox::getOutput() {
     return nullptr;
   }
 
-  // All early returns passed — begin GPU region before actual H2D work.
-  beginGpuRegion();
   GpuGuard gpuGuard;
 
   auto stream = cudfGlobalStreamPool().get_stream();

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -31,6 +31,8 @@
 
 #include <cudf/copying.hpp>
 #include <cudf/detail/utilities/stream_pool.hpp>
+
+#include <iostream>
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
@@ -199,11 +201,12 @@ RowVectorPtr CudfFromVelox::getOutput() {
   }
 
   GpuGuard gpuGuard;
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [CudfFromVelox-H2D] "
+  std::cerr << "GPU_MEM_SNAPSHOT [CudfFromVelox-H2D] "
                << gpuMemorySnapshotString()
                << " batches=" << selectedInputs.size()
                << " totalRows=" << totalSize
-               << " totalBytes=" << succinctBytes(totalBytes);
+               << " totalBytes=" << succinctBytes(totalBytes)
+               << std::endl;
 
   auto stream = cudfGlobalStreamPool().get_stream();
 
@@ -285,10 +288,11 @@ std::optional<uint64_t> CudfToVelox::averageRowSize() {
 RowVectorPtr CudfToVelox::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
   GpuGuard gpuGuard;
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [CudfToVelox-D2H] "
+  std::cerr << "GPU_MEM_SNAPSHOT [CudfToVelox-D2H] "
                << gpuMemorySnapshotString()
                << " inputs=" << inputs_.size()
-               << " finished=" << finished_;
+               << " finished=" << finished_
+               << std::endl;
   if (finished_ || inputs_.empty()) {
     finished_ = noMoreInput_ && inputs_.empty();
     endGpuRegion();

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -23,6 +23,7 @@
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
+#include "velox/common/base/SuccinctPrinter.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/Operator.h"
 #include "velox/vector/ComplexVector.h"
@@ -198,6 +199,11 @@ RowVectorPtr CudfFromVelox::getOutput() {
   }
 
   GpuGuard gpuGuard;
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [CudfFromVelox-H2D] "
+               << gpuMemorySnapshotString()
+               << " batches=" << selectedInputs.size()
+               << " totalRows=" << totalSize
+               << " totalBytes=" << succinctBytes(totalBytes);
 
   auto stream = cudfGlobalStreamPool().get_stream();
 
@@ -279,6 +285,10 @@ std::optional<uint64_t> CudfToVelox::averageRowSize() {
 RowVectorPtr CudfToVelox::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
   GpuGuard gpuGuard;
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [CudfToVelox-D2H] "
+               << gpuMemorySnapshotString()
+               << " inputs=" << inputs_.size()
+               << " finished=" << finished_;
   if (finished_ || inputs_.empty()) {
     finished_ = noMoreInput_ && inputs_.empty();
     endGpuRegion();

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -154,8 +154,6 @@ void CudfFromVelox::addInput(RowVectorPtr input) {
 
 RowVectorPtr CudfFromVelox::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
-  beginGpuRegion();
-  GpuGuard gpuGuard;
 
   const auto targetBytes = CudfConfig::getInstance().gpuTargetBatchBytes;
   const auto targetRows =
@@ -198,6 +196,10 @@ RowVectorPtr CudfFromVelox::getOutput() {
   if (totalSize == 0) {
     return nullptr;
   }
+
+  // All early returns passed — begin GPU region before actual H2D work.
+  beginGpuRegion();
+  GpuGuard gpuGuard;
 
   auto stream = cudfGlobalStreamPool().get_stream();
 

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -154,6 +154,7 @@ void CudfFromVelox::addInput(RowVectorPtr input) {
 
 RowVectorPtr CudfFromVelox::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
+  beginGpuRegion();
   GpuGuard gpuGuard;
 
   const auto targetBytes = CudfConfig::getInstance().gpuTargetBatchBytes;
@@ -280,6 +281,7 @@ RowVectorPtr CudfToVelox::getOutput() {
   GpuGuard gpuGuard;
   if (finished_ || inputs_.empty()) {
     finished_ = noMoreInput_ && inputs_.empty();
+    endGpuRegion();
     return nullptr;
   }
 
@@ -301,12 +303,15 @@ RowVectorPtr CudfToVelox::getOutput() {
     auto tableView = cudfVector->getTableView();
     if (tableView.num_rows() == 0) {
       finished_ = noMoreInput_ && inputs_.empty();
+      endGpuRegion();
       return nullptr;
     }
     gpuTimer_.start(stream);
     RowVectorPtr output =
         with_arrow::toVeloxColumn(tableView, pool(), "", stream);
     gpuTimer_.stop(stream);
+    // D2H complete — end GPU region before returning host data.
+    endGpuRegion();
     finished_ = noMoreInput_ && inputs_.empty();
     if (output->type()->kindEquals(outputType_)) {
       output->setType(outputType_);
@@ -386,6 +391,7 @@ RowVectorPtr CudfToVelox::getOutput() {
 
   // If we have no inputs to process, return nullptr
   if (selectedInputs.empty()) {
+    endGpuRegion();
     return nullptr;
   }
 
@@ -396,6 +402,7 @@ RowVectorPtr CudfToVelox::getOutput() {
   const auto size = resultTable->num_rows();
   VELOX_CHECK_NOT_NULL(resultTable);
   if (size == 0) {
+    endGpuRegion();
     return nullptr;
   }
 
@@ -403,6 +410,8 @@ RowVectorPtr CudfToVelox::getOutput() {
   RowVectorPtr output =
       with_arrow::toVeloxColumn(resultTable->view(), pool(), "", stream);
   gpuTimer_.stop(stream);
+  // D2H complete — end GPU region before returning host data.
+  endGpuRegion();
   finished_ = noMoreInput_ && inputs_.empty();
   if (output->type()->kindEquals(outputType_)) {
     output->setType(outputType_);

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -266,8 +266,9 @@ RowVectorPtr CudfFilterProject::getOutput() {
   vector_size_t inputRows = 0;
   vector_size_t outputRows = 0;
   GpuGuard gpuGuard;
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [filterProject-entry] "
-               << gpuMemorySnapshotString();
+  std::cerr << "GPU_MEM_SNAPSHOT [filterProject-entry] "
+               << gpuMemorySnapshotString()
+               << std::endl;
 
   try {
     if (allInputProcessed()) {

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -19,9 +19,11 @@
 #include "velox/experimental/cudf/exec/GpuGuard.h"
 #include "velox/experimental/cudf/exec/GpuTimer.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FieldReference.h"
@@ -258,88 +260,119 @@ void CudfFilterProject::addInput(RowVectorPtr input) {
 
 RowVectorPtr CudfFilterProject::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
+  const bool debugEnabled = CudfConfig::getInstance().debugEnabled;
+  uint64_t inputBytes = 0;
+  uint64_t outputBytes = 0;
+  vector_size_t inputRows = 0;
+  vector_size_t outputRows = 0;
   GpuGuard gpuGuard;
 
-  if (allInputProcessed()) {
-    if (!hasFilter_) {
+  try {
+    if (allInputProcessed()) {
+      if (!hasFilter_) {
+        return nullptr;
+      }
+      if (!accumulatedOutputs_.empty() && noMoreInput_) {
+        return flushAccumulatedOutputs();
+      }
       return nullptr;
     }
-    if (!accumulatedOutputs_.empty() && noMoreInput_) {
-      return flushAccumulatedOutputs();
+    if (input_->size() == 0) {
+      input_.reset();
+      if (!accumulatedOutputs_.empty() && noMoreInput_) {
+        return flushAccumulatedOutputs();
+      }
+      return nullptr;
     }
-    return nullptr;
-  }
-  if (input_->size() == 0) {
+
+    auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
+    VELOX_CHECK_NOT_NULL(cudfInput);
+    auto stream = cudfInput->stream();
+    inputBytes = cudfInput->estimateFlatSize();
+    inputRows = cudfInput->size();
+    if (debugEnabled) {
+      LOG(INFO) << "CudfFilterProject::getOutput start: inputRows=" << inputRows
+                << ", inputBytes=" << succinctBytes(inputBytes)
+                << ", " << gpuMemorySnapshotString();
+    }
+    auto inputTableColumns = cudfInput->release()->release();
+
+    gpuTimer_.start(stream);
+
+    if (hasFilter_) {
+      filter(inputTableColumns, stream);
+    }
+    auto outputColumns = project(inputTableColumns, stream);
+
+    gpuTimer_.stop(stream);
+
+    auto outputTable = std::make_unique<cudf::table>(std::move(outputColumns));
+    auto const numColumns = outputTable->num_columns();
+    auto const size = outputTable->num_rows();
+    outputRows = size;
+    outputBytes = estimateTableBytes(outputTable);
+    if (debugEnabled) {
+      LOG(INFO) << "CudfFilterProject::getOutput produced: rows=" << size
+                << ", columns=" << numColumns
+                << ", outputBytes=" << succinctBytes(outputBytes)
+                << ", " << gpuMemorySnapshotString();
+    }
+
+    auto pool = input_->pool();
     input_.reset();
-    if (!accumulatedOutputs_.empty() && noMoreInput_) {
+
+    if (numColumns == 0 || size == 0) {
+      if (!accumulatedOutputs_.empty() && noMoreInput_) {
+        return flushAccumulatedOutputs();
+      }
+      return nullptr;
+    }
+
+    auto cudfOutput = std::make_shared<CudfVector>(
+        pool, outputType_, size, std::move(outputTable), stream);
+
+    if (!hasFilter_) {
+      return cudfOutput;
+    }
+
+    auto targetBytes = CudfConfig::getInstance().gpuTargetBatchBytes;
+    auto minRows = CudfConfig::getInstance().gpuTargetBatchRows;
+    if (targetBytes <= 0 && minRows <= 0) {
+      return cudfOutput;
+    }
+
+    accumulatedOutputRows_ += size;
+    accumulatedOutputBytes_ += cudfOutput->estimateFlatSize();
+    accumulatedOutputs_.push_back(std::move(cudfOutput));
+
+    bool thresholdReached;
+    if (targetBytes > 0 && minRows > 0) {
+      thresholdReached =
+          accumulatedOutputBytes_ >= targetBytes ||
+          accumulatedOutputRows_ >= minRows;
+    } else if (targetBytes > 0) {
+      thresholdReached = accumulatedOutputBytes_ >= targetBytes;
+    } else {
+      thresholdReached = accumulatedOutputRows_ >= minRows;
+    }
+    if (thresholdReached) {
       return flushAccumulatedOutputs();
     }
     return nullptr;
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "CudfFilterProject::getOutput failed: " << e.what()
+               << ", hasFilter=" << hasFilter_
+               << ", noMoreInput=" << noMoreInput_
+               << ", inputRows=" << inputRows
+               << ", outputRows=" << outputRows
+               << ", inputBytes=" << succinctBytes(inputBytes)
+               << ", outputBytes=" << succinctBytes(outputBytes)
+               << ", accumulatedOutputBytes="
+               << succinctBytes(accumulatedOutputBytes_)
+               << ", accumulatedOutputs=" << accumulatedOutputs_.size()
+               << ", " << gpuMemorySnapshotString();
+    throw;
   }
-
-  auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
-  VELOX_CHECK_NOT_NULL(cudfInput);
-  auto stream = cudfInput->stream();
-  auto inputTableColumns = cudfInput->release()->release();
-
-  gpuTimer_.start(stream);
-
-  if (hasFilter_) {
-    filter(inputTableColumns, stream);
-  }
-  auto outputColumns = project(inputTableColumns, stream);
-
-  gpuTimer_.stop(stream);
-
-  auto outputTable = std::make_unique<cudf::table>(std::move(outputColumns));
-  auto const numColumns = outputTable->num_columns();
-  auto const size = outputTable->num_rows();
-  if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(1) << "cudfProject Output: " << size << " rows, " << numColumns
-            << " columns";
-  }
-
-  auto pool = input_->pool();
-  input_.reset();
-
-  if (numColumns == 0 || size == 0) {
-    if (!accumulatedOutputs_.empty() && noMoreInput_) {
-      return flushAccumulatedOutputs();
-    }
-    return nullptr;
-  }
-
-  auto cudfOutput = std::make_shared<CudfVector>(
-      pool, outputType_, size, std::move(outputTable), stream);
-
-  if (!hasFilter_) {
-    return cudfOutput;
-  }
-
-  auto targetBytes = CudfConfig::getInstance().gpuTargetBatchBytes;
-  auto minRows = CudfConfig::getInstance().gpuTargetBatchRows;
-  if (targetBytes <= 0 && minRows <= 0) {
-    return cudfOutput;
-  }
-
-  accumulatedOutputRows_ += size;
-  accumulatedOutputBytes_ += cudfOutput->estimateFlatSize();
-  accumulatedOutputs_.push_back(std::move(cudfOutput));
-
-  bool thresholdReached;
-  if (targetBytes > 0 && minRows > 0) {
-    thresholdReached =
-        accumulatedOutputBytes_ >= targetBytes ||
-        accumulatedOutputRows_ >= minRows;
-  } else if (targetBytes > 0) {
-    thresholdReached = accumulatedOutputBytes_ >= targetBytes;
-  } else {
-    thresholdReached = accumulatedOutputRows_ >= minRows;
-  }
-  if (thresholdReached) {
-    return flushAccumulatedOutputs();
-  }
-  return nullptr;
 }
 
 RowVectorPtr CudfFilterProject::flushAccumulatedOutputs() {

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -266,6 +266,8 @@ RowVectorPtr CudfFilterProject::getOutput() {
   vector_size_t inputRows = 0;
   vector_size_t outputRows = 0;
   GpuGuard gpuGuard;
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [filterProject-entry] "
+               << gpuMemorySnapshotString();
 
   try {
     if (allInputProcessed()) {

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -579,6 +579,10 @@ struct ApproxDistinctAggregator : cudf_velox::CudfHashAggregation::Aggregator {
             cuda::std::span<cuda::std::byte>(
                 static_cast<cuda::std::byte*>(temp_sketch.data()), size),
             stream);
+        // Wait for merge kernel to finish reading temp_sketch before it goes
+        // out of scope. The RMM pool deallocator returns memory immediately,
+        // so another thread could reuse the address while merge is in flight.
+        stream.synchronize();
       }
     }
 

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -21,6 +21,7 @@
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
+#include "velox/common/base/SuccinctPrinter.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregateFunctionRegistry.h"
 #include "velox/exec/PrefixSort.h"
@@ -1048,6 +1049,11 @@ void CudfHashAggregation::addInput(RowVectorPtr input) {
 
   auto cudfInput = std::dynamic_pointer_cast<cudf_velox::CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput);
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [hashAgg-addInput] "
+               << cudf_velox::gpuMemorySnapshotString()
+               << " rows=" << input->size()
+               << " inputBytes=" << succinctBytes(cudfInput->estimateFlatSize())
+               << " totalInputRows=" << numInputRows_;
 
   if (isPartialOutput_ && !isGlobal_) {
     const auto targetBytes = CudfConfig::getInstance().gpuTargetBatchBytes;
@@ -1205,6 +1211,11 @@ CudfVectorPtr CudfHashAggregation::releaseAndResetPartialOutput() {
 RowVectorPtr CudfHashAggregation::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
   GpuGuard gpuGuard;
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [hashAgg-getOutput] "
+               << cudf_velox::gpuMemorySnapshotString()
+               << " inputs=" << inputs_.size()
+               << " isPartial=" << isPartialOutput_
+               << " isGlobal=" << isGlobal_;
 
   // Handle partial groupby and distinct.
   if (isPartialOutput_ && !isGlobal_) {

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -40,6 +40,7 @@
 #include <cudf/unary.hpp>
 #include <cudf/utilities/error.hpp>
 
+#include <iostream>
 #include <vector>
 
 namespace {
@@ -1049,11 +1050,12 @@ void CudfHashAggregation::addInput(RowVectorPtr input) {
 
   auto cudfInput = std::dynamic_pointer_cast<cudf_velox::CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput);
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [hashAgg-addInput] "
+  std::cerr << "GPU_MEM_SNAPSHOT [hashAgg-addInput] "
                << cudf_velox::gpuMemorySnapshotString()
                << " rows=" << input->size()
                << " inputBytes=" << succinctBytes(cudfInput->estimateFlatSize())
-               << " totalInputRows=" << numInputRows_;
+               << " totalInputRows=" << numInputRows_
+               << std::endl;
 
   if (isPartialOutput_ && !isGlobal_) {
     const auto targetBytes = CudfConfig::getInstance().gpuTargetBatchBytes;
@@ -1211,11 +1213,12 @@ CudfVectorPtr CudfHashAggregation::releaseAndResetPartialOutput() {
 RowVectorPtr CudfHashAggregation::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
   GpuGuard gpuGuard;
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [hashAgg-getOutput] "
+  std::cerr << "GPU_MEM_SNAPSHOT [hashAgg-getOutput] "
                << cudf_velox::gpuMemorySnapshotString()
                << " inputs=" << inputs_.size()
                << " isPartial=" << isPartialOutput_
-               << " isGlobal=" << isGlobal_;
+               << " isGlobal=" << isGlobal_
+               << std::endl;
 
   // Handle partial groupby and distinct.
   if (isPartialOutput_ && !isGlobal_) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -238,6 +238,7 @@ void CudfHashJoinBuild::addInput(RowVectorPtr input) {
     VLOG(2) << "Calling CudfHashJoinBuild::addInput";
   }
   if (input->size() == 0) {
+    endGpuRegion();
     return;
   }
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -144,6 +144,11 @@ void CudfHashJoinProbe::buildHashTable() {
         std::move(unpacked),
         stream));
   }
+  // Wait for all async H2D copies to complete before freeing the source
+  // pinned host buffers. Without this, the GPU DMA engine may still be
+  // reading from pinned addresses that the pool reclaims and reuses,
+  // causing SEGV_ACCERR in cudaMemcpyAsync on Blackwell GPUs.
+  stream.synchronize();
   buildBatches_.reset();
   std::cerr << "GPU_MEM_SNAPSHOT [buildHashTable-post-H2D] "
                << gpuMemorySnapshotString()

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -17,14 +17,12 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
 #include "velox/experimental/cudf/exec/GpuGuard.h"
-#include "velox/experimental/cudf/exec/PinnedHostMemory.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/expression/AstExpression.h"
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
 
-#include "velox/common/base/SuccinctPrinter.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h" // NOLINT(misc-unused-headers)
 #include "velox/type/TypeUtil.h"
@@ -33,7 +31,6 @@
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
-#include <cudf/contiguous_split.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/groupby.hpp>
@@ -52,8 +49,6 @@
 #include <rmm/exec_policy.hpp>
 
 #include <nvtx3/nvtx3.hpp>
-
-#include <iostream>
 
 namespace facebook::velox::cudf_velox {
 
@@ -76,172 +71,54 @@ void CudfHashJoinProbe::close() {
   accumulatedProbeBytes_ = 0;
 }
 
-void CudfHashJoinProbe::buildHashTable() {
-  VELOX_CHECK(buildBatches_.has_value());
-  VELOX_CHECK(!hashObject_.has_value());
-  VELOX_NVTX_OPERATOR_FUNC_RANGE();
-
-  auto& hostBatches = buildBatches_.value();
-  auto buildType = joinNode_->sources()[1]->outputType();
-
-  if (hostBatches.empty()) {
-    std::vector<std::unique_ptr<cudf::column>> emptyCols;
-    for (int i = 0; i < buildType->size(); ++i) {
-      auto cudfType = cudf::data_type{veloxToCudfTypeId(buildType->childAt(i))};
-      emptyCols.push_back(cudf::make_empty_column(cudfType));
-    }
-    auto emptyTbl = std::make_unique<cudf::table>(std::move(emptyCols));
-    std::vector<std::shared_ptr<cudf::table>> emptyTbls;
-    emptyTbls.push_back(std::move(emptyTbl));
-    std::vector<std::shared_ptr<cudf::hash_join>> emptyHashObjs;
-    emptyHashObjs.push_back(nullptr);
-    hashObject_ = std::make_pair(
-        std::move(emptyTbls), std::move(emptyHashObjs));
-    buildBatches_.reset();
-    return;
-  }
-
-  auto stream = cudfGlobalStreamPool().get_stream();
-  buildStream_ = stream;
-
-  size_t totalHostBytes = 0;
-  for (auto& hb : hostBatches) {
-    totalHostBytes += hb.data->size();
-  }
-  std::cerr << "GPU_MEM_SNAPSHOT [buildHashTable-pre-H2D] "
-               << gpuMemorySnapshotString()
-               << " hostBatches=" << hostBatches.size()
-               << " totalHostBytes=" << succinctBytes(totalHostBytes)
-               << std::endl;
-
+void CudfHashJoinBridge::setHashTable(
+    std::optional<CudfHashJoinBridge::hash_type> hashObject) {
   if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(1) << "CudfHashJoinProbe::buildHashTable hostBatches="
-            << hostBatches.size();
+    VLOG(2) << "Calling CudfHashJoinBridge::setHashTable";
   }
-
-  // H2D: copy each host-pinned batch back to GPU and reconstruct CudfVectors.
-  std::vector<CudfVectorPtr> gpuBatches;
-  gpuBatches.reserve(hostBatches.size());
-  for (auto& hb : hostBatches) {
-    rmm::device_buffer devBuf(hb.data->size(), stream);
-    CUDF_CUDA_TRY(cudaMemcpyAsync(
-        devBuf.data(),
-        hb.data->data(),
-        hb.data->size(),
-        cudaMemcpyHostToDevice,
-        stream.value()));
-    auto metadata = std::make_unique<std::vector<uint8_t>>(
-        std::move(hb.metadata));
-    cudf::packed_columns pc{std::move(metadata),
-                            std::make_unique<rmm::device_buffer>(
-                                std::move(devBuf))};
-    auto unpacked = std::make_unique<cudf::packed_table>(cudf::unpack(pc));
-    auto numRows = hb.numRows;
-    gpuBatches.push_back(std::make_shared<CudfVector>(
-        operatorCtx_->pool(),
-        buildType,
-        numRows,
-        std::move(unpacked),
-        stream));
-  }
-  // Wait for all async H2D copies to complete before freeing the source
-  // pinned host buffers. Without this, the GPU DMA engine may still be
-  // reading from pinned addresses that the pool reclaims and reuses,
-  // causing SEGV_ACCERR in cudaMemcpyAsync on Blackwell GPUs.
-  stream.synchronize();
-  buildBatches_.reset();
-  std::cerr << "GPU_MEM_SNAPSHOT [buildHashTable-post-H2D] "
-               << gpuMemorySnapshotString()
-               << " gpuBatches=" << gpuBatches.size()
-               << " (all build data now on GPU, about to concatenate)"
-               << std::endl;
-
-  auto tbls = getConcatenatedTableBatched(gpuBatches, buildType, stream);
-  // Release individual GPU batches immediately — the concatenated tables in
-  // `tbls` own all the data now. Without this, both gpuBatches (~N bytes)
-  // and tbls (~N bytes) coexist on GPU during hash_join construction,
-  // doubling peak memory vs v4 which cleared inputs_ here.
-  gpuBatches.clear();
-
-  for (auto const& tbl : tbls) {
-    VELOX_CHECK_NOT_NULL(tbl);
-  }
-
-  auto rightKeys = joinNode_->rightKeys();
-  auto buildKeyIndices = std::vector<cudf::size_type>(rightKeys.size());
-  for (size_t i = 0; i < buildKeyIndices.size(); i++) {
-    buildKeyIndices[i] = static_cast<cudf::size_type>(
-        buildType->getChildIdx(rightKeys[i]->name()));
-  }
-
-  bool needsHashJoin =
-      (joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
-       joinNode_->isRightJoin());
-
-  std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
-  for (size_t i = 0; i < tbls.size(); i++) {
-    hashObjects.push_back(
-        needsHashJoin ? std::make_shared<cudf::hash_join>(
-                            tbls[i]->view().select(buildKeyIndices),
-                            cudf::null_equality::UNEQUAL,
-                            stream)
-                      : nullptr);
-  }
-
-  std::vector<std::shared_ptr<cudf::table>> shared_tbls;
-  for (auto& tbl : tbls) {
-    shared_tbls.push_back(std::move(tbl));
-  }
-
-  hashObject_ = std::make_pair(
-      std::move(shared_tbls), std::move(hashObjects));
-  std::cerr << "GPU_MEM_SNAPSHOT [buildHashTable-post-build] "
-               << gpuMemorySnapshotString()
-               << " (hash table built, concatenated tables + hash objects on GPU)"
-               << std::endl;
-
-  // Initialize right-join matched flags under the same GpuGuard.
-  if (joinNode_->isRightJoin()) {
-    auto& rightTables = hashObject_.value().first;
-    rightMatchedFlags_.clear();
-    rightMatchedFlags_.reserve(rightTables.size());
-    for (auto& rt : rightTables) {
-      auto n = rt->num_rows();
-      auto false_scalar = cudf::numeric_scalar<bool>(false, true, stream);
-      auto flags_col = cudf::make_column_from_scalar(
-          false_scalar, n, stream, cudf::get_current_device_resource_ref());
-      rightMatchedFlags_.push_back(std::move(flags_col));
-    }
-  }
-}
-
-void CudfHashJoinBridge::setBuildBatches(
-    std::vector<HostBuildBatch> batches) {
-  VLOG_IF(2, CudfConfig::getInstance().debugEnabled)
-      << "CudfHashJoinBridge::setBuildBatches  batches=" << batches.size();
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
     VELOX_CHECK(
-        !buildBatches_.has_value(),
-        "setBuildBatches may be called only once");
-    buildBatches_ = std::move(batches);
+        !hashObject_.has_value(),
+        "CudfHashJoinBridge already has a hash table");
+    hashObject_ = std::move(hashObject);
     promises = std::move(promises_);
   }
   notify(std::move(promises));
 }
 
-std::optional<std::vector<HostBuildBatch>>
-CudfHashJoinBridge::buildBatchesOrFuture(ContinueFuture* future) {
-  VLOG_IF(2, CudfConfig::getInstance().debugEnabled)
-      << "CudfHashJoinBridge::buildBatchesOrFuture";
-  std::lock_guard<std::mutex> l(mutex_);
-  if (buildBatches_.has_value()) {
-    return std::move(buildBatches_);
+std::optional<CudfHashJoinBridge::hash_type> CudfHashJoinBridge::hashOrFuture(
+    ContinueFuture* future) {
+  if (CudfConfig::getInstance().debugEnabled) {
+    VLOG(2) << "Calling CudfHashJoinBridge::hashOrFuture";
   }
-  promises_.emplace_back("CudfHashJoinBridge::buildBatchesOrFuture");
+  std::lock_guard<std::mutex> l(mutex_);
+  if (hashObject_.has_value()) {
+    return hashObject_;
+  }
+  if (CudfConfig::getInstance().debugEnabled) {
+    VLOG(2) << "Calling CudfHashJoinBridge::hashOrFuture constructing promise";
+  }
+  promises_.emplace_back("CudfHashJoinBridge::hashOrFuture");
+  if (CudfConfig::getInstance().debugEnabled) {
+    VLOG(2) << "Calling CudfHashJoinBridge::hashOrFuture getSemiFuture";
+  }
   *future = promises_.back().getSemiFuture();
+  if (CudfConfig::getInstance().debugEnabled) {
+    VLOG(2) << "Calling CudfHashJoinBridge::hashOrFuture returning nullopt";
+  }
   return std::nullopt;
+}
+
+void CudfHashJoinBridge::setBuildStream(rmm::cuda_stream_view buildStream) {
+  std::lock_guard<std::mutex> l(mutex_);
+  buildStream_ = buildStream;
+}
+
+std::optional<rmm::cuda_stream_view> CudfHashJoinBridge::getBuildStream() {
+  std::lock_guard<std::mutex> l(mutex_);
+  return buildStream_;
 }
 
 CudfHashJoinBuild::CudfHashJoinBuild(
@@ -269,35 +146,12 @@ void CudfHashJoinBuild::addInput(RowVectorPtr input) {
   if (CudfConfig::getInstance().debugEnabled) {
     VLOG(2) << "Calling CudfHashJoinBuild::addInput";
   }
-  if (input->size() == 0) {
-    endGpuRegion();
-    return;
+  // Queue inputs, process all at once.
+  if (input->size() > 0) {
+    auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
+    VELOX_CHECK_NOT_NULL(cudfInput);
+    inputs_.push_back(std::move(cudfInput));
   }
-  auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
-  VELOX_CHECK_NOT_NULL(cudfInput);
-
-  auto stream = cudfInput->stream();
-
-  // D2H: pack into contiguous device buffer, copy to pinned host memory.
-  // Runs under the GPU region started by the source operator (scan).
-  auto packed = cudf::pack(cudfInput->getTableView(), stream);
-  auto devSize = packed.gpu_data->size();
-  auto hostBuf = std::make_shared<PinnedHostBuffer>(devSize);
-  CUDF_CUDA_TRY(cudaMemcpyAsync(
-      hostBuf->data(),
-      packed.gpu_data->data(),
-      devSize,
-      cudaMemcpyDeviceToHost,
-      stream.value()));
-  stream.synchronize();
-
-  auto numRows = static_cast<vector_size_t>(cudfInput->size());
-  hostInputs_.push_back(
-      {std::move(*packed.metadata), std::move(hostBuf), numRows});
-
-  // D2H complete — end the GPU region started by the source operator.
-  // All GPU data for this batch is now on host; semaphore released.
-  endGpuRegion();
 }
 
 bool CudfHashJoinBuild::needsInput() const {
@@ -319,36 +173,109 @@ void CudfHashJoinBuild::noMoreInput() {
   Operator::noMoreInput();
   std::vector<ContinuePromise> promises;
   std::vector<std::shared_ptr<exec::Driver>> peers;
+  // Only last driver collects all answers.
+  // Do NOT hold GpuGuard here — allPeersFinished may set a future and return,
+  // leaving the semaphore held while waiting for peer drivers.
   if (!operatorCtx_->task()->allPeersFinished(
           planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
     return;
   }
-  // Collect host-resident batches from all peers (pointer moves, no GPU work).
+  // All peers finished — acquire GPU semaphore for hash table build.
+  GpuGuard gpuGuard;
+  // Collect results from peers
   for (auto& peer : peers) {
     auto op = peer->findOperator(planNodeId());
     auto* build = dynamic_cast<CudfHashJoinBuild*>(op);
     VELOX_CHECK_NOT_NULL(build);
-    hostInputs_.insert(
-        hostInputs_.end(),
-        std::make_move_iterator(build->hostInputs_.begin()),
-        std::make_move_iterator(build->hostInputs_.end()));
+    inputs_.insert(inputs_.end(), build->inputs_.begin(), build->inputs_.end());
   }
 
   SCOPE_EXIT {
+    // Realize the promises so that the other Drivers (which were not
+    // the last to finish) can continue from the barrier and finish.
     peers.clear();
     for (auto& promise : promises) {
       promise.setValue();
     }
   };
 
-  // Pass host-pinned batches to bridge — probe side does H2D + hash table
-  // build lazily under its own GpuGuard. Build pipeline never holds the
-  // GPU semaphore beyond the brief pack+D2H in addInput().
+  if (CudfConfig::getInstance().debugEnabled) {
+    VLOG(1) << "CudfHashJoinBuild: build batches";
+    VLOG(1) << "Build batches number of columns: "
+            << inputs_[0]->getTableView().num_columns();
+    for (auto i = 0; i < inputs_.size(); i++) {
+      VLOG(1) << "Build batch " << i
+              << ": number of rows: " << inputs_[i]->getTableView().num_rows();
+    }
+  }
+
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto tbls = getConcatenatedTableBatched(
+      inputs_, joinNode_->sources()[1]->outputType(), stream);
+  inputs_.clear();
+
+  for (auto const& tbl : tbls) {
+    VELOX_CHECK_NOT_NULL(tbl);
+  }
+  if (CudfConfig::getInstance().debugEnabled) {
+    VLOG(1) << "Build table number of columns: " << tbls[0]->num_columns();
+    for (auto i = 0; i < tbls.size(); i++) {
+      VLOG(1) << "Build table " << i
+              << ": number of rows: " << tbls[i]->num_rows();
+    }
+  }
+
+  auto buildType = joinNode_->sources()[1]->outputType();
+  auto rightKeys = joinNode_->rightKeys();
+
+  auto buildKeyIndices = std::vector<cudf::size_type>(rightKeys.size());
+  for (size_t i = 0; i < buildKeyIndices.size(); i++) {
+    buildKeyIndices[i] = static_cast<cudf::size_type>(
+        buildType->getChildIdx(rightKeys[i]->name()));
+  }
+
+  // Only need to construct hash_join object if it's an inner join, left join or
+  // right join.
+  // All other cases use a standalone function in cudf
+  bool buildHashJoin =
+      (joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
+       joinNode_->isRightJoin());
+
+  std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
+  for (auto i = 0; i < tbls.size(); i++) {
+    hashObjects.push_back(
+        (buildHashJoin) ? std::make_shared<cudf::hash_join>(
+                              tbls[i]->view().select(buildKeyIndices),
+                              cudf::null_equality::UNEQUAL,
+                              stream)
+                        : nullptr);
+    if (buildHashJoin) {
+      VELOX_CHECK_NOT_NULL(hashObjects.back());
+    }
+    if (CudfConfig::getInstance().debugEnabled) {
+      if (hashObjects.back() != nullptr) {
+        VLOG(2) << "hashObject " << i << " is not nullptr "
+                << hashObjects.back().get() << "\n";
+      } else {
+        VLOG(2) << "hashObject " << i << " is *** nullptr\n";
+      }
+    }
+  }
+
+  std::vector<std::shared_ptr<cudf::table>> shared_tbls;
+  for (auto& tbl : tbls) {
+    shared_tbls.push_back(std::move(tbl));
+  }
+  // set hash table to CudfHashJoinBridge
   auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
       operatorCtx_->driverCtx()->splitGroupId, planNodeId());
   auto cudfHashJoinBridge =
       std::dynamic_pointer_cast<CudfHashJoinBridge>(joinBridge);
-  cudfHashJoinBridge->setBuildBatches(std::move(hostInputs_));
+
+  cudfHashJoinBridge->setBuildStream(stream);
+  cudfHashJoinBridge->setHashTable(
+      std::make_optional(
+          std::make_pair(std::move(shared_tbls), std::move(hashObjects))));
 }
 
 exec::BlockingReason CudfHashJoinBuild::isBlocked(ContinueFuture* future) {
@@ -1193,11 +1120,12 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
   }
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
 
-  if (finished_) {
-    return nullptr;
-  }
-  // Need either a built hash table or pending build batches.
-  if (!hashObject_.has_value() && !buildBatches_.has_value()) {
+  // GpuGuard is NOT acquired here — it was the root cause of the Q21
+  // deadlock (semaphore held while waiting for shuffle I/O data from
+  // other tasks that themselves need the semaphore for H2D). The guard
+  // is acquired below, only after data is confirmed ready for GPU work.
+
+  if (finished_ or !hashObject_.has_value()) {
     return nullptr;
   }
 
@@ -1250,7 +1178,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
   if (!input_) {
     // If no more input, emit unmatched-right rows if needed.
     if (joinNode_->isRightJoin() && noMoreInput_ && !finished_ &&
-        isLastDriver_ && hashObject_.has_value()) {
+        isLastDriver_) {
       GpuGuard gpuGuard;
       auto& rightTables = hashObject_.value().first;
       auto stream = cudfGlobalStreamPool().get_stream();
@@ -1262,6 +1190,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
           continue;
         }
         auto& flags = rightMatchedFlags_[i];
+        // Build a boolean mask: unmatched = NOT(flags)
         auto boolMask = cudf::unary_operation(
             flags->view(), cudf::unary_operator::NOT, stream);
 
@@ -1273,7 +1202,10 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
         if (m == 0) {
           continue;
         }
+        // Build left null columns
         std::vector<std::unique_ptr<cudf::column>> outCols(outputType_->size());
+        // Left side nulls (types derive from probe schema at the matching
+        // channel indices)
         auto probeType = joinNode_->sources()[0]->outputType();
         for (int li = 0; li < leftColumnOutputIndices_.size(); ++li) {
           auto outIdx = leftColumnOutputIndices_[li];
@@ -1285,6 +1217,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
           outCols[outIdx] = cudf::make_column_from_scalar(
               *nullScalar, m, stream, cudf::get_current_device_resource_ref());
         }
+        // Right side
         auto rightCols = unmatchedRight->release();
         for (int ri = 0; ri < rightColumnOutputIndices_.size(); ++ri) {
           auto outIdx = rightColumnOutputIndices_[ri];
@@ -1311,15 +1244,10 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
     return nullptr;
   }
 
-  // Both build and probe data are ready — acquire GPU lock NOW.
-  // Lock is per-batch: held only during actual GPU compute, released when
-  // getOutput() returns. Never held while waiting for I/O.
+  // Acquire GPU semaphore now — data is ready, actual GPU join work begins.
+  // This is the Spark Rapids-style pattern: acquire before GPU compute,
+  // hold through the entire join kernel, release when getOutput() returns.
   GpuGuard gpuGuard;
-
-  // Build hash table lazily on first batch (under the same lock as probe).
-  if (!hashObject_.has_value()) {
-    buildHashTable();
-  }
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
   VELOX_CHECK_NOT_NULL(cudfInput);
@@ -1414,7 +1342,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
     return exec::BlockingReason::kWaitForJoinProbe;
   }
 
-  if (hashObject_.has_value() || buildBatches_.has_value()) {
+  if (hashObject_.has_value()) {
     return exec::BlockingReason::kNotBlocked;
   }
 
@@ -1424,21 +1352,36 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
       std::dynamic_pointer_cast<CudfHashJoinBridge>(joinBridge);
   VELOX_CHECK_NOT_NULL(cudfJoinBridge);
   VELOX_CHECK_NOT_NULL(future);
-  auto batches = cudfJoinBridge->buildBatchesOrFuture(future);
+  auto hashObject = cudfJoinBridge->hashOrFuture(future);
 
-  if (!batches.has_value()) {
-    VLOG_IF(2, CudfConfig::getInstance().debugEnabled)
-        << "CudfHashJoinProbe is blocked, waiting for join build";
+  if (!hashObject.has_value()) {
+    if (CudfConfig::getInstance().debugEnabled) {
+      VLOG(2) << "CudfHashJoinProbe is blocked, waiting for join build";
+    }
     return exec::BlockingReason::kWaitForJoinBuild;
   }
-  buildBatches_ = std::move(batches);
+  hashObject_ = std::move(hashObject);
+  buildStream_ = cudfJoinBridge->getBuildStream();
 
-  // Detect empty build from raw batch row counts (no GPU work needed).
-  int64_t totalBuildRows = 0;
-  for (auto& batch : buildBatches_.value()) {
-    totalBuildRows += batch.numRows;
+  // Lazy initialize matched flags only when build side is done
+  if (joinNode_->isRightJoin()) {
+    auto& rightTablesInit = hashObject_.value().first;
+    rightMatchedFlags_.clear();
+    rightMatchedFlags_.reserve(rightTablesInit.size());
+    auto initStream = cudfGlobalStreamPool().get_stream();
+    for (auto& rt : rightTablesInit) {
+      auto n = rt->num_rows();
+      auto false_scalar = cudf::numeric_scalar<bool>(false, true, initStream);
+      auto flags_col = cudf::make_column_from_scalar(
+          false_scalar, n, initStream, cudf::get_current_device_resource_ref());
+      rightMatchedFlags_.push_back(std::move(flags_col));
+    }
+    initStream.synchronize();
   }
-  if (totalBuildRows == 0) {
+  auto& rightTables = hashObject_.value().first;
+  // should be rightTable->numDistinct() but it needs compute,
+  // so we use num_rows()
+  if (rightTables[0]->num_rows() == 0) {
     if (skipProbeOnEmptyBuild()) {
       if (operatorCtx_->driverCtx()
               ->queryConfig()
@@ -1449,7 +1392,6 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
       }
     }
   }
-
   if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin()) &&
       future_.valid()) {
     *future = std::move(future_);
@@ -1462,9 +1404,9 @@ bool CudfHashJoinProbe::isFinished() {
   auto const isFinished = finished_ ||
       (noMoreInput_ && input_ == nullptr && accumulatedProbeInputs_.empty());
 
+  // Release hashObject_ if finished
   if (isFinished) {
     hashObject_.reset();
-    buildBatches_.reset();
   }
   return isFinished;
 }

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -17,6 +17,7 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
 #include "velox/experimental/cudf/exec/GpuGuard.h"
+#include "velox/experimental/cudf/exec/PinnedHostMemory.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
@@ -31,6 +32,7 @@
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
+#include <cudf/contiguous_split.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/groupby.hpp>
@@ -76,12 +78,10 @@ void CudfHashJoinProbe::buildHashTable() {
   VELOX_CHECK(!hashObject_.has_value());
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
 
-  auto& batches = buildBatches_.value();
+  auto& hostBatches = buildBatches_.value();
   auto buildType = joinNode_->sources()[1]->outputType();
 
-  if (batches.empty()) {
-    // Empty build side — create a 0-row table with the correct schema
-    // so probe logic can detect "0 rows" via the standard path.
+  if (hostBatches.empty()) {
     std::vector<std::unique_ptr<cudf::column>> emptyCols;
     for (int i = 0; i < buildType->size(); ++i) {
       auto cudfType = cudf::data_type{veloxToCudfTypeId(buildType->childAt(i))};
@@ -101,13 +101,39 @@ void CudfHashJoinProbe::buildHashTable() {
   auto stream = cudfGlobalStreamPool().get_stream();
   buildStream_ = stream;
 
-  auto buildType = joinNode_->sources()[1]->outputType();
   if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(1) << "CudfHashJoinProbe::buildHashTable batches=" << batches.size();
+    VLOG(1) << "CudfHashJoinProbe::buildHashTable hostBatches="
+            << hostBatches.size();
   }
 
-  auto tbls = getConcatenatedTableBatched(batches, buildType, stream);
+  // H2D: copy each host-pinned batch back to GPU and reconstruct CudfVectors.
+  std::vector<CudfVectorPtr> gpuBatches;
+  gpuBatches.reserve(hostBatches.size());
+  for (auto& hb : hostBatches) {
+    rmm::device_buffer devBuf(hb.data->size(), stream);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        devBuf.data(),
+        hb.data->data(),
+        hb.data->size(),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+    auto metadata = std::make_unique<std::vector<uint8_t>>(
+        std::move(hb.metadata));
+    cudf::packed_columns pc{std::move(metadata),
+                            std::make_unique<rmm::device_buffer>(
+                                std::move(devBuf))};
+    auto unpacked = std::make_unique<cudf::packed_table>(cudf::unpack(pc));
+    auto numRows = hb.numRows;
+    gpuBatches.push_back(std::make_shared<CudfVector>(
+        operatorCtx_->pool(),
+        buildType,
+        numRows,
+        std::move(unpacked),
+        stream));
+  }
   buildBatches_.reset();
+
+  auto tbls = getConcatenatedTableBatched(gpuBatches, buildType, stream);
 
   for (auto const& tbl : tbls) {
     VELOX_CHECK_NOT_NULL(tbl);
@@ -157,7 +183,8 @@ void CudfHashJoinProbe::buildHashTable() {
   }
 }
 
-void CudfHashJoinBridge::setBuildBatches(std::vector<CudfVectorPtr> batches) {
+void CudfHashJoinBridge::setBuildBatches(
+    std::vector<HostBuildBatch> batches) {
   VLOG_IF(2, CudfConfig::getInstance().debugEnabled)
       << "CudfHashJoinBridge::setBuildBatches  batches=" << batches.size();
   std::vector<ContinuePromise> promises;
@@ -172,7 +199,7 @@ void CudfHashJoinBridge::setBuildBatches(std::vector<CudfVectorPtr> batches) {
   notify(std::move(promises));
 }
 
-std::optional<std::vector<CudfVectorPtr>>
+std::optional<std::vector<HostBuildBatch>>
 CudfHashJoinBridge::buildBatchesOrFuture(ContinueFuture* future) {
   VLOG_IF(2, CudfConfig::getInstance().debugEnabled)
       << "CudfHashJoinBridge::buildBatchesOrFuture";
@@ -210,12 +237,32 @@ void CudfHashJoinBuild::addInput(RowVectorPtr input) {
   if (CudfConfig::getInstance().debugEnabled) {
     VLOG(2) << "Calling CudfHashJoinBuild::addInput";
   }
-  // Queue inputs, process all at once.
-  if (input->size() > 0) {
-    auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
-    VELOX_CHECK_NOT_NULL(cudfInput);
-    inputs_.push_back(std::move(cudfInput));
+  if (input->size() == 0) {
+    return;
   }
+  auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
+  VELOX_CHECK_NOT_NULL(cudfInput);
+
+  auto stream = cudfInput->stream();
+
+  // Pack GPU table into one contiguous device buffer, then D2H to pinned
+  // host memory. This frees GPU memory immediately — the bridge holds only
+  // host-resident data, so build accumulation consumes zero GPU memory.
+  GpuGuard gpuGuard;
+  auto packed = cudf::pack(cudfInput->getTableView(), stream);
+  auto devSize = packed.gpu_data->size();
+  auto hostBuf = std::make_shared<PinnedHostBuffer>(devSize);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      hostBuf->data(),
+      packed.gpu_data->data(),
+      devSize,
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+  stream.synchronize();
+
+  auto numRows = static_cast<vector_size_t>(cudfInput->size());
+  hostInputs_.push_back(
+      {std::move(*packed.metadata), std::move(hostBuf), numRows});
 }
 
 bool CudfHashJoinBuild::needsInput() const {
@@ -241,12 +288,15 @@ void CudfHashJoinBuild::noMoreInput() {
           planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
     return;
   }
-  // Collect batches from all peers (CPU pointer moves, no GPU work).
+  // Collect host-resident batches from all peers (pointer moves, no GPU work).
   for (auto& peer : peers) {
     auto op = peer->findOperator(planNodeId());
     auto* build = dynamic_cast<CudfHashJoinBuild*>(op);
     VELOX_CHECK_NOT_NULL(build);
-    inputs_.insert(inputs_.end(), build->inputs_.begin(), build->inputs_.end());
+    hostInputs_.insert(
+        hostInputs_.end(),
+        std::make_move_iterator(build->hostInputs_.begin()),
+        std::make_move_iterator(build->hostInputs_.end()));
   }
 
   SCOPE_EXIT {
@@ -256,14 +306,14 @@ void CudfHashJoinBuild::noMoreInput() {
     }
   };
 
-  // Pass raw batches to bridge — the probe side builds the hash table
-  // lazily under its own GpuGuard, so the build pipeline does no GPU work
-  // and never acquires the GPU semaphore.
+  // Pass host-pinned batches to bridge — probe side does H2D + hash table
+  // build lazily under its own GpuGuard. Build pipeline never holds the
+  // GPU semaphore beyond the brief pack+D2H in addInput().
   auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
       operatorCtx_->driverCtx()->splitGroupId, planNodeId());
   auto cudfHashJoinBridge =
       std::dynamic_pointer_cast<CudfHashJoinBridge>(joinBridge);
-  cudfHashJoinBridge->setBuildBatches(std::move(inputs_));
+  cudfHashJoinBridge->setBuildBatches(std::move(hostInputs_));
 }
 
 exec::BlockingReason CudfHashJoinBuild::isBlocked(ContinueFuture* future) {
@@ -1351,7 +1401,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
   // Detect empty build from raw batch row counts (no GPU work needed).
   int64_t totalBuildRows = 0;
   for (auto& batch : buildBatches_.value()) {
-    totalBuildRows += batch->size();
+    totalBuildRows += batch.numRows;
   }
   if (totalBuildRows == 0) {
     if (skipProbeOnEmptyBuild()) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -24,6 +24,7 @@
 #include "velox/experimental/cudf/expression/AstExpression.h"
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
 
+#include "velox/common/base/SuccinctPrinter.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h" // NOLINT(misc-unused-headers)
 #include "velox/type/TypeUtil.h"
@@ -101,6 +102,15 @@ void CudfHashJoinProbe::buildHashTable() {
   auto stream = cudfGlobalStreamPool().get_stream();
   buildStream_ = stream;
 
+  size_t totalHostBytes = 0;
+  for (auto& hb : hostBatches) {
+    totalHostBytes += hb.data->size();
+  }
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [buildHashTable-pre-H2D] "
+               << gpuMemorySnapshotString()
+               << " hostBatches=" << hostBatches.size()
+               << " totalHostBytes=" << succinctBytes(totalHostBytes);
+
   if (CudfConfig::getInstance().debugEnabled) {
     VLOG(1) << "CudfHashJoinProbe::buildHashTable hostBatches="
             << hostBatches.size();
@@ -132,8 +142,17 @@ void CudfHashJoinProbe::buildHashTable() {
         stream));
   }
   buildBatches_.reset();
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [buildHashTable-post-H2D] "
+               << gpuMemorySnapshotString()
+               << " gpuBatches=" << gpuBatches.size()
+               << " (all build data now on GPU, about to concatenate)";
 
   auto tbls = getConcatenatedTableBatched(gpuBatches, buildType, stream);
+  // Release individual GPU batches immediately — the concatenated tables in
+  // `tbls` own all the data now. Without this, both gpuBatches (~N bytes)
+  // and tbls (~N bytes) coexist on GPU during hash_join construction,
+  // doubling peak memory vs v4 which cleared inputs_ here.
+  gpuBatches.clear();
 
   for (auto const& tbl : tbls) {
     VELOX_CHECK_NOT_NULL(tbl);
@@ -167,6 +186,9 @@ void CudfHashJoinProbe::buildHashTable() {
 
   hashObject_ = std::make_pair(
       std::move(shared_tbls), std::move(hashObjects));
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [buildHashTable-post-build] "
+               << gpuMemorySnapshotString()
+               << " (hash table built, concatenated tables + hash objects on GPU)";
 
   // Initialize right-join matched flags under the same GpuGuard.
   if (joinNode_->isRightJoin()) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -246,9 +246,9 @@ void CudfHashJoinBuild::addInput(RowVectorPtr input) {
   auto stream = cudfInput->stream();
 
   // Pack GPU table into one contiguous device buffer, then D2H to pinned
-  // host memory. This frees GPU memory immediately — the bridge holds only
-  // host-resident data, so build accumulation consumes zero GPU memory.
-  GpuGuard gpuGuard;
+  // host memory. No GpuGuard here — the data is already on GPU from the
+  // upstream operator, and the net effect is freeing GPU memory. Skipping
+  // the semaphore allows parallel D2H across tasks for faster cleanup.
   auto packed = cudf::pack(cudfInput->getTableView(), stream);
   auto devSize = packed.gpu_data->size();
   auto hostBuf = std::make_shared<PinnedHostBuffer>(devSize);

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -62,10 +62,6 @@ void CudfHashJoinProbe::close() {
   }
   hashObject_.reset();
   buildBatches_.reset();
-  if (gpuSlotHeld_) {
-    gluten::unlockGpu();
-    gpuSlotHeld_ = false;
-  }
   Operator::close();
   filterEvaluator_.reset();
   scalars_.clear();
@@ -1112,18 +1108,11 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
   }
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
 
-  // Lazily build hash table on first getOutput() call. This runs under an
-  // operator-level GpuGuard that stays held until close()/isFinished(),
-  // protecting the hash table's GPU memory for the probe's lifetime.
-  if (!hashObject_.has_value() && buildBatches_.has_value()) {
-    if (!gpuSlotHeld_) {
-      gluten::lockGpu();
-      gpuSlotHeld_ = true;
-    }
-    buildHashTable();
+  if (finished_) {
+    return nullptr;
   }
-
-  if (finished_ || !hashObject_.has_value()) {
+  // Need either a built hash table or pending build batches.
+  if (!hashObject_.has_value() && !buildBatches_.has_value()) {
     return nullptr;
   }
 
@@ -1188,7 +1177,6 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
           continue;
         }
         auto& flags = rightMatchedFlags_[i];
-        // Build a boolean mask: unmatched = NOT(flags)
         auto boolMask = cudf::unary_operation(
             flags->view(), cudf::unary_operator::NOT, stream);
 
@@ -1200,10 +1188,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
         if (m == 0) {
           continue;
         }
-        // Build left null columns
         std::vector<std::unique_ptr<cudf::column>> outCols(outputType_->size());
-        // Left side nulls (types derive from probe schema at the matching
-        // channel indices)
         auto probeType = joinNode_->sources()[0]->outputType();
         for (int li = 0; li < leftColumnOutputIndices_.size(); ++li) {
           auto outIdx = leftColumnOutputIndices_[li];
@@ -1215,7 +1200,6 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
           outCols[outIdx] = cudf::make_column_from_scalar(
               *nullScalar, m, stream, cudf::get_current_device_resource_ref());
         }
-        // Right side
         auto rightCols = unmatchedRight->release();
         for (int ri = 0; ri < rightColumnOutputIndices_.size(); ++ri) {
           auto outIdx = rightColumnOutputIndices_[ri];
@@ -1242,8 +1226,15 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
     return nullptr;
   }
 
-  // Re-entrant: operator-level lock is already held (gpuSlotHeld_).
+  // Both build and probe data are ready — acquire GPU lock NOW.
+  // Lock is per-batch: held only during actual GPU compute, released when
+  // getOutput() returns. Never held while waiting for I/O.
   GpuGuard gpuGuard;
+
+  // Build hash table lazily on first batch (under the same lock as probe).
+  if (!hashObject_.has_value()) {
+    buildHashTable();
+  }
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
   VELOX_CHECK_NOT_NULL(cudfInput);
@@ -1389,10 +1380,6 @@ bool CudfHashJoinProbe::isFinished() {
   if (isFinished) {
     hashObject_.reset();
     buildBatches_.reset();
-    if (gpuSlotHeld_) {
-      gluten::unlockGpu();
-      gpuSlotHeld_ = false;
-    }
   }
   return isFinished;
 }

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -60,6 +60,12 @@ void CudfHashJoinProbe::close() {
         kGpuComputeNanos,
         RuntimeCounter(gpuNs, RuntimeCounter::Unit::kNanos));
   }
+  hashObject_.reset();
+  buildBatches_.reset();
+  if (gpuSlotHeld_) {
+    gluten::unlockGpu();
+    gpuSlotHeld_ = false;
+  }
   Operator::close();
   filterEvaluator_.reset();
   scalars_.clear();
@@ -69,54 +75,118 @@ void CudfHashJoinProbe::close() {
   accumulatedProbeBytes_ = 0;
 }
 
-void CudfHashJoinBridge::setHashTable(
-    std::optional<CudfHashJoinBridge::hash_type> hashObject) {
-  if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(2) << "Calling CudfHashJoinBridge::setHashTable";
+void CudfHashJoinProbe::buildHashTable() {
+  VELOX_CHECK(buildBatches_.has_value());
+  VELOX_CHECK(!hashObject_.has_value());
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
+
+  auto& batches = buildBatches_.value();
+  auto buildType = joinNode_->sources()[1]->outputType();
+
+  if (batches.empty()) {
+    // Empty build side — create a 0-row table with the correct schema
+    // so probe logic can detect "0 rows" via the standard path.
+    std::vector<std::unique_ptr<cudf::column>> emptyCols;
+    for (int i = 0; i < buildType->size(); ++i) {
+      auto cudfType = cudf::data_type{veloxToCudfTypeId(buildType->childAt(i))};
+      emptyCols.push_back(cudf::make_empty_column(cudfType));
+    }
+    auto emptyTbl = std::make_unique<cudf::table>(std::move(emptyCols));
+    std::vector<std::shared_ptr<cudf::table>> emptyTbls;
+    emptyTbls.push_back(std::move(emptyTbl));
+    std::vector<std::shared_ptr<cudf::hash_join>> emptyHashObjs;
+    emptyHashObjs.push_back(nullptr);
+    hashObject_ = std::make_pair(
+        std::move(emptyTbls), std::move(emptyHashObjs));
+    buildBatches_.reset();
+    return;
   }
+
+  auto stream = cudfGlobalStreamPool().get_stream();
+  buildStream_ = stream;
+
+  auto buildType = joinNode_->sources()[1]->outputType();
+  if (CudfConfig::getInstance().debugEnabled) {
+    VLOG(1) << "CudfHashJoinProbe::buildHashTable batches=" << batches.size();
+  }
+
+  auto tbls = getConcatenatedTableBatched(batches, buildType, stream);
+  buildBatches_.reset();
+
+  for (auto const& tbl : tbls) {
+    VELOX_CHECK_NOT_NULL(tbl);
+  }
+
+  auto rightKeys = joinNode_->rightKeys();
+  auto buildKeyIndices = std::vector<cudf::size_type>(rightKeys.size());
+  for (size_t i = 0; i < buildKeyIndices.size(); i++) {
+    buildKeyIndices[i] = static_cast<cudf::size_type>(
+        buildType->getChildIdx(rightKeys[i]->name()));
+  }
+
+  bool needsHashJoin =
+      (joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
+       joinNode_->isRightJoin());
+
+  std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
+  for (size_t i = 0; i < tbls.size(); i++) {
+    hashObjects.push_back(
+        needsHashJoin ? std::make_shared<cudf::hash_join>(
+                            tbls[i]->view().select(buildKeyIndices),
+                            cudf::null_equality::UNEQUAL,
+                            stream)
+                      : nullptr);
+  }
+
+  std::vector<std::shared_ptr<cudf::table>> shared_tbls;
+  for (auto& tbl : tbls) {
+    shared_tbls.push_back(std::move(tbl));
+  }
+
+  hashObject_ = std::make_pair(
+      std::move(shared_tbls), std::move(hashObjects));
+
+  // Initialize right-join matched flags under the same GpuGuard.
+  if (joinNode_->isRightJoin()) {
+    auto& rightTables = hashObject_.value().first;
+    rightMatchedFlags_.clear();
+    rightMatchedFlags_.reserve(rightTables.size());
+    for (auto& rt : rightTables) {
+      auto n = rt->num_rows();
+      auto false_scalar = cudf::numeric_scalar<bool>(false, true, stream);
+      auto flags_col = cudf::make_column_from_scalar(
+          false_scalar, n, stream, cudf::get_current_device_resource_ref());
+      rightMatchedFlags_.push_back(std::move(flags_col));
+    }
+  }
+}
+
+void CudfHashJoinBridge::setBuildBatches(std::vector<CudfVectorPtr> batches) {
+  VLOG_IF(2, CudfConfig::getInstance().debugEnabled)
+      << "CudfHashJoinBridge::setBuildBatches  batches=" << batches.size();
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
     VELOX_CHECK(
-        !hashObject_.has_value(),
-        "CudfHashJoinBridge already has a hash table");
-    hashObject_ = std::move(hashObject);
+        !buildBatches_.has_value(),
+        "setBuildBatches may be called only once");
+    buildBatches_ = std::move(batches);
     promises = std::move(promises_);
   }
   notify(std::move(promises));
 }
 
-std::optional<CudfHashJoinBridge::hash_type> CudfHashJoinBridge::hashOrFuture(
-    ContinueFuture* future) {
-  if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(2) << "Calling CudfHashJoinBridge::hashOrFuture";
-  }
+std::optional<std::vector<CudfVectorPtr>>
+CudfHashJoinBridge::buildBatchesOrFuture(ContinueFuture* future) {
+  VLOG_IF(2, CudfConfig::getInstance().debugEnabled)
+      << "CudfHashJoinBridge::buildBatchesOrFuture";
   std::lock_guard<std::mutex> l(mutex_);
-  if (hashObject_.has_value()) {
-    return hashObject_;
+  if (buildBatches_.has_value()) {
+    return std::move(buildBatches_);
   }
-  if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(2) << "Calling CudfHashJoinBridge::hashOrFuture constructing promise";
-  }
-  promises_.emplace_back("CudfHashJoinBridge::hashOrFuture");
-  if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(2) << "Calling CudfHashJoinBridge::hashOrFuture getSemiFuture";
-  }
+  promises_.emplace_back("CudfHashJoinBridge::buildBatchesOrFuture");
   *future = promises_.back().getSemiFuture();
-  if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(2) << "Calling CudfHashJoinBridge::hashOrFuture returning nullopt";
-  }
   return std::nullopt;
-}
-
-void CudfHashJoinBridge::setBuildStream(rmm::cuda_stream_view buildStream) {
-  std::lock_guard<std::mutex> l(mutex_);
-  buildStream_ = buildStream;
-}
-
-std::optional<rmm::cuda_stream_view> CudfHashJoinBridge::getBuildStream() {
-  std::lock_guard<std::mutex> l(mutex_);
-  return buildStream_;
 }
 
 CudfHashJoinBuild::CudfHashJoinBuild(
@@ -171,16 +241,11 @@ void CudfHashJoinBuild::noMoreInput() {
   Operator::noMoreInput();
   std::vector<ContinuePromise> promises;
   std::vector<std::shared_ptr<exec::Driver>> peers;
-  // Only last driver collects all answers.
-  // Do NOT hold GpuGuard here — allPeersFinished may set a future and return,
-  // leaving the semaphore held while waiting for peer drivers.
   if (!operatorCtx_->task()->allPeersFinished(
           planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
     return;
   }
-  // All peers finished — acquire GPU semaphore for hash table build.
-  GpuGuard gpuGuard;
-  // Collect results from peers
+  // Collect batches from all peers (CPU pointer moves, no GPU work).
   for (auto& peer : peers) {
     auto op = peer->findOperator(planNodeId());
     auto* build = dynamic_cast<CudfHashJoinBuild*>(op);
@@ -189,91 +254,20 @@ void CudfHashJoinBuild::noMoreInput() {
   }
 
   SCOPE_EXIT {
-    // Realize the promises so that the other Drivers (which were not
-    // the last to finish) can continue from the barrier and finish.
     peers.clear();
     for (auto& promise : promises) {
       promise.setValue();
     }
   };
 
-  if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(1) << "CudfHashJoinBuild: build batches";
-    VLOG(1) << "Build batches number of columns: "
-            << inputs_[0]->getTableView().num_columns();
-    for (auto i = 0; i < inputs_.size(); i++) {
-      VLOG(1) << "Build batch " << i
-              << ": number of rows: " << inputs_[i]->getTableView().num_rows();
-    }
-  }
-
-  auto stream = cudfGlobalStreamPool().get_stream();
-  auto tbls = getConcatenatedTableBatched(
-      inputs_, joinNode_->sources()[1]->outputType(), stream);
-  inputs_.clear();
-
-  for (auto const& tbl : tbls) {
-    VELOX_CHECK_NOT_NULL(tbl);
-  }
-  if (CudfConfig::getInstance().debugEnabled) {
-    VLOG(1) << "Build table number of columns: " << tbls[0]->num_columns();
-    for (auto i = 0; i < tbls.size(); i++) {
-      VLOG(1) << "Build table " << i
-              << ": number of rows: " << tbls[i]->num_rows();
-    }
-  }
-
-  auto buildType = joinNode_->sources()[1]->outputType();
-  auto rightKeys = joinNode_->rightKeys();
-
-  auto buildKeyIndices = std::vector<cudf::size_type>(rightKeys.size());
-  for (size_t i = 0; i < buildKeyIndices.size(); i++) {
-    buildKeyIndices[i] = static_cast<cudf::size_type>(
-        buildType->getChildIdx(rightKeys[i]->name()));
-  }
-
-  // Only need to construct hash_join object if it's an inner join, left join or
-  // right join.
-  // All other cases use a standalone function in cudf
-  bool buildHashJoin =
-      (joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
-       joinNode_->isRightJoin());
-
-  std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
-  for (auto i = 0; i < tbls.size(); i++) {
-    hashObjects.push_back(
-        (buildHashJoin) ? std::make_shared<cudf::hash_join>(
-                              tbls[i]->view().select(buildKeyIndices),
-                              cudf::null_equality::UNEQUAL,
-                              stream)
-                        : nullptr);
-    if (buildHashJoin) {
-      VELOX_CHECK_NOT_NULL(hashObjects.back());
-    }
-    if (CudfConfig::getInstance().debugEnabled) {
-      if (hashObjects.back() != nullptr) {
-        VLOG(2) << "hashObject " << i << " is not nullptr "
-                << hashObjects.back().get() << "\n";
-      } else {
-        VLOG(2) << "hashObject " << i << " is *** nullptr\n";
-      }
-    }
-  }
-
-  std::vector<std::shared_ptr<cudf::table>> shared_tbls;
-  for (auto& tbl : tbls) {
-    shared_tbls.push_back(std::move(tbl));
-  }
-  // set hash table to CudfHashJoinBridge
+  // Pass raw batches to bridge — the probe side builds the hash table
+  // lazily under its own GpuGuard, so the build pipeline does no GPU work
+  // and never acquires the GPU semaphore.
   auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
       operatorCtx_->driverCtx()->splitGroupId, planNodeId());
   auto cudfHashJoinBridge =
       std::dynamic_pointer_cast<CudfHashJoinBridge>(joinBridge);
-
-  cudfHashJoinBridge->setBuildStream(stream);
-  cudfHashJoinBridge->setHashTable(
-      std::make_optional(
-          std::make_pair(std::move(shared_tbls), std::move(hashObjects))));
+  cudfHashJoinBridge->setBuildBatches(std::move(inputs_));
 }
 
 exec::BlockingReason CudfHashJoinBuild::isBlocked(ContinueFuture* future) {
@@ -1118,12 +1112,18 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
   }
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
 
-  // GpuGuard is NOT acquired here — it was the root cause of the Q21
-  // deadlock (semaphore held while waiting for shuffle I/O data from
-  // other tasks that themselves need the semaphore for H2D). The guard
-  // is acquired below, only after data is confirmed ready for GPU work.
+  // Lazily build hash table on first getOutput() call. This runs under an
+  // operator-level GpuGuard that stays held until close()/isFinished(),
+  // protecting the hash table's GPU memory for the probe's lifetime.
+  if (!hashObject_.has_value() && buildBatches_.has_value()) {
+    if (!gpuSlotHeld_) {
+      gluten::lockGpu();
+      gpuSlotHeld_ = true;
+    }
+    buildHashTable();
+  }
 
-  if (finished_ or !hashObject_.has_value()) {
+  if (finished_ || !hashObject_.has_value()) {
     return nullptr;
   }
 
@@ -1176,7 +1176,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
   if (!input_) {
     // If no more input, emit unmatched-right rows if needed.
     if (joinNode_->isRightJoin() && noMoreInput_ && !finished_ &&
-        isLastDriver_) {
+        isLastDriver_ && hashObject_.has_value()) {
       GpuGuard gpuGuard;
       auto& rightTables = hashObject_.value().first;
       auto stream = cudfGlobalStreamPool().get_stream();
@@ -1242,9 +1242,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
     return nullptr;
   }
 
-  // Acquire GPU semaphore now — data is ready, actual GPU join work begins.
-  // This is the Spark Rapids-style pattern: acquire before GPU compute,
-  // hold through the entire join kernel, release when getOutput() returns.
+  // Re-entrant: operator-level lock is already held (gpuSlotHeld_).
   GpuGuard gpuGuard;
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
@@ -1340,7 +1338,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
     return exec::BlockingReason::kWaitForJoinProbe;
   }
 
-  if (hashObject_.has_value()) {
+  if (hashObject_.has_value() || buildBatches_.has_value()) {
     return exec::BlockingReason::kNotBlocked;
   }
 
@@ -1350,36 +1348,21 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
       std::dynamic_pointer_cast<CudfHashJoinBridge>(joinBridge);
   VELOX_CHECK_NOT_NULL(cudfJoinBridge);
   VELOX_CHECK_NOT_NULL(future);
-  auto hashObject = cudfJoinBridge->hashOrFuture(future);
+  auto batches = cudfJoinBridge->buildBatchesOrFuture(future);
 
-  if (!hashObject.has_value()) {
-    if (CudfConfig::getInstance().debugEnabled) {
-      VLOG(2) << "CudfHashJoinProbe is blocked, waiting for join build";
-    }
+  if (!batches.has_value()) {
+    VLOG_IF(2, CudfConfig::getInstance().debugEnabled)
+        << "CudfHashJoinProbe is blocked, waiting for join build";
     return exec::BlockingReason::kWaitForJoinBuild;
   }
-  hashObject_ = std::move(hashObject);
-  buildStream_ = cudfJoinBridge->getBuildStream();
+  buildBatches_ = std::move(batches);
 
-  // Lazy initialize matched flags only when build side is done
-  if (joinNode_->isRightJoin()) {
-    auto& rightTablesInit = hashObject_.value().first;
-    rightMatchedFlags_.clear();
-    rightMatchedFlags_.reserve(rightTablesInit.size());
-    auto initStream = cudfGlobalStreamPool().get_stream();
-    for (auto& rt : rightTablesInit) {
-      auto n = rt->num_rows();
-      auto false_scalar = cudf::numeric_scalar<bool>(false, true, initStream);
-      auto flags_col = cudf::make_column_from_scalar(
-          false_scalar, n, initStream, cudf::get_current_device_resource_ref());
-      rightMatchedFlags_.push_back(std::move(flags_col));
-    }
-    initStream.synchronize();
+  // Detect empty build from raw batch row counts (no GPU work needed).
+  int64_t totalBuildRows = 0;
+  for (auto& batch : buildBatches_.value()) {
+    totalBuildRows += batch->size();
   }
-  auto& rightTables = hashObject_.value().first;
-  // should be rightTable->numDistinct() but it needs compute,
-  // so we use num_rows()
-  if (rightTables[0]->num_rows() == 0) {
+  if (totalBuildRows == 0) {
     if (skipProbeOnEmptyBuild()) {
       if (operatorCtx_->driverCtx()
               ->queryConfig()
@@ -1390,6 +1373,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
       }
     }
   }
+
   if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin()) &&
       future_.valid()) {
     *future = std::move(future_);
@@ -1402,9 +1386,13 @@ bool CudfHashJoinProbe::isFinished() {
   auto const isFinished = finished_ ||
       (noMoreInput_ && input_ == nullptr && accumulatedProbeInputs_.empty());
 
-  // Release hashObject_ if finished
   if (isFinished) {
     hashObject_.reset();
+    buildBatches_.reset();
+    if (gpuSlotHeld_) {
+      gluten::unlockGpu();
+      gpuSlotHeld_ = false;
+    }
   }
   return isFinished;
 }

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -61,7 +61,6 @@ void CudfHashJoinProbe::close() {
         RuntimeCounter(gpuNs, RuntimeCounter::Unit::kNanos));
   }
   hashObject_.reset();
-  buildBatches_.reset();
   Operator::close();
   filterEvaluator_.reset();
   scalars_.clear();

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -168,15 +168,18 @@ void CudfHashJoinBuild::noMoreInput() {
     VLOG(2) << "Calling CudfHashJoinBuild::noMoreInput";
   }
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
-  GpuGuard gpuGuard;
   Operator::noMoreInput();
   std::vector<ContinuePromise> promises;
   std::vector<std::shared_ptr<exec::Driver>> peers;
-  // Only last driver collects all answers
+  // Only last driver collects all answers.
+  // Do NOT hold GpuGuard here — allPeersFinished may set a future and return,
+  // leaving the semaphore held while waiting for peer drivers.
   if (!operatorCtx_->task()->allPeersFinished(
           planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
     return;
   }
+  // All peers finished — acquire GPU semaphore for hash table build.
+  GpuGuard gpuGuard;
   // Collect results from peers
   for (auto& peer : peers) {
     auto op = peer->findOperator(planNodeId());
@@ -1114,7 +1117,11 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
     VLOG(2) << "Calling CudfHashJoinProbe::getOutput";
   }
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
-  GpuGuard gpuGuard;
+
+  // GpuGuard is NOT acquired here — it was the root cause of the Q21
+  // deadlock (semaphore held while waiting for shuffle I/O data from
+  // other tasks that themselves need the semaphore for H2D). The guard
+  // is acquired below, only after data is confirmed ready for GPU work.
 
   if (finished_ or !hashObject_.has_value()) {
     return nullptr;
@@ -1170,6 +1177,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
     // If no more input, emit unmatched-right rows if needed.
     if (joinNode_->isRightJoin() && noMoreInput_ && !finished_ &&
         isLastDriver_) {
+      GpuGuard gpuGuard;
       auto& rightTables = hashObject_.value().first;
       auto stream = cudfGlobalStreamPool().get_stream();
       std::vector<std::unique_ptr<cudf::table>> toConcat;
@@ -1233,6 +1241,11 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
     }
     return nullptr;
   }
+
+  // Acquire GPU semaphore now — data is ready, actual GPU join work begins.
+  // This is the Spark Rapids-style pattern: acquire before GPU compute,
+  // hold through the entire join kernel, release when getOutput() returns.
+  GpuGuard gpuGuard;
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
   VELOX_CHECK_NOT_NULL(cudfInput);

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -53,6 +53,8 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+#include <iostream>
+
 namespace facebook::velox::cudf_velox {
 
 void CudfHashJoinProbe::close() {
@@ -106,10 +108,11 @@ void CudfHashJoinProbe::buildHashTable() {
   for (auto& hb : hostBatches) {
     totalHostBytes += hb.data->size();
   }
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [buildHashTable-pre-H2D] "
+  std::cerr << "GPU_MEM_SNAPSHOT [buildHashTable-pre-H2D] "
                << gpuMemorySnapshotString()
                << " hostBatches=" << hostBatches.size()
-               << " totalHostBytes=" << succinctBytes(totalHostBytes);
+               << " totalHostBytes=" << succinctBytes(totalHostBytes)
+               << std::endl;
 
   if (CudfConfig::getInstance().debugEnabled) {
     VLOG(1) << "CudfHashJoinProbe::buildHashTable hostBatches="
@@ -142,10 +145,11 @@ void CudfHashJoinProbe::buildHashTable() {
         stream));
   }
   buildBatches_.reset();
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [buildHashTable-post-H2D] "
+  std::cerr << "GPU_MEM_SNAPSHOT [buildHashTable-post-H2D] "
                << gpuMemorySnapshotString()
                << " gpuBatches=" << gpuBatches.size()
-               << " (all build data now on GPU, about to concatenate)";
+               << " (all build data now on GPU, about to concatenate)"
+               << std::endl;
 
   auto tbls = getConcatenatedTableBatched(gpuBatches, buildType, stream);
   // Release individual GPU batches immediately — the concatenated tables in
@@ -186,9 +190,10 @@ void CudfHashJoinProbe::buildHashTable() {
 
   hashObject_ = std::make_pair(
       std::move(shared_tbls), std::move(hashObjects));
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [buildHashTable-post-build] "
+  std::cerr << "GPU_MEM_SNAPSHOT [buildHashTable-post-build] "
                << gpuMemorySnapshotString()
-               << " (hash table built, concatenated tables + hash objects on GPU)";
+               << " (hash table built, concatenated tables + hash objects on GPU)"
+               << std::endl;
 
   // Initialize right-join matched flags under the same GpuGuard.
   if (joinNode_->isRightJoin()) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -245,10 +245,8 @@ void CudfHashJoinBuild::addInput(RowVectorPtr input) {
 
   auto stream = cudfInput->stream();
 
-  // Pack GPU table into one contiguous device buffer, then D2H to pinned
-  // host memory. No GpuGuard here — the data is already on GPU from the
-  // upstream operator, and the net effect is freeing GPU memory. Skipping
-  // the semaphore allows parallel D2H across tasks for faster cleanup.
+  // D2H: pack into contiguous device buffer, copy to pinned host memory.
+  // Runs under the GPU region started by the source operator (scan).
   auto packed = cudf::pack(cudfInput->getTableView(), stream);
   auto devSize = packed.gpu_data->size();
   auto hostBuf = std::make_shared<PinnedHostBuffer>(devSize);
@@ -263,6 +261,10 @@ void CudfHashJoinBuild::addInput(RowVectorPtr input) {
   auto numRows = static_cast<vector_size_t>(cudfInput->size());
   hostInputs_.push_back(
       {std::move(*packed.metadata), std::move(hostBuf), numRows});
+
+  // D2H complete — end the GPU region started by the source operator.
+  // All GPU data for this batch is now on host; semaphore released.
+  endGpuRegion();
 }
 
 bool CudfHashJoinBuild::needsInput() const {

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -38,6 +38,16 @@ namespace facebook::velox::cudf_velox {
 
 class CudaEvent;
 class CudfExpression;
+class PinnedHostBuffer;
+
+/// Build-side batch stored in pinned host memory (not GPU).
+/// Created by Build::addInput() via cudf::pack() + D2H.
+/// Consumed by Probe::buildHashTable() via H2D + cudf::unpack().
+struct HostBuildBatch {
+  std::vector<uint8_t> metadata;
+  std::shared_ptr<PinnedHostBuffer> data;
+  vector_size_t numRows;
+};
 
 /**
  * @brief Bridge for transferring build-side hash tables between build and probe
@@ -60,17 +70,17 @@ class CudfHashJoinBridge : public exec::JoinBridge {
       std::vector<std::shared_ptr<cudf::table>>,
       std::vector<std::shared_ptr<cudf::hash_join>>>;
 
-  /// Set raw build-side batches. The hash table is built lazily on the
-  /// probe side under its GpuGuard, so the build pipeline does no GPU work.
-  void setBuildBatches(std::vector<CudfVectorPtr> batches);
+  /// Set build-side batches (host pinned memory). The hash table is built
+  /// lazily on the probe side under its GpuGuard via H2D + unpack.
+  void setBuildBatches(std::vector<HostBuildBatch> batches);
 
-  /// Get the raw build batches, or register a future to be notified when
+  /// Get the build batches, or register a future to be notified when
   /// they become available.
-  std::optional<std::vector<CudfVectorPtr>> buildBatchesOrFuture(
+  std::optional<std::vector<HostBuildBatch>> buildBatchesOrFuture(
       ContinueFuture* future);
 
  private:
-  std::optional<std::vector<CudfVectorPtr>> buildBatches_;
+  std::optional<std::vector<HostBuildBatch>> buildBatches_;
 };
 
 /**
@@ -104,7 +114,7 @@ class CudfHashJoinBuild : public exec::Operator, public NvtxHelper {
 
  private:
   std::shared_ptr<const core::HashJoinNode> joinNode_;
-  std::vector<CudfVectorPtr> inputs_;
+  std::vector<HostBuildBatch> hostInputs_;
   ContinueFuture future_{ContinueFuture::makeEmpty()};
 };
 
@@ -205,9 +215,9 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   // hanging problem at the producer side caused by the early query finish.
   bool skipInput_{false};
 
-  /// Raw build-side batches received from the bridge, consumed once by
-  /// buildHashTable() to construct hashObject_.
-  std::optional<std::vector<CudfVectorPtr>> buildBatches_;
+  /// Build-side batches in pinned host memory, received from the bridge.
+  /// Consumed once by buildHashTable() (H2D + unpack + hash_join build).
+  std::optional<std::vector<HostBuildBatch>> buildBatches_;
 
   /** @brief CUDA stream used during hash table construction */
   std::optional<rmm::cuda_stream_view> buildStream_;

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -213,9 +213,6 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   std::optional<rmm::cuda_stream_view> buildStream_;
   /** @brief CUDA event for coordinating stream synchronization */
   std::unique_ptr<CudaEvent> cudaEvent_;
-  /** @brief True when this probe holds an operator-level GPU semaphore slot
-   * (from buildHashTable through close). */
-  bool gpuSlotHeld_{false};
 
   // Streaming right join state
   // Per-build-table flags indicating whether a build row has had at least one

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -38,16 +38,6 @@ namespace facebook::velox::cudf_velox {
 
 class CudaEvent;
 class CudfExpression;
-class PinnedHostBuffer;
-
-/// Build-side batch stored in pinned host memory (not GPU).
-/// Created by Build::addInput() via cudf::pack() + D2H.
-/// Consumed by Probe::buildHashTable() via H2D + cudf::unpack().
-struct HostBuildBatch {
-  std::vector<uint8_t> metadata;
-  std::shared_ptr<PinnedHostBuffer> data;
-  vector_size_t numRows;
-};
 
 /**
  * @brief Bridge for transferring build-side hash tables between build and probe
@@ -70,17 +60,17 @@ class CudfHashJoinBridge : public exec::JoinBridge {
       std::vector<std::shared_ptr<cudf::table>>,
       std::vector<std::shared_ptr<cudf::hash_join>>>;
 
-  /// Set build-side batches (host pinned memory). The hash table is built
-  /// lazily on the probe side under its GpuGuard via H2D + unpack.
-  void setBuildBatches(std::vector<HostBuildBatch> batches);
+  void setHashTable(std::optional<hash_type> hashObject);
 
-  /// Get the build batches, or register a future to be notified when
-  /// they become available.
-  std::optional<std::vector<HostBuildBatch>> buildBatchesOrFuture(
-      ContinueFuture* future);
+  std::optional<hash_type> hashOrFuture(ContinueFuture* future);
+
+  void setBuildStream(rmm::cuda_stream_view buildStream);
+
+  std::optional<rmm::cuda_stream_view> getBuildStream();
 
  private:
-  std::optional<std::vector<HostBuildBatch>> buildBatches_;
+  std::optional<hash_type> hashObject_;
+  std::optional<rmm::cuda_stream_view> buildStream_;
 };
 
 /**
@@ -114,7 +104,7 @@ class CudfHashJoinBuild : public exec::Operator, public NvtxHelper {
 
  private:
   std::shared_ptr<const core::HashJoinNode> joinNode_;
-  std::vector<HostBuildBatch> hostInputs_;
+  std::vector<CudfVectorPtr> inputs_;
   ContinueFuture future_{ContinueFuture::makeEmpty()};
 };
 
@@ -214,10 +204,6 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   // probe input from the sources have been processed. It prevents the exchange
   // hanging problem at the producer side caused by the early query finish.
   bool skipInput_{false};
-
-  /// Build-side batches in pinned host memory, received from the bridge.
-  /// Consumed once by buildHashTable() (H2D + unpack + hash_join build).
-  std::optional<std::vector<HostBuildBatch>> buildBatches_;
 
   /** @brief CUDA stream used during hash table construction */
   std::optional<rmm::cuda_stream_view> buildStream_;
@@ -328,10 +314,6 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
           std::vector<std::unique_ptr<cudf::column>>&&,
           cudf::column_view)> func,
       rmm::cuda_stream_view stream);
-
-  /// Build hash table from raw batches received via the bridge. Called
-  /// lazily on the first getOutput() under operator-level GpuGuard.
-  void buildHashTable();
 
   std::unique_ptr<cudf::table> filteredOutputIndices(
       cudf::table_view leftTableView,

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -54,29 +54,23 @@ class CudfExpression;
  */
 class CudfHashJoinBridge : public exec::JoinBridge {
  public:
-  // The bridge transfers all build side batches and the hash join objects
-  // constructed from them to the probe operator
   /** @brief Hash tables paired with their corresponding join objects for
    * batched processing */
   using hash_type = std::pair<
       std::vector<std::shared_ptr<cudf::table>>,
       std::vector<std::shared_ptr<cudf::hash_join>>>;
 
-  void setHashTable(std::optional<hash_type> hashObject);
+  /// Set raw build-side batches. The hash table is built lazily on the
+  /// probe side under its GpuGuard, so the build pipeline does no GPU work.
+  void setBuildBatches(std::vector<CudfVectorPtr> batches);
 
-  std::optional<hash_type> hashOrFuture(ContinueFuture* future);
-
-  // Store and retrieve the CUDA stream used for building the hash join.
-  void setBuildStream(rmm::cuda_stream_view buildStream);
-
-  std::optional<rmm::cuda_stream_view> getBuildStream();
+  /// Get the raw build batches, or register a future to be notified when
+  /// they become available.
+  std::optional<std::vector<CudfVectorPtr>> buildBatchesOrFuture(
+      ContinueFuture* future);
 
  private:
-  /** @brief Hash tables and join objects transferred from build to probe
-   * operators */
-  std::optional<hash_type> hashObject_;
-  /** @brief CUDA stream used by build operator for proper synchronization */
-  std::optional<rmm::cuda_stream_view> buildStream_;
+  std::optional<std::vector<CudfVectorPtr>> buildBatches_;
 };
 
 /**
@@ -211,10 +205,17 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   // hanging problem at the producer side caused by the early query finish.
   bool skipInput_{false};
 
-  /** @brief CUDA stream from build operator for synchronization */
+  /// Raw build-side batches received from the bridge, consumed once by
+  /// buildHashTable() to construct hashObject_.
+  std::optional<std::vector<CudfVectorPtr>> buildBatches_;
+
+  /** @brief CUDA stream used during hash table construction */
   std::optional<rmm::cuda_stream_view> buildStream_;
   /** @brief CUDA event for coordinating stream synchronization */
   std::unique_ptr<CudaEvent> cudaEvent_;
+  /** @brief True when this probe holds an operator-level GPU semaphore slot
+   * (from buildHashTable through close). */
+  bool gpuSlotHeld_{false};
 
   // Streaming right join state
   // Per-build-table flags indicating whether a build row has had at least one
@@ -320,6 +321,10 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
           std::vector<std::unique_ptr<cudf::column>>&&,
           cudf::column_view)> func,
       rmm::cuda_stream_view stream);
+
+  /// Build hash table from raw batches received via the bridge. Called
+  /// lazily on the first getOutput() under operator-level GpuGuard.
+  void buildHashTable();
 
   std::unique_ptr<cudf::table> filteredOutputIndices(
       cudf::table_view leftTableView,

--- a/velox/experimental/cudf/exec/CudfLimit.cpp
+++ b/velox/experimental/cudf/exec/CudfLimit.cpp
@@ -94,6 +94,11 @@ RowVectorPtr CudfLimit::getOutput() {
     if (remainingLimit_ == 0) {
       finished_ = true;
     }
+    // Sync before releasing input — cudf::table() does async deep copy from
+    // slicedTable view which references input's device buffers. RMM pool
+    // deallocate is immediate, so input_.reset() would free memory while the
+    // async copy kernel is still reading.
+    cudfInput->stream().synchronize();
     auto output = std::make_shared<cudf_velox::CudfVector>(
         input_->pool(),
         input_->type(),
@@ -129,6 +134,11 @@ RowVectorPtr CudfLimit::getOutput() {
       cudfInput->stream(),
       cudf::get_current_device_resource_ref());
 
+  // Sync before releasing input — cudf::table() does async deep copy from
+  // slicedTable view which references input's device buffers. RMM pool
+  // deallocate is immediate, so input_.reset() would free memory while the
+  // async copy kernel is still reading.
+  cudfInput->stream().synchronize();
   auto output = std::make_shared<cudf_velox::CudfVector>(
       input_->pool(),
       input_->type(),

--- a/velox/experimental/cudf/exec/CudfShufflePartition.cpp
+++ b/velox/experimental/cudf/exec/CudfShufflePartition.cpp
@@ -95,6 +95,12 @@ void CudfShufflePartition::addInput(RowVectorPtr input) {
 
   gpuTimer_.stop(stream);
 
+  // Sync before locals go out of scope — cudf::partition reads from pidCol
+  // and input tableView asynchronously. When addInput() returns, pidCol is
+  // destroyed and cudfVec may be the last reference to the input CudfVector.
+  // RMM pool deallocate is immediate, so device buffers would be freed while
+  // the async partition kernel is still reading.
+  stream.synchronize();
   output_ = std::make_shared<CudfVector>(
       pool(),
       outputType_,

--- a/velox/experimental/cudf/exec/GpuGuard.cpp
+++ b/velox/experimental/cudf/exec/GpuGuard.cpp
@@ -19,23 +19,25 @@
 namespace facebook::velox::cudf_velox {
 
 namespace {
-thread_local int gpuRegionDepth = 0;
+thread_local bool gpuRegionActive = false;
 } // namespace
 
 void beginGpuRegion() {
-  gluten::lockGpu();
-  ++gpuRegionDepth;
+  if (!gpuRegionActive) {
+    gluten::lockGpu();
+    gpuRegionActive = true;
+  }
 }
 
 void endGpuRegion() {
-  if (gpuRegionDepth > 0) {
-    --gpuRegionDepth;
+  if (gpuRegionActive) {
+    gpuRegionActive = false;
     gluten::unlockGpu();
   }
 }
 
 bool isInGpuRegion() {
-  return gpuRegionDepth > 0;
+  return gpuRegionActive;
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuGuard.cpp
+++ b/velox/experimental/cudf/exec/GpuGuard.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/GpuGuard.h"
+
+namespace facebook::velox::cudf_velox {
+
+namespace {
+thread_local int gpuRegionDepth = 0;
+} // namespace
+
+void beginGpuRegion() {
+  gluten::lockGpu();
+  ++gpuRegionDepth;
+}
+
+void endGpuRegion() {
+  if (gpuRegionDepth > 0) {
+    --gpuRegionDepth;
+    gluten::unlockGpu();
+  }
+}
+
+bool isInGpuRegion() {
+  return gpuRegionDepth > 0;
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuGuard.cpp
+++ b/velox/experimental/cudf/exec/GpuGuard.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/experimental/cudf/exec/GpuGuard.h"
 
+#include <cuda_runtime.h>
+
 namespace facebook::velox::cudf_velox {
 
 namespace {
@@ -31,6 +33,15 @@ void beginGpuRegion() {
 
 void endGpuRegion() {
   if (gpuRegionActive) {
+    // Synchronize ALL CUDA streams before releasing the GPU semaphore.
+    // Without this, async operations (cudaMemcpyAsync, kernel launches)
+    // from the current thread may still be in-flight when the next thread
+    // acquires the semaphore and starts new CUDA operations, causing
+    // SEGV_ACCERR in the CUDA driver on concurrent access.
+    // This is the root cause of the Blackwell SIGSEGV: v4 accidentally
+    // serialized everything via semaphore leak; proper endGpuRegion
+    // without sync creates async overlap between threads.
+    cudaDeviceSynchronize();
     gpuRegionActive = false;
     gluten::unlockGpu();
   }

--- a/velox/experimental/cudf/exec/GpuGuard.cpp
+++ b/velox/experimental/cudf/exec/GpuGuard.cpp
@@ -16,8 +16,6 @@
 
 #include "velox/experimental/cudf/exec/GpuGuard.h"
 
-#include <cuda_runtime.h>
-
 namespace facebook::velox::cudf_velox {
 
 namespace {
@@ -33,15 +31,6 @@ void beginGpuRegion() {
 
 void endGpuRegion() {
   if (gpuRegionActive) {
-    // Synchronize ALL CUDA streams before releasing the GPU semaphore.
-    // Without this, async operations (cudaMemcpyAsync, kernel launches)
-    // from the current thread may still be in-flight when the next thread
-    // acquires the semaphore and starts new CUDA operations, causing
-    // SEGV_ACCERR in the CUDA driver on concurrent access.
-    // This is the root cause of the Blackwell SIGSEGV: v4 accidentally
-    // serialized everything via semaphore leak; proper endGpuRegion
-    // without sync creates async overlap between threads.
-    cudaDeviceSynchronize();
     gpuRegionActive = false;
     gluten::unlockGpu();
   }

--- a/velox/experimental/cudf/exec/GpuGuard.cpp
+++ b/velox/experimental/cudf/exec/GpuGuard.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/experimental/cudf/exec/GpuGuard.h"
+#include <iostream>
+#include <thread>
 
 namespace facebook::velox::cudf_velox {
 
@@ -23,16 +25,28 @@ thread_local bool gpuRegionActive = false;
 } // namespace
 
 void beginGpuRegion() {
+  auto tid = std::this_thread::get_id();
   if (!gpuRegionActive) {
+    std::cerr << "GPU_REGION [begin-acquire] tid=" << tid
+              << " caller=" << __builtin_return_address(0) << std::endl;
     gluten::lockGpu();
     gpuRegionActive = true;
+  } else {
+    std::cerr << "GPU_REGION [begin-noop] tid=" << tid
+              << " caller=" << __builtin_return_address(0) << std::endl;
   }
 }
 
 void endGpuRegion() {
+  auto tid = std::this_thread::get_id();
   if (gpuRegionActive) {
     gpuRegionActive = false;
+    std::cerr << "GPU_REGION [end-release] tid=" << tid
+              << " caller=" << __builtin_return_address(0) << std::endl;
     gluten::unlockGpu();
+  } else {
+    std::cerr << "GPU_REGION [end-noop] tid=" << tid
+              << " caller=" << __builtin_return_address(0) << std::endl;
   }
 }
 

--- a/velox/experimental/cudf/exec/GpuGuard.h
+++ b/velox/experimental/cudf/exec/GpuGuard.h
@@ -36,4 +36,23 @@ struct GpuGuard {
   GpuGuard& operator=(const GpuGuard&) = delete;
 };
 
+/// Pipeline-level GPU region using thread-local state.
+///
+/// A GPU region brackets a contiguous sequence of GPU work across multiple
+/// operators within one pipeline iteration. It exploits the existing
+/// thread-local ref-counting in lockGpu/unlockGpu: beginGpuRegion() bumps
+/// the refcount, so all nested GpuGuard acquisitions become free (refcount
+/// 1→2→1→2→1). The actual semaphore is never released between operators.
+///
+/// Usage pattern:
+///   Source operator (after I/O, before H2D): beginGpuRegion()
+///   Intermediate operators: GpuGuard as usual (nested, no-op on semaphore)
+///   Sink / D2H point: endGpuRegion()
+///
+/// This gives the Spark-Rapids scope: [H2D acquire, D2H release] without
+/// holding the lock during I/O at either end.
+void beginGpuRegion();
+void endGpuRegion();
+bool isInGpuRegion();
+
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuGuard.h
+++ b/velox/experimental/cudf/exec/GpuGuard.h
@@ -23,10 +23,27 @@ void unlockGpu();
 
 namespace facebook::velox::cudf_velox {
 
-/// RAII guard that limits concurrent GPU usage across Velox pipeline tasks.
-/// Forwards to gluten::lockGpu / unlockGpu which are ref-counted per thread.
+/// Pipeline-level GPU region — thread-local boolean.
+///
+/// beginGpuRegion() is idempotent: first call acquires the semaphore,
+/// subsequent calls are no-ops. endGpuRegion() releases once.
+/// This lets the semaphore span an entire pipeline iteration [H2D, D2H]
+/// even when accumulating operators cause the source to be called N times
+/// before the sink produces output.
+void beginGpuRegion();
+void endGpuRegion();
+bool isInGpuRegion();
+
+/// RAII guard for GPU work. Automatically starts a GPU region on
+/// construction (idempotent — only the first GpuGuard in a pipeline
+/// iteration actually acquires the semaphore). The nested lockGpu/unlockGpu
+/// keeps refcount > 0 so the semaphore is never released between operators.
+///
+/// The region is ended explicitly by calling endGpuRegion() at D2H points
+/// (CudfToVelox, HashJoinBuild::addInput, etc.), NOT by ~GpuGuard.
 struct GpuGuard {
   GpuGuard() {
+    beginGpuRegion();
     gluten::lockGpu();
   }
   ~GpuGuard() {
@@ -35,24 +52,5 @@ struct GpuGuard {
   GpuGuard(const GpuGuard&) = delete;
   GpuGuard& operator=(const GpuGuard&) = delete;
 };
-
-/// Pipeline-level GPU region using thread-local state.
-///
-/// A GPU region brackets a contiguous sequence of GPU work across multiple
-/// operators within one pipeline iteration. It exploits the existing
-/// thread-local ref-counting in lockGpu/unlockGpu: beginGpuRegion() bumps
-/// the refcount, so all nested GpuGuard acquisitions become free (refcount
-/// 1→2→1→2→1). The actual semaphore is never released between operators.
-///
-/// Usage pattern:
-///   Source operator (after I/O, before H2D): beginGpuRegion()
-///   Intermediate operators: GpuGuard as usual (nested, no-op on semaphore)
-///   Sink / D2H point: endGpuRegion()
-///
-/// This gives the Spark-Rapids scope: [H2D acquire, D2H release] without
-/// holding the lock during I/O at either end.
-void beginGpuRegion();
-void endGpuRegion();
-bool isInGpuRegion();
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/PinnedArrowInterop.cpp
+++ b/velox/experimental/cudf/exec/PinnedArrowInterop.cpp
@@ -218,11 +218,32 @@ void attachHostBufToArrowBuffer(
 /// `idx` is advanced past the current column and all its children.
 void buildArrowColumnFromPacked(
     const SerializedColumn* meta,
+    size_t metaCount,
     size_t& idx,
     uint8_t* hostBase,
+    size_t hostBufSize,
     const std::shared_ptr<PinnedHostBuffer>& hostBuf,
     ArrowArray* out) {
+  if (idx >= metaCount) {
+    throw std::runtime_error(
+        "buildArrowColumnFromPacked: metadata index " + std::to_string(idx) +
+        " out of bounds (metaCount=" + std::to_string(metaCount) + ")");
+  }
   auto& col = meta[idx++];
+
+  // Validate that a buffer region [offset, offset+size) falls within hostBuf.
+  auto validateBufRange = [&](int64_t offset, int64_t size,
+                              const char* label) {
+    if (offset < 0 ||
+        static_cast<size_t>(offset) + static_cast<size_t>(size) >
+            hostBufSize) {
+      throw std::runtime_error(
+          std::string("buildArrowColumnFromPacked: ") + label +
+          " offset=" + std::to_string(offset) +
+          " size=" + std::to_string(size) +
+          " exceeds hostBufSize=" + std::to_string(hostBufSize));
+    }
+  };
 
   auto typeId = col.type.id();
   bool isString = (typeId == cudf::type_id::STRING);
@@ -234,6 +255,12 @@ void buildArrowColumnFromPacked(
     // Peek at the offsets child to determine offset width.
     CUDF_EXPECTS(
         col.num_children >= 1, "String column must have offsets child");
+    if (idx >= metaCount) {
+      throw std::runtime_error(
+          "buildArrowColumnFromPacked: string offsets child index " +
+          std::to_string(idx) +
+          " out of bounds (metaCount=" + std::to_string(metaCount) + ")");
+    }
     auto& offsetsCol = meta[idx]; // peek, don't advance yet
     bool largeOffsets = (offsetsCol.type.id() == cudf::type_id::INT64);
 
@@ -248,6 +275,7 @@ void buildArrowColumnFromPacked(
       auto* buf = ArrowArrayBuffer(out, 0);
       auto maskBytes =
           static_cast<int64_t>(cudf::bitmask_allocation_size_bytes(col.size));
+      validateBufRange(col.null_mask_offset, maskBytes, "string validity");
       attachHostBufToArrowBuffer(
           buf, hostBuf, hostBase + col.null_mask_offset, maskBytes);
       out->buffers[0] = buf->data;
@@ -265,6 +293,8 @@ void buildArrowColumnFromPacked(
         static_cast<int64_t>(col.size + 1) * offsetElemSize;
     auto* offsetsBuf = ArrowArrayBuffer(out, 1);
     if (offsetsCol.data_offset != -1) {
+      validateBufRange(
+          offsetsCol.data_offset, offsetsBytes, "string offsets");
       attachHostBufToArrowBuffer(
           offsetsBuf,
           hostBuf,
@@ -287,6 +317,7 @@ void buildArrowColumnFromPacked(
 
     auto* charsBuf = ArrowArrayBuffer(out, 2);
     if (col.data_offset != -1 && charsSize > 0) {
+      validateBufRange(col.data_offset, charsSize, "string chars");
       attachHostBufToArrowBuffer(
           charsBuf, hostBuf, hostBase + col.data_offset, charsSize);
     }
@@ -375,6 +406,14 @@ void buildArrowColumnFromPacked(
         arrowType = NANOARROW_TYPE_DECIMAL128;
         elemSize = 16;
         break;
+      case cudf::type_id::STRUCT:
+        arrowType = NANOARROW_TYPE_STRUCT;
+        elemSize = 0; // struct has only validity buffer; children handled below
+        break;
+      case cudf::type_id::LIST:
+        arrowType = NANOARROW_TYPE_LIST;
+        elemSize = 0; // list has validity + int32 offsets; handled below
+        break;
       default:
         arrowType = NANOARROW_TYPE_BINARY;
         elemSize = 0;
@@ -390,6 +429,7 @@ void buildArrowColumnFromPacked(
       auto* buf = ArrowArrayBuffer(out, 0);
       auto maskBytes =
           static_cast<int64_t>(cudf::bitmask_allocation_size_bytes(col.size));
+      validateBufRange(col.null_mask_offset, maskBytes, "validity");
       attachHostBufToArrowBuffer(
           buf, hostBuf, hostBase + col.null_mask_offset, maskBytes);
       out->buffers[0] = buf->data;
@@ -399,15 +439,28 @@ void buildArrowColumnFromPacked(
     if (col.data_offset != -1 && elemSize > 0) {
       auto* buf = ArrowArrayBuffer(out, 1);
       auto dataBytes = static_cast<int64_t>(col.size) * elemSize;
+      validateBufRange(col.data_offset, dataBytes, "data");
       attachHostBufToArrowBuffer(
           buf, hostBuf, hostBase + col.data_offset, dataBytes);
       out->buffers[1] = buf->data;
     } else if (col.data_offset != -1 && arrowType == NANOARROW_TYPE_BOOL) {
+      // cudf::pack stores BOOL8 as 1 byte per element (not bit-packed).
+      // Use the actual byte count from packed data.
       auto* buf = ArrowArrayBuffer(out, 1);
-      auto dataBytes =
-          static_cast<int64_t>(cudf::bitmask_allocation_size_bytes(col.size));
+      auto dataBytes = static_cast<int64_t>(col.size);
+      validateBufRange(col.data_offset, dataBytes, "bool data");
       attachHostBufToArrowBuffer(
           buf, hostBuf, hostBase + col.data_offset, dataBytes);
+      out->buffers[1] = buf->data;
+    } else if (arrowType == NANOARROW_TYPE_LIST && col.data_offset != -1) {
+      // LIST has validity (buf[0], handled above) + int32 offsets (buf[1]).
+      // The offsets buffer has (size + 1) int32 entries.
+      auto* buf = ArrowArrayBuffer(out, 1);
+      auto offsetsBytes =
+          static_cast<int64_t>(col.size + 1) * sizeof(int32_t);
+      validateBufRange(col.data_offset, offsetsBytes, "list offsets");
+      attachHostBufToArrowBuffer(
+          buf, hostBuf, hostBase + col.data_offset, offsetsBytes);
       out->buffers[1] = buf->data;
     }
 
@@ -417,7 +470,8 @@ void buildArrowColumnFromPacked(
           ArrowArrayAllocateChildren(out, col.num_children));
       for (int c = 0; c < col.num_children; ++c) {
         buildArrowColumnFromPacked(
-            meta, idx, hostBase, hostBuf, out->children[c]);
+            meta, metaCount, idx, hostBase, hostBufSize, hostBuf,
+            out->children[c]);
       }
     }
   }
@@ -431,6 +485,8 @@ void buildArrowFromPackedHost(
     int64_t numRows,
     ArrowArray* out) {
   auto* meta = reinterpret_cast<const SerializedColumn*>(metadata.data());
+  size_t metaCount = metadata.size() / sizeof(SerializedColumn);
+  size_t hostBufSize = hostBuf->size();
   // First entry is a stub: size == number of top-level columns
   size_t idx = 1;
 
@@ -442,7 +498,8 @@ void buildArrowFromPackedHost(
 
   for (int c = 0; c < numColumns; ++c) {
     buildArrowColumnFromPacked(
-        meta, idx, hostBuf->data(), hostBuf, out->children[c]);
+        meta, metaCount, idx, hostBuf->data(), hostBufSize, hostBuf,
+        out->children[c]);
   }
 
   NANOARROW_THROW_NOT_OK(ArrowArrayFinishBuilding(

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -345,10 +345,12 @@ void registerCudf() {
       mrMode, CudfConfig::getInstance().memoryPercent);
   cudf::set_current_device_resource(mr.get());
   mr_ = mr;
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [registerCudf-post-RMM-init] "
-               << cudf_velox::gpuMemorySnapshotString()
-               << " mrMode=" << mrMode
-               << " memoryPercent=" << CudfConfig::getInstance().memoryPercent;
+  {
+    auto snap = cudf_velox::gpuMemorySnapshotString();
+    fprintf(stderr, "GPU_MEM_SNAPSHOT [registerCudf-post-RMM-init] %s mrMode=%s memoryPercent=%d\n",
+            snap.c_str(), mrMode.c_str(), CudfConfig::getInstance().memoryPercent);
+    fflush(stderr);
+  }
 
   // Temporarily lower cudf logger level so pinned pool init is visible.
   cudf::default_logger().set_level(rapids_logger::level_enum::info);
@@ -406,8 +408,11 @@ void registerCudf() {
   }
 
   isCudfRegistered = true;
-  LOG(ERROR) << "GPU_MEM_SNAPSHOT [registerCudf-complete] "
-               << cudf_velox::gpuMemorySnapshotString();
+  {
+    auto snap = cudf_velox::gpuMemorySnapshotString();
+    fprintf(stderr, "GPU_MEM_SNAPSHOT [registerCudf-complete] %s\n", snap.c_str());
+    fflush(stderr);
+  }
 }
 
 void unregisterCudf() {

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -345,6 +345,10 @@ void registerCudf() {
       mrMode, CudfConfig::getInstance().memoryPercent);
   cudf::set_current_device_resource(mr.get());
   mr_ = mr;
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [registerCudf-post-RMM-init] "
+               << cudf_velox::gpuMemorySnapshotString()
+               << " mrMode=" << mrMode
+               << " memoryPercent=" << CudfConfig::getInstance().memoryPercent;
 
   // Temporarily lower cudf logger level so pinned pool init is visible.
   cudf::default_logger().set_level(rapids_logger::level_enum::info);
@@ -402,6 +406,8 @@ void registerCudf() {
   }
 
   isCudfRegistered = true;
+  LOG(ERROR) << "GPU_MEM_SNAPSHOT [registerCudf-complete] "
+               << cudf_velox::gpuMemorySnapshotString();
 }
 
 void unregisterCudf() {

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -48,9 +48,15 @@
 #include <sstream>
 #include <string_view>
 
+namespace gluten {
+std::string gpuMemoryTrackerBreakdownString(uint64_t visiblePayloadBytes)
+    __attribute__((weak));
+}
+
 namespace facebook::velox::cudf_velox {
 
 namespace {
+
 /// \brief Makes a cuda resource
 [[nodiscard]] auto makeCudaMr() {
   return std::make_shared<rmm::mr::cuda_memory_resource>();
@@ -203,6 +209,19 @@ std::string gpuMemorySnapshotString() {
   out << "gpuMem{free=" << succinctBytes(freeMem)
       << ", used=" << succinctBytes(usedMem)
       << ", total=" << succinctBytes(totalMem) << "}";
+  return out.str();
+}
+
+std::string gpuMemoryBreakdownString(uint64_t visiblePayloadBytes) {
+  std::ostringstream out;
+  out << gpuMemorySnapshotString();
+  if (gluten::gpuMemoryTrackerBreakdownString != nullptr) {
+    auto trackerBreakdown =
+        gluten::gpuMemoryTrackerBreakdownString(visiblePayloadBytes);
+    if (!trackerBreakdown.empty()) {
+      out << ", " << trackerBreakdown;
+    }
+  }
   return out.str();
 }
 

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -241,8 +241,12 @@ std::unique_ptr<cudf::table> concatenateTables(
       tables.end(),
       std::back_inserter(tableViews),
       [&](const auto& tbl) { return tbl->view(); });
-  return cudf::concatenate(
+  auto result = cudf::concatenate(
       tableViews, stream, cudf::get_current_device_resource_ref());
+  // Sync before source tables go out of scope — cudf::concatenate reads
+  // from tableViews asynchronously, and RMM pool deallocate is immediate.
+  stream.synchronize();
+  return result;
 }
 
 std::unique_ptr<cudf::table> makeEmptyTable(TypePtr const& inputType) {

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -28,6 +28,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/prefetch.hpp>
+#include <cuda_runtime.h>
 
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/cuda_async_managed_memory_resource.hpp>
@@ -44,6 +45,7 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
+#include <sstream>
 #include <string_view>
 
 namespace facebook::velox::cudf_velox {
@@ -167,16 +169,41 @@ uint64_t estimateColumnViewBytes(cudf::column_view const& col) {
 }
 } // namespace
 
-uint64_t estimateTableBytes(std::unique_ptr<cudf::table>& table) {
-  if (!table || table->num_columns() == 0 || table->num_rows() == 0) {
+uint64_t estimateTableBytes(cudf::table_view const& table) {
+  if (table.num_columns() == 0 || table.num_rows() == 0) {
     return 0;
   }
   uint64_t totalBytes = 0;
-  auto view = table->view();
-  for (int i = 0; i < view.num_columns(); ++i) {
-    totalBytes += estimateColumnViewBytes(view.column(i));
+  for (int i = 0; i < table.num_columns(); ++i) {
+    totalBytes += estimateColumnViewBytes(table.column(i));
   }
   return totalBytes;
+}
+
+uint64_t estimateTableBytes(std::unique_ptr<cudf::table>& table) {
+  if (!table) {
+    return 0;
+  }
+  return estimateTableBytes(table->view());
+}
+
+std::string gpuMemorySnapshotString() {
+  size_t freeMem = 0;
+  size_t totalMem = 0;
+  auto err = cudaMemGetInfo(&freeMem, &totalMem);
+  if (err != cudaSuccess) {
+    cudaGetLastError();
+    std::ostringstream out;
+    out << "gpuMem{error=" << cudaGetErrorString(err) << "}";
+    return out.str();
+  }
+
+  const auto usedMem = totalMem >= freeMem ? totalMem - freeMem : 0;
+  std::ostringstream out;
+  out << "gpuMem{free=" << succinctBytes(freeMem)
+      << ", used=" << succinctBytes(usedMem)
+      << ", total=" << succinctBytes(totalMem) << "}";
+  return out.str();
 }
 
 std::unique_ptr<cudf::table> concatenateTables(

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -25,6 +25,7 @@
 #include <rmm/mr/device_memory_resource.hpp>
 
 #include <memory>
+#include <string>
 #include <string_view>
 
 namespace facebook::velox::cudf_velox {
@@ -93,8 +94,16 @@ getConcatenatedTableBatched(
 /// does not require releasing or copying the table.  It may slightly
 /// undercount for nested types (LIST, STRUCT with children) but is
 /// accurate enough for coalescing decisions.
+[[nodiscard]] uint64_t estimateTableBytes(cudf::table_view const& table);
+
+/// Estimates the total memory size of a cudf table by summing per-column
+/// data + null-mask buffer sizes for an owned table.
 [[nodiscard]] uint64_t estimateTableBytes(
     std::unique_ptr<cudf::table>& table);
+
+/// Returns a compact snapshot of current device memory reported by CUDA.
+/// This reflects actual device pressure and complements table-size estimates.
+[[nodiscard]] std::string gpuMemorySnapshotString();
 
 /**
  * @brief Wrapper for CUDA events used for stream synchronization.

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -105,6 +105,10 @@ getConcatenatedTableBatched(
 /// This reflects actual device pressure and complements table-size estimates.
 [[nodiscard]] std::string gpuMemorySnapshotString();
 
+/// Returns a snapshot that combines actual device pressure with allocator-side
+/// live / retained proxies for a known visible payload.
+[[nodiscard]] std::string gpuMemoryBreakdownString(uint64_t visiblePayloadBytes);
+
 /**
  * @brief Wrapper for CUDA events used for stream synchronization.
  *

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -386,11 +386,20 @@ RowVectorPtr toVeloxColumn(
   }
 
   auto arrowSchema = cudf::to_arrow_schema(table, metadata);
-  auto veloxTable = importFromArrowAsOwner(*arrowSchema, arrowArray, pool);
-  auto castedPtr =
-      std::dynamic_pointer_cast<facebook::velox::RowVector>(veloxTable);
-  VELOX_CHECK_NOT_NULL(castedPtr);
-  return castedPtr;
+  try {
+    auto veloxTable = importFromArrowAsOwner(*arrowSchema, arrowArray, pool);
+    auto castedPtr =
+        std::dynamic_pointer_cast<facebook::velox::RowVector>(veloxTable);
+    VELOX_CHECK_NOT_NULL(castedPtr);
+    return castedPtr;
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "importFromArrowAsOwner failed in packed D2H path: "
+               << e.what() << " (table: " << table.num_columns() << " cols, "
+               << table.num_rows() << " rows, arrowArray.length="
+               << arrowArray.length
+               << ", n_children=" << arrowArray.n_children << ")";
+    throw;
+  }
 }
 
 template <typename Iterator>


### PR DESCRIPTION
 Comprehensive GPU execution reliability improvements for Velox cuDF backend,  addressing deadlocks, memory safety, and CUDA stream synchronization issues discovered during TPC-H SF1K/SF3K GPU benchmarking.  

Key changes:        
  - Fix hash join GpuGuard deadlock with per-batch GpuGuard acquisition       
  -  Use host-pinned memory for hash join build batches  
  - Use host-pinned memory for hash join build batches  
  - Implement thread-local GPU region for pipeline-level semaphore scope  
  - Add GPU OOM diagnostics, memory logging, and scan budget estimates 
  - Add CUDA stream sync before freeing pinned host buffers (multiple sites)  
  - Sync CudfHashJoin.h with reverted .cpp changes  