### PR TITLE
fix(ucx-exchange): Make host staging configurable

### DIFF
--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -57,6 +57,9 @@ struct CudfConfig {
   static constexpr const char* kUcxxErrorHandling{"ucxx.error_handling"};
   static constexpr const char* kUcxIntraNodeExchange{
       "cudf.intra_node_exchange"};
+  static constexpr const char* kUcxExchangeHostStaging{
+      "cudf.exchange.host_staging"};
+  static constexpr const char* kUcxExchangeHostStagingDefault{"false"};
   static constexpr const char* kUcxxBlockingPolling{"ucxx.blocking_polling"};
   static constexpr const char* kUcxExchangeLogLevel{"cudf.exchange_log_level"};
 
@@ -146,6 +149,10 @@ struct CudfConfig {
   /// Whether intra-node exchange optimization is enabled.
   /// When disabled, all transfers use UCXX even within the same node.
   bool intraNodeExchange{false};
+
+  /// Whether remote UCX exchange payloads should stage GPU data through host
+  /// memory. Enable this when UCX lacks CUDA-aware transports.
+  bool exchangeHostStaging{false};
 
   /// Whether to use blocking polling in UCXX.
   bool ucxxBlockingPolling{true};

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -434,6 +434,12 @@ void CudfConfig::initialize(
   if (config.find(kUcxIntraNodeExchange) != config.end()) {
     intraNodeExchange = folly::to<bool>(config[kUcxIntraNodeExchange]);
   }
+  auto hostStaging = config.find(kUcxExchangeHostStaging);
+  if (hostStaging != config.end()) {
+    exchangeHostStaging = folly::to<bool>(hostStaging->second);
+  } else {
+    exchangeHostStaging = folly::to<bool>(kUcxExchangeHostStagingDefault);
+  }
   if (config.find(kUcxxErrorHandling) != config.end()) {
     ucxxErrorHandling = folly::to<bool>(config[kUcxxErrorHandling]);
   }

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -27,9 +27,11 @@ TEST(ConfigTest, CudfConfig) {
       {CudfConfig::kCudfMemoryResource, "arena"},
       {CudfConfig::kCudfMemoryPercent, "25"},
       {CudfConfig::kCudfFunctionNamePrefix, "presto"},
-      {CudfConfig::kCudfAllowCpuFallback, "false"}};
+      {CudfConfig::kCudfAllowCpuFallback, "false"},
+      {CudfConfig::kUcxExchangeHostStaging, "true"}};
 
   CudfConfig config;
+  ASSERT_EQ(config.exchangeHostStaging, false);
   config.initialize(std::move(options));
   ASSERT_EQ(config.enabled, false);
   ASSERT_EQ(config.debugEnabled, true);
@@ -37,5 +39,10 @@ TEST(ConfigTest, CudfConfig) {
   ASSERT_EQ(config.memoryPercent, 25);
   ASSERT_EQ(config.functionNamePrefix, "presto");
   ASSERT_EQ(config.allowCpuFallback, false);
+  ASSERT_EQ(config.exchangeHostStaging, true);
+
+  std::unordered_map<std::string, std::string> defaultOptions;
+  config.initialize(std::move(defaultOptions));
+  ASSERT_EQ(config.exchangeHostStaging, false);
 }
 } // namespace facebook::velox::cudf_velox::test

--- a/velox/experimental/ucx-exchange/UcxExchangeProtocol.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeProtocol.h
@@ -110,6 +110,7 @@ struct MetadataMsg {
   WireDataSizeType dataSizeBytes;
   std::vector<WireRemainingElementType> remainingBytes;
   bool atEnd;
+  bool hostStaging{false};
 
   uint32_t getSerializedSize() const {
     // The header: the magic number and the metadata length.
@@ -124,6 +125,8 @@ struct MetadataMsg {
     totalSize += sizeof(WireLengthType); // for numRemaining count
     totalSize += remainingBytes.size() * sizeof(remainingBytes[0]);
     // atEnd, encoded in a byte.
+    totalSize += sizeof(uint8_t);
+    // hostStaging, encoded in a byte.
     totalSize += sizeof(uint8_t);
 
     return totalSize;
@@ -188,6 +191,11 @@ struct MetadataMsg {
     // Serialize atEnd bool as 0/1.
     uint8_t atEndByte = atEnd ? 1 : 0;
     *ptr = atEndByte;
+    ptr += sizeof(atEndByte);
+
+    // Serialize hostStaging bool as 0/1.
+    uint8_t hostStagingByte = hostStaging ? 1 : 0;
+    *ptr = hostStagingByte;
 
     return std::make_pair<std::shared_ptr<uint8_t>, size_t>(
         std::move(buffer), totalSize);
@@ -258,6 +266,13 @@ struct MetadataMsg {
     // Deserialize bool `atEnd` (stored as a single byte: 1 for true, 0 for
     // false)
     record.atEnd = (*ptr != 0);
+    ptr += sizeof(uint8_t);
+
+    // Deserialize bool `hostStaging` if present. Older metadata did not include
+    // this byte, so default to false when reading that format.
+    if (ptr < endPtr) {
+      record.hostStaging = (*ptr != 0);
+    }
 
     return record;
   }

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -16,6 +16,7 @@
 #include "velox/experimental/ucx-exchange/UcxExchangeServer.h"
 #include <glog/logging.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <vector>
 #include "cuda_runtime.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
@@ -23,6 +24,8 @@
 #include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"
 
 namespace facebook::velox::ucx_exchange {
+
+namespace {
 
 // Context wrappers for UCXX tagSend callbackData. These decouple the
 // ucxx::Request lifetime (which must survive for UCP wireup replay) from
@@ -39,7 +42,34 @@ struct MetaSendContext {
 
 struct DataSendContext {
   std::shared_ptr<cudf::packed_columns> data;
+  std::shared_ptr<std::vector<uint8_t>> hostData;
 };
+
+std::shared_ptr<std::vector<uint8_t>> stageDeviceBufferToHost(
+    const cudf::packed_columns& data,
+    const PartitionKey& partitionKey) {
+  VELOX_CHECK_NOT_NULL(data.gpu_data);
+
+  auto hostData = std::make_shared<std::vector<uint8_t>>(data.gpu_data->size());
+  if (hostData->empty()) {
+    return hostData;
+  }
+
+  auto status = cudaMemcpy(
+      hostData->data(),
+      data.gpu_data->data(),
+      hostData->size(),
+      cudaMemcpyDeviceToHost);
+  VELOX_CHECK(
+      status == cudaSuccess,
+      "Failed to stage UCX exchange payload from device to host for task {}: {}",
+      partitionKey.toString(),
+      cudaGetErrorString(status));
+
+  return hostData;
+}
+
+} // namespace
 
 void UcxExchangeServer::setState(ServerState newState) {
   auto oldState = state_.exchange(newState, std::memory_order_seq_cst);
@@ -287,6 +317,9 @@ void UcxExchangeServer::sendData() {
   } else {
     // REMOTE EXCHANGE PATH: Use UCXX for metadata and data transfer
     std::shared_ptr<MetadataMsg> metadataMsg = std::make_shared<MetadataMsg>();
+    std::shared_ptr<DataSendContext> dataCtx;
+    const bool hostStaging =
+        queueMgr_->hostStagingEnabled(partitionKey_.taskId);
 
     if (dataPtr_) {
       // Copy metadata (not move) because in broadcast mode, the same
@@ -297,6 +330,16 @@ void UcxExchangeServer::sendData() {
       metadataMsg->dataSizeBytes = dataPtr_->gpu_data->size();
       metadataMsg->remainingBytes = {};
       metadataMsg->atEnd = false;
+      metadataMsg->hostStaging = hostStaging;
+
+      dataCtx = std::make_shared<DataSendContext>();
+      dataCtx->data = dataPtr_;
+      if (hostStaging) {
+        // UCX deployments are not guaranteed to have CUDA-aware transports
+        // enabled. Stage remote payloads through host memory so TCP/self/shm
+        // transports never try to CPU-memcpy directly from device memory.
+        dataCtx->hostData = stageDeviceBufferToHost(*dataPtr_, partitionKey_);
+      }
     } else {
       VLOG(3) << "@" << partitionKey_.taskId << " Final exchange for "
               << partitionKey_.toString();
@@ -383,29 +426,37 @@ void UcxExchangeServer::sendData() {
         completedRequests_.push_back(std::move(dataRequest_));
       }
 
-      // Wrap the GPU data buffer in a context so the callback can release
-      // it after the DMA completes, while the Request (and context shell)
-      // stays alive for UCP wireup replay.
-      auto dataCtx = std::make_shared<DataSendContext>();
-      dataCtx->data = dataPtr_;
-
+      void* sendBuffer = nullptr;
+      size_t sendSize = 0;
+      if (hostStaging) {
+        sendBuffer = dataCtx->hostData->data();
+        sendSize = dataCtx->hostData->size();
+      } else {
+        sendBuffer = dataCtx->data->gpu_data->data();
+        sendSize = dataCtx->data->gpu_data->size();
+      }
       dataRequest_ = endpointRef_->endpoint_->tagSend(
-          dataCtx->data->gpu_data->data(),
-          dataCtx->data->gpu_data->size(),
+          sendBuffer,
+          sendSize,
           ucxx::Tag{dataTag},
           false,
-          [weakData](ucs_status_t status, std::shared_ptr<void> arg) {
-            // Release the GPU data buffer from the context. The DMA has
-            // completed by the time this callback fires, so the buffer is
-            // safe to free. The context shell stays alive with the Request.
+          [weakData, hostStaging](
+              ucs_status_t status, std::shared_ptr<void> arg) {
+            // Release buffers from the context. The UCX send has completed by
+            // the time this callback fires, so the buffers are safe to free.
+            // The context shell stays alive with the Request.
             auto ctx = std::static_pointer_cast<DataSendContext>(arg);
             auto dataHolder = std::move(ctx->data);
+            std::shared_ptr<std::vector<uint8_t>> hostDataHolder;
+            if (hostStaging) {
+              hostDataHolder = std::move(ctx->hostData);
+            }
 
             if (auto self = weakData.lock()) {
               self->sendComplete(status, arg);
             }
-            // dataHolder is destroyed here, releasing the GPU buffer if
-            // sendComplete() already reset the server's dataPtr_.
+            // Holders are destroyed here, releasing buffers if sendComplete()
+            // already reset the server's dataPtr_.
           },
           dataCtx);
     } else {

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -479,7 +479,25 @@ void UcxExchangeSource::onMetadata(
       return;
     }
 
-    // REMOTE EXCHANGE PATH: Allocate buffer and receive via UCXX
+    if (ptr->metadata.dataSizeBytes < 0) {
+      std::string errorMsg = fmt::format(
+          "Invalid negative UCX exchange payload size {} from host {}:{}, task {}",
+          ptr->metadata.dataSizeBytes,
+          host_,
+          port_,
+          partitionKey_.toString());
+      VLOG(0) << toString() << " " << errorMsg;
+      queue_->setError(errorMsg);
+      deliverEndMarker();
+      setState(ReceiverState::Done);
+      communicator_->addToWorkQueue(getSelfPtr());
+      return;
+    }
+    const auto dataSize = static_cast<size_t>(ptr->metadata.dataSizeBytes);
+    ptr->hostStaging = ptr->metadata.hostStaging;
+
+    // REMOTE EXCHANGE PATH: optionally receive UCXX data into host memory, then
+    // copy it to device memory before unpacking.
     // Get a stream from the global stream pool
     auto stream =
         facebook::velox::cudf_velox::cudfGlobalStreamPool().get_stream();
@@ -487,12 +505,20 @@ void UcxExchangeSource::onMetadata(
     // in onData() when creating the PackedTableWithStream.
     ptr->stream = stream;
     try {
-      ptr->dataBuf = std::make_unique<rmm::device_buffer>(
-          ptr->metadata.dataSizeBytes, stream);
-    } catch (const rmm::bad_alloc& e) {
-      VLOG(0) << toString() << " *** RMM  failed to allocate: " << e.what();
-      queue_->setError("Failed to alloc GPU memory"); // Let the operator know
-                                                      // via the queue
+      ptr->dataBuf = std::make_unique<rmm::device_buffer>(dataSize, stream);
+      if (ptr->hostStaging) {
+        ptr->hostData = std::make_shared<std::vector<uint8_t>>(dataSize);
+      }
+    } catch (const std::exception& e) {
+      std::string errorMsg = fmt::format(
+          "Failed to allocate UCX exchange receive buffers for host {}:{}, task {}, size {}: {}",
+          host_,
+          port_,
+          partitionKey_.toString(),
+          dataSize,
+          e.what());
+      VLOG(0) << toString() << " " << errorMsg;
+      queue_->setError(errorMsg);
       deliverEndMarker();
       setState(ReceiverState::Done);
       communicator_->addToWorkQueue(getSelfPtr());
@@ -505,7 +531,7 @@ void UcxExchangeSource::onMetadata(
     VLOG(3) << toString() << " Allocated " << ptr->metadata.dataSizeBytes
             << " bytes of device memory";
 
-    // Initiate the transfer of the actual data from GPU-2-GPU
+    // Initiate the payload transfer.
     uint64_t dataTag = getDataTag(partitionKeyHash_, sequenceNumber_);
     VLOG(3) << toString() << " waiting for data for chunk: " << sequenceNumber_
             << " using tag: " << std::hex << dataTag << std::dec;
@@ -521,9 +547,17 @@ void UcxExchangeSource::onMetadata(
     if (request_) {
       completedRequests_.push_back(std::move(request_));
     }
+    void* recvBuffer = nullptr;
+    size_t recvSize = dataSize;
+    if (ptr->hostStaging) {
+      recvBuffer = ptr->hostData->data();
+      recvSize = ptr->hostData->size();
+    } else {
+      recvBuffer = ptr->dataBuf->data();
+    }
     request_ = endpointRef_->endpoint_->tagRecv(
-        ptr->dataBuf->data(),
-        ptr->metadata.dataSizeBytes,
+        recvBuffer,
+        recvSize,
         ucxx::Tag{dataTag},
         ucxx::TagMaskFull,
         false,
@@ -574,6 +608,35 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
 
     metrics_.numPackedColumns_.addValue(1);
     metrics_.totalBytes_.addValue(ptr->metadata.dataSizeBytes);
+
+    const auto dataSize = static_cast<size_t>(ptr->metadata.dataSizeBytes);
+    if (ptr->hostStaging && dataSize > 0) {
+      VELOX_CHECK_NOT_NULL(ptr->hostData);
+      auto copyStatus = cudaMemcpyAsync(
+          ptr->dataBuf->data(),
+          ptr->hostData->data(),
+          dataSize,
+          cudaMemcpyHostToDevice,
+          ptr->stream.value());
+      if (copyStatus == cudaSuccess) {
+        copyStatus = cudaStreamSynchronize(ptr->stream.value());
+      }
+      if (copyStatus != cudaSuccess) {
+        std::string errorMsg = fmt::format(
+            "Failed to stage UCX exchange payload from host to device for host {}:{}, task {}: {}",
+            host_,
+            port_,
+            partitionKey_.toString(),
+            cudaGetErrorString(copyStatus));
+        VLOG(0) << toString() << " " << errorMsg;
+        queue_->setError(errorMsg);
+        deliverEndMarker();
+        setState(ReceiverState::Done);
+        communicator_->addToWorkQueue(getSelfPtr());
+        return;
+      }
+    }
+    ptr->hostData.reset();
 
     // Create packed_columns from the received metadata and data buffer
     cudf::packed_columns packedCols(

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -35,6 +35,8 @@
 #include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
+#include <vector>
+
 namespace facebook::velox::ucx_exchange {
 
 struct UcxExchangeMetrics {
@@ -141,6 +143,8 @@ class UcxExchangeSource
   struct DataAndMetadata {
     MetadataMsg metadata;
     std::unique_ptr<rmm::device_buffer> dataBuf;
+    std::shared_ptr<std::vector<uint8_t>> hostData;
+    bool hostStaging{false};
     rmm::cuda_stream_view stream; // The stream used to allocate dataBuf
   };
 

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
@@ -145,6 +145,11 @@ bool UcxOutputQueueManager::canUseIntraNode(const std::string& taskId) {
       queue->kind() != core::PartitionedOutputNode::Kind::kBroadcast;
 }
 
+bool UcxOutputQueueManager::hostStagingEnabled(const std::string& taskId) {
+  auto queue = getQueueIfExists(taskId);
+  return queue && queue->hostStagingEnabled();
+}
+
 void UcxOutputQueueManager::removeTask(const std::string& taskId) {
   auto queue =
       queues_.withLock([&](auto& queues) -> std::shared_ptr<UcxOutputQueue> {

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
@@ -107,6 +107,10 @@ class UcxOutputQueueManager {
   /// source's destructive move would corrupt data for other servers).
   bool canUseIntraNode(const std::string& taskId);
 
+  /// Returns true if remote UCXX sends for the given task should stage payloads
+  /// through host memory.
+  bool hostStagingEnabled(const std::string& taskId);
+
   /// @brief Removes the queue for the given task from the queue manager.
   /// Calls "terminate" on the queue to awake waiting producers.
   void removeTask(const std::string& taskId);

--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -17,7 +17,22 @@
 
 #include <atomic>
 
+#include "velox/experimental/cudf/CudfConfig.h"
+
 namespace facebook::velox::ucx_exchange {
+
+namespace {
+
+bool ucxExchangeHostStagingEnabled(const std::shared_ptr<exec::Task>& task) {
+  if (!task) {
+    return cudf_velox::CudfConfig::getInstance().exchangeHostStaging;
+  }
+  return task->queryCtx()->queryConfig().get<bool>(
+      cudf_velox::CudfConfig::kUcxExchangeHostStaging,
+      cudf_velox::CudfConfig::getInstance().exchangeHostStaging);
+}
+
+} // namespace
 
 void UcxDestinationQueue::Stats::recordEnqueue(
     const cudf::packed_columns* data) {
@@ -147,6 +162,7 @@ UcxOutputQueue::UcxOutputQueue(
   if (task_) {
     maxSize_ = task_->queryCtx()->queryConfig().maxOutputBufferSize();
     continueSize_ = (maxSize_ * kContinuePct) / 100;
+    hostStagingEnabled_ = ucxExchangeHostStagingEnabled(task_);
   } // else: maxSize_ and continueSize_ will be set once the task is created and
     // initialize called.
   // create a queue for each destination.
@@ -169,6 +185,7 @@ bool UcxOutputQueue::initialize(
   }
   kind_ = kind;
   numDrivers_ = numDrivers;
+  hostStagingEnabled_ = ucxExchangeHostStagingEnabled(task);
   // Release fence: ensure kind_ and numDrivers_ are visible before task_
   // is published. Concurrent lock-free readers (e.g. isBroadcast() via
   // kind()) use task_ != nullptr as the "initialized" signal, so kind_
@@ -183,6 +200,11 @@ bool UcxOutputQueue::initialize(
     queues_.emplace_back(std::make_unique<UcxDestinationQueue>());
   }
   return true;
+}
+
+bool UcxOutputQueue::hostStagingEnabled() {
+  std::lock_guard<std::mutex> l(mutex_);
+  return hostStagingEnabled_;
 }
 
 void UcxOutputQueue::updateNumDrivers(uint32_t newNumDrivers) {

--- a/velox/experimental/ucx-exchange/UcxQueues.h
+++ b/velox/experimental/ucx-exchange/UcxQueues.h
@@ -163,6 +163,9 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
     return task_ != nullptr;
   }
 
+  /// Whether remote UCXX sends for this task should stage through host memory.
+  bool hostStagingEnabled();
+
   /// @brief When we understand the final number of split groups (for grouped
   /// execution only), we need to update the number of producing drivers here.
   void updateNumDrivers(uint32_t newNumDrivers);
@@ -264,6 +267,9 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
 
   // Reference to the task that owns this UcxQueue.
   std::shared_ptr<exec::Task> task_{nullptr};
+
+  // Remote UCXX payloads use host staging when the task config requests it.
+  bool hostStagingEnabled_{false};
 
   // The output mode (partitioned, broadcast, etc.)
   core::PartitionedOutputNode::Kind kind_{


### PR DESCRIPTION
Fixes #29

## Summary
- Add `cudf.exchange.host_staging` as a binary true/false option, defaulting to `false`.
- Preserve the default CUDA-aware fast path:

  `GPU buffer -> UCX tagSend/tagRecv directly`

- When host staging is enabled, use:

  `GPU -> host staging buffer -> UCX -> host staging buffer -> GPU`

- Record the selected mode in UCX metadata so the receiver posts the matching host/device receive buffer.
- Leave the intra-node registry path unchanged.

## Why
Some UCX deployments only have TCP/self/shm transports available. Those transports may CPU-copy from UCX buffers and cannot safely dereference CUDA device pointers. Host staging gives MPP replay/runners a safe opt-in path without penalizing CUDA-aware deployments by default.

## Validation
- `git diff --check`
- Docker compile of `UcxExchangeServer.cpp.o`, `UcxExchangeSource.cpp.o`, `UcxOutputQueueManager.cpp.o`, `UcxQueues.cpp.o`, and `ToCudf.cpp.o`.

Commit: https://github.com/sperlingxx/velox/commit/4e0798bfb1914680fb61afa383c254f0df091c6e