### PR TITLE
Revert streaming aggregation fix unintentionally merged via PR #28

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -728,18 +728,12 @@ core::AggregationNode::Step getCompanionStep(
   }
 
   // The format is count_merge_extract_BIGINT or count_merge_extract.
-  // _merge_extract companion: input is intermediate state (e.g.
-  // row(sum, count) for avg); output depends on the requested step.
-  //   - kPartial / kIntermediate (streaming slot building a partial or
-  //     intermediate accumulator): merge intermediate states, keep them
-  //     as intermediate (sum+count grow, no extract).
-  //   - kFinal / kSingle (final extraction or canBeEvaluatedByCudf
-  //     signature check against the plan-level final signature): consume
-  //     intermediate state and produce the final value.
+  // In a SINGLE-step aggregation node, _merge_extract companions receive raw
+  // input (not intermediate state) so they must use kSingle signatures and
+  // aggregation logic rather than kFinal.
   if (kind.find("_merge_extract") != std::string::npos) {
-    if (step == core::AggregationNode::Step::kPartial ||
-        step == core::AggregationNode::Step::kIntermediate) {
-      return core::AggregationNode::Step::kIntermediate;
+    if (step == core::AggregationNode::Step::kSingle) {
+      return core::AggregationNode::Step::kSingle;
     }
     return core::AggregationNode::Step::kFinal;
   }
@@ -761,28 +755,6 @@ std::string getOriginalName(const std::string& kind) {
   }
 
   return kind;
-}
-
-// Resolve the intermediate (partial-output) type of an aggregate. For
-// companion aggregates whose input is already intermediate state
-// (_merge, _merge_extract), the intermediate type IS the input type:
-// velox CPU exec::resolveIntermediateType only knows raw-input
-// signatures for the base function and will fail when given an
-// already-intermediate row(...) input.
-TypePtr companionAwareIntermediateType(
-    core::AggregationNode::Aggregate const& aggregate) {
-  const auto& kind = aggregate.call->name();
-  if (kind.ends_with("_merge") ||
-      kind.find("_merge_extract") != std::string::npos) {
-    VELOX_CHECK_EQ(
-        aggregate.rawInputTypes.size(),
-        1,
-        "Companion aggregate must have exactly one input type: {}",
-        kind);
-    return aggregate.rawInputTypes[0];
-  }
-  return exec::resolveIntermediateType(
-      getOriginalName(kind), aggregate.rawInputTypes);
 }
 
 bool hasFinalAggs(
@@ -877,8 +849,9 @@ auto toAggregators(
     auto const kind = aggregate.call->name();
     auto const constant = constants[i];
     auto const companionStep = getCompanionStep(kind, step);
+    const auto originalName = getOriginalName(kind);
     const auto resultType = exec::isPartialOutput(companionStep)
-        ? companionAwareIntermediateType(aggregate)
+        ? exec::resolveIntermediateType(originalName, aggregate.rawInputTypes)
         : outputType->childAt(numKeys + i);
 
     aggregators.push_back(createAggregator(
@@ -900,7 +873,9 @@ RowTypePtr getFinalStepBufferedType(
 
   for (auto i = 0; i < aggregationNode.aggregates().size(); ++i) {
     auto const& aggregate = aggregationNode.aggregates()[i];
-    types[numKeys + i] = companionAwareIntermediateType(aggregate);
+    const auto originalName = getOriginalName(aggregate.call->name());
+    types[numKeys + i] =
+        exec::resolveIntermediateType(originalName, aggregate.rawInputTypes);
   }
 
   return ROW(std::move(names), std::move(types));
@@ -968,14 +943,8 @@ void CudfHashAggregation::initialize() {
       aggregationNode_->step(),
       outputType_,
       aggregationInput.constants);
-  // The hasCompanionAggregates guard (PR #16488) kept streaming on
-  // Presto-style plans only (bare function names like "avg"). With the
-  // slot-aware getCompanionStep above, _merge_extract companions can
-  // correctly participate in the 4-slot streaming pipeline, so the
-  // guard is no longer needed; removing it lets MPP single-task plans
-  // (which always use companion names) avoid the 2^31 column-size
-  // limit on high-cardinality final aggregations.
-  streamingEnabled_ = !isGlobal_;
+  streamingEnabled_ =
+      !hasCompanionAggregates(aggregationNode_->aggregates()) && !isGlobal_;
 
   // Make aggregators for intermediate step when streaming is enabled.
   // Distinct does not need any aggregators.


### PR DESCRIPTION
PR #28 was opened to ship the CudfLocalPartition backpressure fix (estimateFlatSize for accurate GPU memory accounting) and was titled accordingly. However, after the PR was opened we continued committing to the same source branch (mahone-option3-velox-260511), which silently appended a separate "cudf: enable streaming aggregation for _merge_extract companions" commit. The squash-merge then bundled both under the PR's BP-fix title, so the streaming agg change landed in stream without explicit review of its scope.

Subsequent SF1000 22-query validation found that the streaming agg change regresses Q18: removing the !hasCompanionAggregates guard on streamingEnabled_ exposes high-cardinality SINGLE-step plans (Q18's nested-subquery agg over l_orderkey, ~1.5B distinct keys) to a streaming bufferedResult_ growth pattern that overshoots the rmm async pool budget and OOMs at ~12 GB single allocation inside cuDF groupby. Q17 was fixed by this change (330 s CPU fallback -> 6.26 s GPU streaming), but Q18 went from 3.60 s working to fatal OOM.

This commit reverts just the CudfHashAggregation.cpp portion of the PR #28 squash, restoring stream's behavior to pre-streaming-fix:
  - getCompanionStep keeps the original SINGLE-step special case for _merge_extract (raw input assumption).
  - streamingEnabled_ keeps the !hasCompanionAggregates guard so companion plans never enter the 4-slot streaming pipeline.
  - companionAwareIntermediateType helper is removed; toAggregators and getFinalStepBufferedType go back to the direct exec::resolveIntermediateType call.

CudfLocalPartition.cpp (the actual BP fix) is intentionally left untouched.

A follow-up PR with a properly scoped streaming agg fix (slot-aware getCompanionStep for both _merge_extract and _partial companions, plus a memory mitigation for high-cardinality SINGLE-step plans like Q18) will be opened separately. Work in progress is saved on branch mahone-q17-streaming-fix-wip-260512.