### PR TITLE
misc: Merge origin/stream and add cuDF bypass detection plus slot-aware companion step

### DIFF
--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -301,6 +301,22 @@ RowVectorPtr LocalExchange::getOutput() {
     VELOX_CHECK(!drained);
     auto lockedStats = stats_.wlock();
     lockedStats->addInputVector(data->estimateFlatSize(), data->size());
+    // Diagnose per-driver pull counts for Q8 batch fragmentation
+    // investigation. Sampled to avoid log explosion.
+    static thread_local int64_t pullCounter{0};
+    static thread_local int64_t pulledRows{0};
+    ++pullCounter;
+    pulledRows += data->size();
+    if (pullCounter <= 5 || pullCounter % 100 == 0) {
+      LOG(WARNING) << "LE_PULL node=" << operatorCtx_->driver()
+                          ->driverCtx()->task->taskId()
+                   << " pipe=" << operatorCtx_->driverCtx()->pipelineId
+                   << " drv=" << operatorCtx_->driverCtx()->driverId
+                   << " partition=" << partition_
+                   << " pull#" << pullCounter
+                   << " rows=" << data->size()
+                   << " totalRows=" << pulledRows;
+    }
     return data;
   }
 

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -301,22 +301,9 @@ RowVectorPtr LocalExchange::getOutput() {
     VELOX_CHECK(!drained);
     auto lockedStats = stats_.wlock();
     lockedStats->addInputVector(data->estimateFlatSize(), data->size());
-    // Diagnose per-driver pull counts for Q8 batch fragmentation
-    // investigation. Sampled to avoid log explosion.
-    static thread_local int64_t pullCounter{0};
-    static thread_local int64_t pulledRows{0};
-    ++pullCounter;
-    pulledRows += data->size();
-    if (pullCounter <= 5 || pullCounter % 100 == 0) {
-      LOG(WARNING) << "LE_PULL node=" << operatorCtx_->driver()
-                          ->driverCtx()->task->taskId()
-                   << " pipe=" << operatorCtx_->driverCtx()->pipelineId
-                   << " drv=" << operatorCtx_->driverCtx()->driverId
-                   << " partition=" << partition_
-                   << " pull#" << pullCounter
-                   << " rows=" << data->size()
-                   << " totalRows=" << pulledRows;
-    }
+    // Track per-LocalExchange-instance pull counts; flush in close().
+    ++lePullCount_;
+    lePullRows_ += data->size();
     return data;
   }
 
@@ -334,6 +321,15 @@ bool LocalExchange::isFinished() {
 }
 
 void LocalExchange::close() {
+  // Flush diagnostic counts at consumer-side close.
+  LOG(WARNING) << "LE_SUMMARY task="
+               << operatorCtx_->driverCtx()->task->taskId()
+               << " node=" << planNodeId()
+               << " pipe=" << operatorCtx_->driverCtx()->pipelineId
+               << " drv=" << operatorCtx_->driverCtx()->driverId
+               << " partition=" << partition_
+               << " pullCount=" << lePullCount_
+               << " pullRows=" << lePullRows_;
   Operator::close();
   if (queue_) {
     queue_->close();

--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -198,6 +198,10 @@ class LocalExchange : public SourceOperator {
   const std::shared_ptr<LocalExchangeQueue> queue_{nullptr};
   ContinueFuture future_;
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};
+
+  // Diagnostic counters for Q8 batch fragmentation investigation.
+  int64_t lePullCount_{0};
+  int64_t lePullRows_{0};
 };
 
 /// Hash partitions the data using specified keys. The number of partitions is

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -218,6 +218,13 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
     auto tableWithMetadata = splitReader_->read_chunk();
     cudfTable = std::move(tableWithMetadata.tbl);
     metadata = std::move(tableWithMetadata.metadata);
+    // Capture per-chunk emit size so we can correlate scan-level batch
+    // granularity against downstream operator NVTX events. Used to localize
+    // where the 960-batch fragmentation seen in Q8 originates.
+    LOG(WARNING) << "CudfHiveDataSource::next chunk: rows="
+                 << cudfTable->num_rows()
+                 << " cols=" << cudfTable->num_columns()
+                 << " split=" << split_->filePath;
   } else {
     // Read table using the experimental parquet reader
     VELOX_CHECK_NOT_NULL(

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1006,6 +1006,31 @@ void CudfHashAggregation::initialize() {
     }
   }
 
+  // EXPERIMENTAL: restore the hasCompanionAggregates-style guard via env var
+  // to verify that d2f2b3cc2 (enable streaming for _merge_extract companions)
+  // is the cause of Q8/Q9 regression vs 5/11 baseline. When
+  // CUDF_RESTORE_COMPANION_NONSTREAMING=1, any aggregate whose kind ends
+  // with _partial / _merge / contains _merge_extract triggers non-streaming
+  // (inputs_ accumulate + one concat at noMoreInput) for THIS operator.
+  // Expected: Q8 returns to ~3.84s; Q17 OOMs at 2^31 (proves why d2f2b3cc2
+  // removed the guard originally).
+  if (const char* restore = std::getenv("CUDF_RESTORE_COMPANION_NONSTREAMING")) {
+    if (std::string_view(restore) == "1") {
+      bool hasCompanion = false;
+      for (const auto& agg : aggregationNode_->aggregates()) {
+        const auto& kind = agg.call->name();
+        if (kind.ends_with("_partial") || kind.ends_with("_merge") ||
+            kind.find("_merge_extract") != std::string::npos) {
+          hasCompanion = true;
+          break;
+        }
+      }
+      if (hasCompanion) {
+        streamingEnabled_ = false;
+      }
+    }
+  }
+
 
   // Make aggregators for intermediate step when streaming is enabled.
   // Distinct does not need any aggregators.

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1177,10 +1177,32 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
                          ? static_cast<int64_t>(compactedOutput->estimateFlatSize())
                          : -1);
     bufferedResult_ = compactedOutput;
+    partialConcatEvents_++;
+    partialCumulativeSmallRows_ += groupbyOnInput->size();
+
+    // Convergence detection: after at least 2 cross-batch merges, check
+    // whether bufferedResult_ is compacting relative to cumulative small
+    // input. If not, switch to bypass mode.
+    if (!partialBypassMode_ && partialConcatEvents_ >= 2) {
+      static constexpr double kPartialBypassThreshold = 0.75;
+      const int64_t bufRows = bufferedResult_->size();
+      const double ratio = partialCumulativeSmallRows_ > 0
+          ? static_cast<double>(bufRows) /
+              static_cast<double>(partialCumulativeSmallRows_)
+          : 0.0;
+      if (ratio > kPartialBypassThreshold) {
+        LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
+                     << "] partial bypass mode triggered: ratio="
+                     << ratio << " buf_rows=" << bufRows
+                     << " cum_small=" << partialCumulativeSmallRows_;
+        partialBypassMode_ = true;
+      }
+    }
   } else {
     // First time processing, just store the result of the input batch's groupby
     // This means we're storing the stream from the first batch.
     bufferedResult_ = groupbyOnInput;
+    partialCumulativeSmallRows_ += groupbyOnInput->size();
   }
 }
 
@@ -1604,9 +1626,15 @@ RowVectorPtr CudfHashAggregation::getOutput() {
 
   // Handle partial groupby and distinct.
   if (isPartialOutput_ && !isGlobal_ && streamingEnabled_) {
-    if (bufferedResult_ &&
-        bufferedResult_->estimateFlatSize() >
-            maxPartialAggregationMemoryUsage_) {
+    // In bypass mode, flush bufferedResult_ every getOutput regardless of
+    // size. Combined with computePartialGroupbyStreaming's bypass branch,
+    // this means each addInput's pre-aggregated output is emitted directly
+    // to the downstream stage without further cross-batch merging.
+    const bool bypassFlush = partialBypassMode_ && bufferedResult_;
+    if (bypassFlush ||
+        (bufferedResult_ &&
+         bufferedResult_->estimateFlatSize() >
+             maxPartialAggregationMemoryUsage_)) {
       // This is basically a flush of the partial output.
       return releaseAndResetPartialOutput();
     }

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -723,8 +723,22 @@ core::AggregationNode::Step getCompanionStep(
     return core::AggregationNode::Step::kIntermediate;
   }
 
+  // _partial companion: raw input -> partial state. Behavior depends on
+  // the requested step:
+  //   - kPartial (first-pass slot reading raw input): use kPartial
+  //     (raw -> struct).
+  //   - kIntermediate / other (an accumulator slot whose input is the
+  //     already-flushed partial state from bufferedResult_): merge
+  //     partial states, keep them as intermediate (use kIntermediate).
+  // Without slot-aware dispatch, a fixed kPartial return makes the
+  // intermediate streaming accumulator try to read struct(sum, count)
+  // as raw values, triggering cuDF "Invalid type/aggregation combination"
+  // at groupby.cu.
   if (kind.ends_with("_partial")) {
-    return core::AggregationNode::Step::kPartial;
+    if (step == core::AggregationNode::Step::kPartial) {
+      return core::AggregationNode::Step::kPartial;
+    }
+    return core::AggregationNode::Step::kIntermediate;
   }
 
   // The format is count_merge_extract_BIGINT or count_merge_extract.

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1294,6 +1294,38 @@ void CudfHashAggregation::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
                  << (compactedOutput
                          ? static_cast<int64_t>(compactedOutput->estimateFlatSize())
                          : -1);
+
+    // Runtime heuristic: when streaming compaction fails to reduce row
+    // count (concat input and compacted output are nearly the same size),
+    // the data has no key-overlap between batches (e.g. lineitem sorted
+    // by the group key feeds disjoint key ranges to each batch). In that
+    // case, every further batch pays the full O(bufferedResult_) D2D copy
+    // cost in the next concat without any compaction benefit. Stop
+    // streaming, preserve current cumulative state as one inputs_ entry,
+    // and let future addInputs accumulate raw inputs for one-shot concat
+    // at noMoreInput time.
+    static constexpr int64_t kStreamingFallbackMinConcatRows = 1'000'000;
+    static constexpr double kStreamingFallbackCompactionThreshold = 0.95;
+    const int64_t concatRows = concatenatedTable->num_rows();
+    const int64_t compactedRows =
+        compactedOutput ? static_cast<int64_t>(compactedOutput->size()) : 0;
+    const double compactionRatio = concatRows > 0
+        ? static_cast<double>(compactedRows) / concatRows
+        : 0.0;
+    if (concatRows > kStreamingFallbackMinConcatRows &&
+        compactionRatio > kStreamingFallbackCompactionThreshold) {
+      LOG(WARNING)
+          << "STREAM_SINGLE[" << planNodeId()
+          << "] disabling streaming: compaction ineffective "
+          << "(concat_rows=" << concatRows
+          << " compacted_rows=" << compactedRows
+          << " ratio=" << compactionRatio
+          << "). Falling back to non-streaming concat-once.";
+      inputs_.push_back(std::move(compactedOutput));
+      bufferedResult_.reset();
+      streamingEnabled_ = false;
+      return;
+    }
     bufferedResult_ = compactedOutput;
   } else {
     bufferedResult_ = groupbyOnInput;

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -991,6 +991,17 @@ void CudfHashAggregation::initialize() {
   // limit on high-cardinality final aggregations.
   streamingEnabled_ = !isGlobal_;
 
+  // Experimental override: env var CUDF_DISABLE_AGG_STREAMING=1 forces the
+  // non-streaming (inputs_-accumulate then final concat) path even when
+  // streaming would otherwise be picked. Used to A/B compare streaming
+  // overhead against per-driver concat cost when row count fits under
+  // 2^31. Read once per operator construction.
+  if (const char* disable = std::getenv("CUDF_DISABLE_AGG_STREAMING")) {
+    if (std::string_view(disable) == "1") {
+      streamingEnabled_ = false;
+    }
+  }
+
   // Make aggregators for intermediate step when streaming is enabled.
   // Distinct does not need any aggregators.
   if (streamingEnabled_ && !isDistinct_) {

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -992,13 +992,35 @@ void CudfHashAggregation::initialize() {
   streamingEnabled_ = !isGlobal_;
 
   // Experimental override: env var CUDF_DISABLE_AGG_STREAMING=1 forces the
-  // non-streaming (inputs_-accumulate then final concat) path even when
-  // streaming would otherwise be picked. Used to A/B compare streaming
-  // overhead against per-driver concat cost when row count fits under
-  // 2^31. Read once per operator construction.
-  if (const char* disable = std::getenv("CUDF_DISABLE_AGG_STREAMING")) {
-    if (std::string_view(disable) == "1") {
-      streamingEnabled_ = false;
+  // non-streaming (inputs_-accumulate then final concat) path. Limited to
+  // kSingle step only -- a global disable would also block PARTIAL stages,
+  // and PARTIAL's bufferedResult_ flush mechanism is what keeps high-card
+  // groupby (Q17 lineitem) under cuDF's 2^31 column-size limit. PARTIAL
+  // streaming must stay on so that the upstream stage's row count is
+  // bounded before reaching kSingle's inputs_ accumulation.
+  if (isSingleStep_) {
+    if (const char* disable = std::getenv("CUDF_DISABLE_AGG_STREAMING")) {
+      if (std::string_view(disable) == "1") {
+        streamingEnabled_ = false;
+      }
+    }
+  }
+
+  // K-batched streaming knob: when CUDF_STREAMING_BATCH_K=K with K>=2, the
+  // single-step streaming path buffers K per-batch pre-aggregated results
+  // in pendingResults_ before doing a single merge into bufferedResult_.
+  // This reduces total D2D concat cost by a factor of K when compaction
+  // ratio is high (each subsequent merge would otherwise copy the full
+  // bufferedResult_). Default 1 preserves the original behavior.
+  streamingBatchK_ = 1;
+  if (const char* k = std::getenv("CUDF_STREAMING_BATCH_K")) {
+    try {
+      const int parsed = std::stoi(k);
+      if (parsed >= 1) {
+        streamingBatchK_ = parsed;
+      }
+    } catch (...) {
+      // Fall through with default.
     }
   }
 
@@ -1271,6 +1293,17 @@ void CudfHashAggregation::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
                        ? static_cast<int64_t>(groupbyOnInput->estimateFlatSize())
                        : -1);
 
+  if (streamingBatchK_ > 1) {
+    // K-batched path: defer the cross-batch merge. Accumulate up to K
+    // per-batch pre-aggregated results before paying one O(bufferedResult_)
+    // D2D copy + one intermediate-agg pass.
+    pendingResults_.push_back(groupbyOnInput);
+    if (static_cast<int>(pendingResults_.size()) >= streamingBatchK_) {
+      flushPendingToBufferedSingle();
+    }
+    return;
+  }
+
   if (bufferedResult_) {
     std::vector<cudf::table_view> tablesToConcat;
     tablesToConcat.push_back(bufferedResult_->getTableView());
@@ -1341,6 +1374,77 @@ void CudfHashAggregation::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
   } else {
     bufferedResult_ = groupbyOnInput;
   }
+}
+
+void CudfHashAggregation::flushPendingToBufferedSingle() {
+  if (pendingResults_.empty()) {
+    return;
+  }
+
+  // Pick a target stream: bufferedResult_'s stream if present, otherwise
+  // the first pending entry's stream.
+  auto targetStream =
+      bufferedResult_ ? bufferedResult_->stream() : pendingResults_.front()->stream();
+
+  // Build the concat input list: [bufferedResult_] + all pendingResults_.
+  std::vector<cudf::table_view> tablesToConcat;
+  tablesToConcat.reserve(pendingResults_.size() + 1);
+  if (bufferedResult_) {
+    tablesToConcat.push_back(bufferedResult_->getTableView());
+  }
+  std::vector<rmm::cuda_stream_view> inputStreams;
+  inputStreams.reserve(pendingResults_.size());
+  for (const auto& p : pendingResults_) {
+    tablesToConcat.push_back(p->getTableView());
+    if (p->stream() != targetStream) {
+      inputStreams.push_back(p->stream());
+    }
+  }
+  if (!inputStreams.empty()) {
+    cudf::detail::join_streams(inputStreams, targetStream);
+  }
+
+  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
+               << "] flush K-batched: pending_size=" << pendingResults_.size()
+               << " buffered_rows="
+               << (bufferedResult_ ? static_cast<int64_t>(bufferedResult_->size())
+                                   : -1);
+
+  auto concatenatedTable =
+      cudf::concatenate(tablesToConcat, targetStream, get_temp_mr());
+  auto compactedOutput = doGroupByAggregation(
+      concatenatedTable->view(),
+      groupingKeyOutputChannels_,
+      intermediateAggregators_,
+      bufferedResultType_,
+      targetStream);
+  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
+               << "] flush K-batched after agg: concat_rows="
+               << concatenatedTable->num_rows() << " compacted_rows="
+               << (compactedOutput
+                       ? static_cast<int64_t>(compactedOutput->size())
+                       : -1);
+
+  // Apply the same compaction-ratio fallback heuristic as the K=1 path.
+  static constexpr int64_t kStreamingFallbackMinConcatRows = 1'000'000;
+  static constexpr double kStreamingFallbackCompactionThreshold = 0.95;
+  const int64_t concatRows = concatenatedTable->num_rows();
+  const int64_t compactedRows =
+      compactedOutput ? static_cast<int64_t>(compactedOutput->size()) : 0;
+  const double compactionRatio =
+      concatRows > 0 ? static_cast<double>(compactedRows) / concatRows : 0.0;
+  pendingResults_.clear();
+  if (concatRows > kStreamingFallbackMinConcatRows &&
+      compactionRatio > kStreamingFallbackCompactionThreshold) {
+    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
+                 << "] disabling streaming after K-batched flush: ratio="
+                 << compactionRatio;
+    inputs_.push_back(std::move(compactedOutput));
+    bufferedResult_.reset();
+    streamingEnabled_ = false;
+    return;
+  }
+  bufferedResult_ = compactedOutput;
 }
 
 void CudfHashAggregation::addInput(RowVectorPtr input) {
@@ -1529,20 +1633,31 @@ RowVectorPtr CudfHashAggregation::getOutput() {
 
   // Single streaming: finalize with final-step aggregators.
   if (isSingleStep_ && !isGlobal_ && !isDistinct_ && streamingEnabled_) {
-    finished_ = true;
-    if (!bufferedResult_) {
-      return nullptr;
+    // Drain any K-batched pending entries into bufferedResult_ before
+    // running finalAggregators_. flushPendingToBufferedSingle may itself
+    // trip the compaction-ratio fallback and disable streaming, in which
+    // case we fall through to the inputs_ concat path below.
+    if (!pendingResults_.empty()) {
+      flushPendingToBufferedSingle();
     }
-    auto stream = bufferedResult_->stream();
-    auto result = doGroupByAggregation(
-        bufferedResult_->getTableView(),
-        groupingKeyOutputChannels_,
-        finalAggregators_,
-        outputType_,
-        stream);
-    stream.synchronize();
-    bufferedResult_.reset();
-    return result;
+    if (streamingEnabled_) {
+      finished_ = true;
+      if (!bufferedResult_) {
+        return nullptr;
+      }
+      auto stream = bufferedResult_->stream();
+      auto result = doGroupByAggregation(
+          bufferedResult_->getTableView(),
+          groupingKeyOutputChannels_,
+          finalAggregators_,
+          outputType_,
+          stream);
+      stream.synchronize();
+      bufferedResult_.reset();
+      return result;
+    }
+    // If streaming was disabled by the heuristic during the flush, fall
+    // through to the non-streaming inputs_ concat path below.
   }
 
   // Final streaming: finalize with the step's own aggregators.

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1069,17 +1069,38 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
   // For every input, we'll do a groupby and compact results with the existing
   // intermediate groupby results.
 
+  // [INSTRUMENT] entry: input + current buffered state
+  LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId() << "] addInput: input_rows="
+               << tbl->size() << " input_bytes=" << tbl->estimateFlatSize()
+               << " buffered_rows="
+               << (bufferedResult_ ? static_cast<int64_t>(bufferedResult_->size()) : -1)
+               << " buffered_bytes="
+               << (bufferedResult_
+                       ? static_cast<int64_t>(bufferedResult_->estimateFlatSize())
+                       : -1);
+
   auto inputTableStream = tbl->stream();
   // Use getTableView() to avoid expensive materialization for packed_table.
   // tbl stays alive during this function call, keeping the view valid.
   auto permutedInputView = tbl->getTableView().select(
       aggregationInputChannels_.begin(), aggregationInputChannels_.end());
+
+  LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
+               << "] before doGroupBy(aggregators_)";
   auto groupbyOnInput = doGroupByAggregation(
       permutedInputView,
       groupingKeyOutputChannels_,
       aggregators_,
       bufferedResultType_,
       inputTableStream);
+  LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
+               << "] after doGroupBy(aggregators_): per_batch_rows="
+               << (groupbyOnInput ? static_cast<int64_t>(groupbyOnInput->size())
+                                  : -1)
+               << " per_batch_bytes="
+               << (groupbyOnInput
+                       ? static_cast<int64_t>(groupbyOnInput->estimateFlatSize())
+                       : -1);
 
   // If we already have partial output, concatenate the new results with it.
   if (bufferedResult_) {
@@ -1095,10 +1116,16 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
         std::vector<rmm::cuda_stream_view>{inputTableStream},
         partialOutputStream);
 
+    LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId() << "] before concat";
     // Concatenate the tables
     auto concatenatedTable =
         cudf::concatenate(tablesToConcat, partialOutputStream, get_output_mr());
+    LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
+                 << "] after concat: concat_rows="
+                 << concatenatedTable->num_rows();
 
+    LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
+                 << "] before doGroupBy(intermediateAggregators_)";
     // Now we have to groupby again but this time with intermediate aggregators.
     // Keep concatenatedTable alive while we use its view.
     auto compactedOutput = doGroupByAggregation(
@@ -1107,6 +1134,15 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
         intermediateAggregators_,
         bufferedResultType_,
         partialOutputStream);
+    LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
+                 << "] after doGroupBy(intermediateAggregators_): compacted_rows="
+                 << (compactedOutput
+                         ? static_cast<int64_t>(compactedOutput->size())
+                         : -1)
+                 << " compacted_bytes="
+                 << (compactedOutput
+                         ? static_cast<int64_t>(compactedOutput->estimateFlatSize())
+                         : -1);
     bufferedResult_ = compactedOutput;
   } else {
     // First time processing, just store the result of the input batch's groupby
@@ -1193,15 +1229,36 @@ void CudfHashAggregation::computeFinalGroupbyStreaming(CudfVectorPtr tbl) {
 }
 
 void CudfHashAggregation::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
+  // [INSTRUMENT] entry: input + current buffered state
+  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId() << "] addInput: input_rows="
+               << tbl->size() << " input_bytes=" << tbl->estimateFlatSize()
+               << " buffered_rows="
+               << (bufferedResult_ ? static_cast<int64_t>(bufferedResult_->size()) : -1)
+               << " buffered_bytes="
+               << (bufferedResult_
+                       ? static_cast<int64_t>(bufferedResult_->estimateFlatSize())
+                       : -1);
+
   auto inputTableStream = tbl->stream();
   auto permutedInputView = tbl->getTableView().select(
       aggregationInputChannels_.begin(), aggregationInputChannels_.end());
+
+  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
+               << "] before doGroupBy(partialAggregators_)";
   auto groupbyOnInput = doGroupByAggregation(
       permutedInputView,
       groupingKeyOutputChannels_,
       partialAggregators_,
       bufferedResultType_,
       inputTableStream);
+  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
+               << "] after doGroupBy(partialAggregators_): per_batch_rows="
+               << (groupbyOnInput ? static_cast<int64_t>(groupbyOnInput->size())
+                                  : -1)
+               << " per_batch_bytes="
+               << (groupbyOnInput
+                       ? static_cast<int64_t>(groupbyOnInput->estimateFlatSize())
+                       : -1);
 
   if (bufferedResult_) {
     std::vector<cudf::table_view> tablesToConcat;
@@ -1213,15 +1270,30 @@ void CudfHashAggregation::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
         std::vector<rmm::cuda_stream_view>{inputTableStream},
         partialOutputStream);
 
+    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId() << "] before concat";
     auto concatenatedTable =
         cudf::concatenate(tablesToConcat, partialOutputStream, get_temp_mr());
+    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
+                 << "] after concat: concat_rows="
+                 << concatenatedTable->num_rows();
 
+    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
+                 << "] before doGroupBy(intermediateAggregators_)";
     auto compactedOutput = doGroupByAggregation(
         concatenatedTable->view(),
         groupingKeyOutputChannels_,
         intermediateAggregators_,
         bufferedResultType_,
         partialOutputStream);
+    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
+                 << "] after doGroupBy(intermediateAggregators_): compacted_rows="
+                 << (compactedOutput
+                         ? static_cast<int64_t>(compactedOutput->size())
+                         : -1)
+                 << " compacted_bytes="
+                 << (compactedOutput
+                         ? static_cast<int64_t>(compactedOutput->estimateFlatSize())
+                         : -1);
     bufferedResult_ = compactedOutput;
   } else {
     bufferedResult_ = groupbyOnInput;

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1006,28 +1006,16 @@ void CudfHashAggregation::initialize() {
     }
   }
 
-  // EXPERIMENTAL: restore the hasCompanionAggregates-style guard via env var
-  // to verify that d2f2b3cc2 (enable streaming for _merge_extract companions)
-  // is the cause of Q8/Q9 regression vs 5/11 baseline. When
-  // CUDF_RESTORE_COMPANION_NONSTREAMING=1, any aggregate whose kind ends
-  // with _partial / _merge / contains _merge_extract triggers non-streaming
-  // (inputs_ accumulate + one concat at noMoreInput) for THIS operator.
-  // Expected: Q8 returns to ~3.84s; Q17 OOMs at 2^31 (proves why d2f2b3cc2
-  // removed the guard originally).
+  // EXPERIMENTAL: when CUDF_RESTORE_COMPANION_NONSTREAMING=1, force
+  // non-streaming for *every* groupby aggregation operator. Tightest possible
+  // test to isolate whether the Q8/Q9 regression is in the streaming path
+  // itself or somewhere else in the binary.
   if (const char* restore = std::getenv("CUDF_RESTORE_COMPANION_NONSTREAMING")) {
     if (std::string_view(restore) == "1") {
-      bool hasCompanion = false;
-      for (const auto& agg : aggregationNode_->aggregates()) {
-        const auto& kind = agg.call->name();
-        if (kind.ends_with("_partial") || kind.ends_with("_merge") ||
-            kind.find("_merge_extract") != std::string::npos) {
-          hasCompanion = true;
-          break;
-        }
-      }
-      if (hasCompanion) {
-        streamingEnabled_ = false;
-      }
+      LOG(WARNING) << "AGG_INIT[" << planNodeId()
+                   << "] CUDF_RESTORE_COMPANION_NONSTREAMING=1 set; "
+                   << "forcing non-streaming (was " << streamingEnabled_ << ")";
+      streamingEnabled_ = false;
     }
   }
 

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1180,10 +1180,13 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
     partialConcatEvents_++;
     partialCumulativeSmallRows_ += groupbyOnInput->size();
 
-    // Convergence detection: after at least 2 cross-batch merges, check
+    // Convergence detection: after the first cross-batch merge, check
     // whether bufferedResult_ is compacting relative to cumulative small
-    // input. If not, switch to bypass mode.
-    if (!partialBypassMode_ && partialConcatEvents_ >= 2) {
+    // input. If not, switch to bypass mode. Earlier detection saves one
+    // batch worth of wasted concat+agg work on non-converging cases (Q18);
+    // safe for converging cases (Q17 ratio at first concat is ~0.54, well
+    // below the 0.75 threshold).
+    if (!partialBypassMode_ && partialConcatEvents_ >= 1) {
       static constexpr double kPartialBypassThreshold = 0.75;
       const int64_t bufRows = bufferedResult_->size();
       const double ratio = partialCumulativeSmallRows_ > 0

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1177,16 +1177,14 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
                          ? static_cast<int64_t>(compactedOutput->estimateFlatSize())
                          : -1);
     bufferedResult_ = compactedOutput;
-    partialConcatEvents_++;
     partialCumulativeSmallRows_ += groupbyOnInput->size();
 
-    // Convergence detection: after the first cross-batch merge, check
-    // whether bufferedResult_ is compacting relative to cumulative small
-    // input. If not, switch to bypass mode. Earlier detection saves one
-    // batch worth of wasted concat+agg work on non-converging cases (Q18);
-    // safe for converging cases (Q17 ratio at first concat is ~0.54, well
-    // below the 0.75 threshold).
-    if (!partialBypassMode_ && partialConcatEvents_ >= 1) {
+    // Convergence detection: after each cross-batch merge, check whether
+    // bufferedResult_ is compacting relative to cumulative small input.
+    // If not, switch to bypass mode. Q17 ratio at first concat is ~0.54
+    // (well below 0.75 threshold) so it stays accumulating; Q18 ratio is
+    // 1.0 and trips immediately.
+    if (!partialBypassMode_) {
       static constexpr double kPartialBypassThreshold = 0.75;
       const int64_t bufRows = bufferedResult_->size();
       const double ratio = partialCumulativeSmallRows_ > 0

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -982,14 +982,16 @@ void CudfHashAggregation::initialize() {
       aggregationNode_->step(),
       outputType_,
       aggregationInput.constants);
-  // The hasCompanionAggregates guard (PR #16488) kept streaming on
-  // Presto-style plans only (bare function names like "avg"). With the
-  // slot-aware getCompanionStep above, _merge_extract companions can
-  // correctly participate in the 4-slot streaming pipeline, so the
-  // guard is no longer needed; removing it lets MPP single-task plans
-  // (which always use companion names) avoid the 2^31 column-size
-  // limit on high-cardinality final aggregations.
-  streamingEnabled_ = !isGlobal_;
+  // EXPERIMENT: restore the original hasCompanionAggregates guard
+  // (temporarily reverts Patch B) so Q18 falls back to non-streaming
+  // concat-once. Keeps Patch A (slot-aware getCompanionStep) + Patch C
+  // (companionAwareIntermediateType) + Patch D (slot-aware _partial)
+  // so Q17's canBeEvaluatedByCudf signature lookup still works on GPU
+  // via the non-streaming aggregators_ slot. Goal: see whether
+  // non-streaming Q18 actually OOMs at the same scale or works (proving
+  // streaming-specific overhead is the OOM trigger, not raw data size).
+  streamingEnabled_ =
+      !hasCompanionAggregates(aggregationNode_->aggregates()) && !isGlobal_;
 
   // Make aggregators for intermediate step when streaming is enabled.
   // Distinct does not need any aggregators.

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1006,23 +1006,6 @@ void CudfHashAggregation::initialize() {
     }
   }
 
-  // K-batched streaming knob: when CUDF_STREAMING_BATCH_K=K with K>=2, the
-  // single-step streaming path buffers K per-batch pre-aggregated results
-  // in pendingResults_ before doing a single merge into bufferedResult_.
-  // This reduces total D2D concat cost by a factor of K when compaction
-  // ratio is high (each subsequent merge would otherwise copy the full
-  // bufferedResult_). Default 1 preserves the original behavior.
-  streamingBatchK_ = 1;
-  if (const char* k = std::getenv("CUDF_STREAMING_BATCH_K")) {
-    try {
-      const int parsed = std::stoi(k);
-      if (parsed >= 1) {
-        streamingBatchK_ = parsed;
-      }
-    } catch (...) {
-      // Fall through with default.
-    }
-  }
 
   // Make aggregators for intermediate step when streaming is enabled.
   // Distinct does not need any aggregators.
@@ -1101,39 +1084,18 @@ void CudfHashAggregation::setupGroupingKeyChannelProjections(
 void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
   // For every input, we'll do a groupby and compact results with the existing
   // intermediate groupby results.
-
-  // [INSTRUMENT] entry: input + current buffered state
-  LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId() << "] addInput: input_rows="
-               << tbl->size() << " input_bytes=" << tbl->estimateFlatSize()
-               << " buffered_rows="
-               << (bufferedResult_ ? static_cast<int64_t>(bufferedResult_->size()) : -1)
-               << " buffered_bytes="
-               << (bufferedResult_
-                       ? static_cast<int64_t>(bufferedResult_->estimateFlatSize())
-                       : -1);
-
   auto inputTableStream = tbl->stream();
   // Use getTableView() to avoid expensive materialization for packed_table.
   // tbl stays alive during this function call, keeping the view valid.
   auto permutedInputView = tbl->getTableView().select(
       aggregationInputChannels_.begin(), aggregationInputChannels_.end());
 
-  LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
-               << "] before doGroupBy(aggregators_)";
   auto groupbyOnInput = doGroupByAggregation(
       permutedInputView,
       groupingKeyOutputChannels_,
       aggregators_,
       bufferedResultType_,
       inputTableStream);
-  LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
-               << "] after doGroupBy(aggregators_): per_batch_rows="
-               << (groupbyOnInput ? static_cast<int64_t>(groupbyOnInput->size())
-                                  : -1)
-               << " per_batch_bytes="
-               << (groupbyOnInput
-                       ? static_cast<int64_t>(groupbyOnInput->estimateFlatSize())
-                       : -1);
 
   // If we already have partial output, concatenate the new results with it.
   if (bufferedResult_) {
@@ -1149,16 +1111,9 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
         std::vector<rmm::cuda_stream_view>{inputTableStream},
         partialOutputStream);
 
-    LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId() << "] before concat";
-    // Concatenate the tables
     auto concatenatedTable =
         cudf::concatenate(tablesToConcat, partialOutputStream, get_output_mr());
-    LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
-                 << "] after concat: concat_rows="
-                 << concatenatedTable->num_rows();
 
-    LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
-                 << "] before doGroupBy(intermediateAggregators_)";
     // Now we have to groupby again but this time with intermediate aggregators.
     // Keep concatenatedTable alive while we use its view.
     auto compactedOutput = doGroupByAggregation(
@@ -1167,15 +1122,6 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
         intermediateAggregators_,
         bufferedResultType_,
         partialOutputStream);
-    LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
-                 << "] after doGroupBy(intermediateAggregators_): compacted_rows="
-                 << (compactedOutput
-                         ? static_cast<int64_t>(compactedOutput->size())
-                         : -1)
-                 << " compacted_bytes="
-                 << (compactedOutput
-                         ? static_cast<int64_t>(compactedOutput->estimateFlatSize())
-                         : -1);
     bufferedResult_ = compactedOutput;
     partialCumulativeSmallRows_ += groupbyOnInput->size();
 
@@ -1285,47 +1231,16 @@ void CudfHashAggregation::computeFinalGroupbyStreaming(CudfVectorPtr tbl) {
 }
 
 void CudfHashAggregation::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
-  // [INSTRUMENT] entry: input + current buffered state
-  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId() << "] addInput: input_rows="
-               << tbl->size() << " input_bytes=" << tbl->estimateFlatSize()
-               << " buffered_rows="
-               << (bufferedResult_ ? static_cast<int64_t>(bufferedResult_->size()) : -1)
-               << " buffered_bytes="
-               << (bufferedResult_
-                       ? static_cast<int64_t>(bufferedResult_->estimateFlatSize())
-                       : -1);
-
   auto inputTableStream = tbl->stream();
   auto permutedInputView = tbl->getTableView().select(
       aggregationInputChannels_.begin(), aggregationInputChannels_.end());
 
-  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
-               << "] before doGroupBy(partialAggregators_)";
   auto groupbyOnInput = doGroupByAggregation(
       permutedInputView,
       groupingKeyOutputChannels_,
       partialAggregators_,
       bufferedResultType_,
       inputTableStream);
-  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
-               << "] after doGroupBy(partialAggregators_): per_batch_rows="
-               << (groupbyOnInput ? static_cast<int64_t>(groupbyOnInput->size())
-                                  : -1)
-               << " per_batch_bytes="
-               << (groupbyOnInput
-                       ? static_cast<int64_t>(groupbyOnInput->estimateFlatSize())
-                       : -1);
-
-  if (streamingBatchK_ > 1) {
-    // K-batched path: defer the cross-batch merge. Accumulate up to K
-    // per-batch pre-aggregated results before paying one O(bufferedResult_)
-    // D2D copy + one intermediate-agg pass.
-    pendingResults_.push_back(groupbyOnInput);
-    if (static_cast<int>(pendingResults_.size()) >= streamingBatchK_) {
-      flushPendingToBufferedSingle();
-    }
-    return;
-  }
 
   if (bufferedResult_) {
     std::vector<cudf::table_view> tablesToConcat;
@@ -1337,137 +1252,19 @@ void CudfHashAggregation::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
         std::vector<rmm::cuda_stream_view>{inputTableStream},
         partialOutputStream);
 
-    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId() << "] before concat";
     auto concatenatedTable =
         cudf::concatenate(tablesToConcat, partialOutputStream, get_temp_mr());
-    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
-                 << "] after concat: concat_rows="
-                 << concatenatedTable->num_rows();
 
-    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
-                 << "] before doGroupBy(intermediateAggregators_)";
     auto compactedOutput = doGroupByAggregation(
         concatenatedTable->view(),
         groupingKeyOutputChannels_,
         intermediateAggregators_,
         bufferedResultType_,
         partialOutputStream);
-    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
-                 << "] after doGroupBy(intermediateAggregators_): compacted_rows="
-                 << (compactedOutput
-                         ? static_cast<int64_t>(compactedOutput->size())
-                         : -1)
-                 << " compacted_bytes="
-                 << (compactedOutput
-                         ? static_cast<int64_t>(compactedOutput->estimateFlatSize())
-                         : -1);
-
-    // Runtime heuristic: when streaming compaction fails to reduce row
-    // count (concat input and compacted output are nearly the same size),
-    // the data has no key-overlap between batches (e.g. lineitem sorted
-    // by the group key feeds disjoint key ranges to each batch). In that
-    // case, every further batch pays the full O(bufferedResult_) D2D copy
-    // cost in the next concat without any compaction benefit. Stop
-    // streaming, preserve current cumulative state as one inputs_ entry,
-    // and let future addInputs accumulate raw inputs for one-shot concat
-    // at noMoreInput time.
-    static constexpr int64_t kStreamingFallbackMinConcatRows = 1'000'000;
-    static constexpr double kStreamingFallbackCompactionThreshold = 0.95;
-    const int64_t concatRows = concatenatedTable->num_rows();
-    const int64_t compactedRows =
-        compactedOutput ? static_cast<int64_t>(compactedOutput->size()) : 0;
-    const double compactionRatio = concatRows > 0
-        ? static_cast<double>(compactedRows) / concatRows
-        : 0.0;
-    if (concatRows > kStreamingFallbackMinConcatRows &&
-        compactionRatio > kStreamingFallbackCompactionThreshold) {
-      LOG(WARNING)
-          << "STREAM_SINGLE[" << planNodeId()
-          << "] disabling streaming: compaction ineffective "
-          << "(concat_rows=" << concatRows
-          << " compacted_rows=" << compactedRows
-          << " ratio=" << compactionRatio
-          << "). Falling back to non-streaming concat-once.";
-      inputs_.push_back(std::move(compactedOutput));
-      bufferedResult_.reset();
-      streamingEnabled_ = false;
-      return;
-    }
     bufferedResult_ = compactedOutput;
   } else {
     bufferedResult_ = groupbyOnInput;
   }
-}
-
-void CudfHashAggregation::flushPendingToBufferedSingle() {
-  if (pendingResults_.empty()) {
-    return;
-  }
-
-  // Pick a target stream: bufferedResult_'s stream if present, otherwise
-  // the first pending entry's stream.
-  auto targetStream =
-      bufferedResult_ ? bufferedResult_->stream() : pendingResults_.front()->stream();
-
-  // Build the concat input list: [bufferedResult_] + all pendingResults_.
-  std::vector<cudf::table_view> tablesToConcat;
-  tablesToConcat.reserve(pendingResults_.size() + 1);
-  if (bufferedResult_) {
-    tablesToConcat.push_back(bufferedResult_->getTableView());
-  }
-  std::vector<rmm::cuda_stream_view> inputStreams;
-  inputStreams.reserve(pendingResults_.size());
-  for (const auto& p : pendingResults_) {
-    tablesToConcat.push_back(p->getTableView());
-    if (p->stream() != targetStream) {
-      inputStreams.push_back(p->stream());
-    }
-  }
-  if (!inputStreams.empty()) {
-    cudf::detail::join_streams(inputStreams, targetStream);
-  }
-
-  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
-               << "] flush K-batched: pending_size=" << pendingResults_.size()
-               << " buffered_rows="
-               << (bufferedResult_ ? static_cast<int64_t>(bufferedResult_->size())
-                                   : -1);
-
-  auto concatenatedTable =
-      cudf::concatenate(tablesToConcat, targetStream, get_temp_mr());
-  auto compactedOutput = doGroupByAggregation(
-      concatenatedTable->view(),
-      groupingKeyOutputChannels_,
-      intermediateAggregators_,
-      bufferedResultType_,
-      targetStream);
-  LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
-               << "] flush K-batched after agg: concat_rows="
-               << concatenatedTable->num_rows() << " compacted_rows="
-               << (compactedOutput
-                       ? static_cast<int64_t>(compactedOutput->size())
-                       : -1);
-
-  // Apply the same compaction-ratio fallback heuristic as the K=1 path.
-  static constexpr int64_t kStreamingFallbackMinConcatRows = 1'000'000;
-  static constexpr double kStreamingFallbackCompactionThreshold = 0.95;
-  const int64_t concatRows = concatenatedTable->num_rows();
-  const int64_t compactedRows =
-      compactedOutput ? static_cast<int64_t>(compactedOutput->size()) : 0;
-  const double compactionRatio =
-      concatRows > 0 ? static_cast<double>(compactedRows) / concatRows : 0.0;
-  pendingResults_.clear();
-  if (concatRows > kStreamingFallbackMinConcatRows &&
-      compactionRatio > kStreamingFallbackCompactionThreshold) {
-    LOG(WARNING) << "STREAM_SINGLE[" << planNodeId()
-                 << "] disabling streaming after K-batched flush: ratio="
-                 << compactionRatio;
-    inputs_.push_back(std::move(compactedOutput));
-    bufferedResult_.reset();
-    streamingEnabled_ = false;
-    return;
-  }
-  bufferedResult_ = compactedOutput;
 }
 
 void CudfHashAggregation::addInput(RowVectorPtr input) {
@@ -1662,31 +1459,20 @@ RowVectorPtr CudfHashAggregation::getOutput() {
 
   // Single streaming: finalize with final-step aggregators.
   if (isSingleStep_ && !isGlobal_ && !isDistinct_ && streamingEnabled_) {
-    // Drain any K-batched pending entries into bufferedResult_ before
-    // running finalAggregators_. flushPendingToBufferedSingle may itself
-    // trip the compaction-ratio fallback and disable streaming, in which
-    // case we fall through to the inputs_ concat path below.
-    if (!pendingResults_.empty()) {
-      flushPendingToBufferedSingle();
+    finished_ = true;
+    if (!bufferedResult_) {
+      return nullptr;
     }
-    if (streamingEnabled_) {
-      finished_ = true;
-      if (!bufferedResult_) {
-        return nullptr;
-      }
-      auto stream = bufferedResult_->stream();
-      auto result = doGroupByAggregation(
-          bufferedResult_->getTableView(),
-          groupingKeyOutputChannels_,
-          finalAggregators_,
-          outputType_,
-          stream);
-      stream.synchronize();
-      bufferedResult_.reset();
-      return result;
-    }
-    // If streaming was disabled by the heuristic during the flush, fall
-    // through to the non-streaming inputs_ concat path below.
+    auto stream = bufferedResult_->stream();
+    auto result = doGroupByAggregation(
+        bufferedResult_->getTableView(),
+        groupingKeyOutputChannels_,
+        finalAggregators_,
+        outputType_,
+        stream);
+    stream.synchronize();
+    bufferedResult_.reset();
+    return result;
   }
 
   // Final streaming: finalize with the step's own aggregators.

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -982,16 +982,14 @@ void CudfHashAggregation::initialize() {
       aggregationNode_->step(),
       outputType_,
       aggregationInput.constants);
-  // EXPERIMENT: restore the original hasCompanionAggregates guard
-  // (temporarily reverts Patch B) so Q18 falls back to non-streaming
-  // concat-once. Keeps Patch A (slot-aware getCompanionStep) + Patch C
-  // (companionAwareIntermediateType) + Patch D (slot-aware _partial)
-  // so Q17's canBeEvaluatedByCudf signature lookup still works on GPU
-  // via the non-streaming aggregators_ slot. Goal: see whether
-  // non-streaming Q18 actually OOMs at the same scale or works (proving
-  // streaming-specific overhead is the OOM trigger, not raw data size).
-  streamingEnabled_ =
-      !hasCompanionAggregates(aggregationNode_->aggregates()) && !isGlobal_;
+  // The hasCompanionAggregates guard (PR #16488) kept streaming on
+  // Presto-style plans only (bare function names like "avg"). With the
+  // slot-aware getCompanionStep above, _merge_extract companions can
+  // correctly participate in the 4-slot streaming pipeline, so the
+  // guard is no longer needed; removing it lets MPP single-task plans
+  // (which always use companion names) avoid the 2^31 column-size
+  // limit on high-cardinality final aggregations.
+  streamingEnabled_ = !isGlobal_;
 
   // Make aggregators for intermediate step when streaming is enabled.
   // Distinct does not need any aggregators.

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -728,12 +728,18 @@ core::AggregationNode::Step getCompanionStep(
   }
 
   // The format is count_merge_extract_BIGINT or count_merge_extract.
-  // In a SINGLE-step aggregation node, _merge_extract companions receive raw
-  // input (not intermediate state) so they must use kSingle signatures and
-  // aggregation logic rather than kFinal.
+  // _merge_extract companion: input is intermediate state (e.g.
+  // row(sum, count) for avg); output depends on the requested step.
+  //   - kPartial / kIntermediate (streaming slot building a partial or
+  //     intermediate accumulator): merge intermediate states, keep them
+  //     as intermediate (sum+count grow, no extract).
+  //   - kFinal / kSingle (final extraction or canBeEvaluatedByCudf
+  //     signature check against the plan-level final signature): consume
+  //     intermediate state and produce the final value.
   if (kind.find("_merge_extract") != std::string::npos) {
-    if (step == core::AggregationNode::Step::kSingle) {
-      return core::AggregationNode::Step::kSingle;
+    if (step == core::AggregationNode::Step::kPartial ||
+        step == core::AggregationNode::Step::kIntermediate) {
+      return core::AggregationNode::Step::kIntermediate;
     }
     return core::AggregationNode::Step::kFinal;
   }
@@ -755,6 +761,28 @@ std::string getOriginalName(const std::string& kind) {
   }
 
   return kind;
+}
+
+// Resolve the intermediate (partial-output) type of an aggregate. For
+// companion aggregates whose input is already intermediate state
+// (_merge, _merge_extract), the intermediate type IS the input type:
+// velox CPU exec::resolveIntermediateType only knows raw-input
+// signatures for the base function and will fail when given an
+// already-intermediate row(...) input.
+TypePtr companionAwareIntermediateType(
+    core::AggregationNode::Aggregate const& aggregate) {
+  const auto& kind = aggregate.call->name();
+  if (kind.ends_with("_merge") ||
+      kind.find("_merge_extract") != std::string::npos) {
+    VELOX_CHECK_EQ(
+        aggregate.rawInputTypes.size(),
+        1,
+        "Companion aggregate must have exactly one input type: {}",
+        kind);
+    return aggregate.rawInputTypes[0];
+  }
+  return exec::resolveIntermediateType(
+      getOriginalName(kind), aggregate.rawInputTypes);
 }
 
 bool hasFinalAggs(
@@ -849,9 +877,8 @@ auto toAggregators(
     auto const kind = aggregate.call->name();
     auto const constant = constants[i];
     auto const companionStep = getCompanionStep(kind, step);
-    const auto originalName = getOriginalName(kind);
     const auto resultType = exec::isPartialOutput(companionStep)
-        ? exec::resolveIntermediateType(originalName, aggregate.rawInputTypes)
+        ? companionAwareIntermediateType(aggregate)
         : outputType->childAt(numKeys + i);
 
     aggregators.push_back(createAggregator(
@@ -873,9 +900,7 @@ RowTypePtr getFinalStepBufferedType(
 
   for (auto i = 0; i < aggregationNode.aggregates().size(); ++i) {
     auto const& aggregate = aggregationNode.aggregates()[i];
-    const auto originalName = getOriginalName(aggregate.call->name());
-    types[numKeys + i] =
-        exec::resolveIntermediateType(originalName, aggregate.rawInputTypes);
+    types[numKeys + i] = companionAwareIntermediateType(aggregate);
   }
 
   return ROW(std::move(names), std::move(types));
@@ -943,8 +968,14 @@ void CudfHashAggregation::initialize() {
       aggregationNode_->step(),
       outputType_,
       aggregationInput.constants);
-  streamingEnabled_ =
-      !hasCompanionAggregates(aggregationNode_->aggregates()) && !isGlobal_;
+  // The hasCompanionAggregates guard (PR #16488) kept streaming on
+  // Presto-style plans only (bare function names like "avg"). With the
+  // slot-aware getCompanionStep above, _merge_extract companions can
+  // correctly participate in the 4-slot streaming pipeline, so the
+  // guard is no longer needed; removing it lets MPP single-task plans
+  // (which always use companion names) avoid the 2^31 column-size
+  // limit on high-cardinality final aggregations.
+  streamingEnabled_ = !isGlobal_;
 
   // Make aggregators for intermediate step when streaming is enabled.
   // Distinct does not need any aggregators.

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -735,6 +735,16 @@ core::AggregationNode::Step getCompanionStep(
   // as raw values, triggering cuDF "Invalid type/aggregation combination"
   // at groupby.cu.
   if (kind.ends_with("_partial")) {
+    // EXPERIMENTAL: env var CUDF_PARTIAL_COMPANION_LEGACY_STEP=1 reverts the
+    // slot-aware logic introduced by c65bd2c8f and returns kPartial
+    // unconditionally (the pre-c65bd2c8f / 5/11 behavior). Used to isolate
+    // whether c65bd2c8f is the root cause of the Q8/Q9 regression.
+    if (const char* legacy =
+            std::getenv("CUDF_PARTIAL_COMPANION_LEGACY_STEP")) {
+      if (std::string_view(legacy) == "1") {
+        return core::AggregationNode::Step::kPartial;
+      }
+    }
     if (step == core::AggregationNode::Step::kPartial) {
       return core::AggregationNode::Step::kPartial;
     }

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1124,7 +1124,7 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
         bufferedResultType_,
         partialOutputStream);
     bufferedResult_ = compactedOutput;
-    partialCumulativeSmallRows_ += groupbyOnInput->size();
+    partialCumulativeInputRows_ += groupbyOnInput->size();
 
     // Convergence detection: after each cross-batch merge, check whether
     // bufferedResult_ is compacting relative to cumulative small input.
@@ -1134,15 +1134,18 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
     if (!partialBypassMode_) {
       static constexpr double kPartialBypassThreshold = 0.75;
       const int64_t bufRows = bufferedResult_->size();
-      const double ratio = partialCumulativeSmallRows_ > 0
+      const double ratio = partialCumulativeInputRows_ > 0
           ? static_cast<double>(bufRows) /
-              static_cast<double>(partialCumulativeSmallRows_)
+              static_cast<double>(partialCumulativeInputRows_)
           : 0.0;
       if (ratio > kPartialBypassThreshold) {
-        LOG(WARNING) << "STREAM_PARTIAL[" << planNodeId()
-                     << "] partial bypass mode triggered: ratio="
-                     << ratio << " buf_rows=" << bufRows
-                     << " cum_small=" << partialCumulativeSmallRows_;
+        // Fires at most once per operator lifetime (partialBypassMode_ is
+        // sticky), but kept at LOG(INFO) so the transition is visible in
+        // production logs -- it's a one-shot state-change event, not noise.
+        LOG(INFO) << "STREAM_PARTIAL[" << planNodeId()
+                  << "] partial bypass mode triggered: ratio="
+                  << ratio << " buf_rows=" << bufRows
+                  << " cum_input=" << partialCumulativeInputRows_;
         partialBypassMode_ = true;
       }
     }
@@ -1150,7 +1153,7 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
     // First time processing, just store the result of the input batch's groupby
     // This means we're storing the stream from the first batch.
     bufferedResult_ = groupbyOnInput;
-    partialCumulativeSmallRows_ += groupbyOnInput->size();
+    partialCumulativeInputRows_ += groupbyOnInput->size();
   }
 }
 

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -735,16 +735,6 @@ core::AggregationNode::Step getCompanionStep(
   // as raw values, triggering cuDF "Invalid type/aggregation combination"
   // at groupby.cu.
   if (kind.ends_with("_partial")) {
-    // EXPERIMENTAL: env var CUDF_PARTIAL_COMPANION_LEGACY_STEP=1 reverts the
-    // slot-aware logic introduced by c65bd2c8f and returns kPartial
-    // unconditionally (the pre-c65bd2c8f / 5/11 behavior). Used to isolate
-    // whether c65bd2c8f is the root cause of the Q8/Q9 regression.
-    if (const char* legacy =
-            std::getenv("CUDF_PARTIAL_COMPANION_LEGACY_STEP")) {
-      if (std::string_view(legacy) == "1") {
-        return core::AggregationNode::Step::kPartial;
-      }
-    }
     if (step == core::AggregationNode::Step::kPartial) {
       return core::AggregationNode::Step::kPartial;
     }
@@ -1016,33 +1006,6 @@ void CudfHashAggregation::initialize() {
       !hasNonPartialCompanionAggregates(aggregationNode_->aggregates());
   streamingEnabled_ =
       (!hasCompanions || canStreamPartialCompanions) && !isGlobal_;
-
-  // Diagnostic override (retained from local pre-merge work, vestigial under
-  // the gating above but kept as a force-off hook): CUDF_DISABLE_AGG_STREAMING=1
-  // forces the non-streaming (inputs_-accumulate then final concat) path for
-  // kSingle only. A global disable would also block PARTIAL stages; PARTIAL's
-  // bufferedResult_ flush mechanism is what keeps high-cardinality groupby
-  // (e.g. Q17 lineitem) under cuDF's 2^31 column-size limit.
-  if (isSingleStep_) {
-    if (const char* disable = std::getenv("CUDF_DISABLE_AGG_STREAMING")) {
-      if (std::string_view(disable) == "1") {
-        streamingEnabled_ = false;
-      }
-    }
-  }
-
-  // Diagnostic override (retained from local pre-merge work): when
-  // CUDF_RESTORE_COMPANION_NONSTREAMING=1, force non-streaming for every
-  // groupby aggregation operator. Used during Q8/Q9 regression isolation.
-  if (const char* restore = std::getenv("CUDF_RESTORE_COMPANION_NONSTREAMING")) {
-    if (std::string_view(restore) == "1") {
-      LOG(WARNING) << "AGG_INIT[" << planNodeId()
-                   << "] CUDF_RESTORE_COMPANION_NONSTREAMING=1 set; "
-                   << "forcing non-streaming (was " << streamingEnabled_ << ")";
-      streamingEnabled_ = false;
-    }
-  }
-
 
   // Make aggregators for intermediate step when streaming is enabled.
   // Distinct does not need any aggregators.

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1098,6 +1098,15 @@ void CudfHashAggregation::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
       bufferedResultType_,
       inputTableStream);
 
+  // doGroupByAggregation returns nullptr when the input batch produces no
+  // output groups (for example all-null grouping keys with ignoreNullKeys_
+  // active). Skip the merge / state-update so we don't deref nullptr in
+  // the bufferedResult_ branch's getTableView() or in the first-time
+  // branch's size() accounting below.
+  if (!groupbyOnInput) {
+    return;
+  }
+
   // If we already have partial output, concatenate the new results with it.
   if (bufferedResult_) {
     // Create a vector of tables to concatenate
@@ -1420,6 +1429,13 @@ CudfVectorPtr CudfHashAggregation::releaseAndResetPartialOutput() {
   }
 
   numInputRows_ = 0;
+  // Reset cumulative input-row counter so the post-flush bypass-trigger
+  // ratio compares bufferedResult_ against rows newly accumulated AFTER
+  // the flush, not against the (now-released) pre-flush input total.
+  // Without this reset, a memory-limit flush that fires before bypass has
+  // triggered can leave the ratio permanently low and suppress later
+  // bypass detection on subsequent high-cardinality batches.
+  partialCumulativeInputRows_ = 0;
   return std::exchange(bufferedResult_, nullptr);
 }
 
@@ -1429,9 +1445,14 @@ RowVectorPtr CudfHashAggregation::getOutput() {
   // Handle partial groupby and distinct.
   if (isPartialOutput_ && !isGlobal_ && streamingEnabled_) {
     // In bypass mode, flush bufferedResult_ every getOutput regardless of
-    // size. Combined with computePartialGroupbyStreaming's bypass branch,
-    // this means each addInput's pre-aggregated output is emitted directly
-    // to the downstream stage without further cross-batch merging.
+    // size, instead of waiting for the maxPartialAggregationMemoryUsage_
+    // threshold. computePartialGroupbyStreaming itself still does the
+    // cross-batch concat + intermediate-aggregator merge each addInput
+    // (there is no skip-merge branch keyed on partialBypassMode_), so the
+    // bypass saves only the flush-latency / late-emit memory; the
+    // per-batch merge CPU/GPU cost is still paid, which preserves
+    // semantic correctness vs. emitting raw doGroupByAggregation output.
+    // See partialBypassMode_ trigger in computePartialGroupbyStreaming.
     const bool bypassFlush = partialBypassMode_ && bufferedResult_;
     if (bypassFlush ||
         (bufferedResult_ &&

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -182,6 +182,20 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
   // var in initialize(). Default 1 preserves the original "merge every
   // batch into bufferedResult_" behavior.
   int streamingBatchK_{1};
+
+  // Partial-streaming convergence detection. After at least 2 cross-batch
+  // concat+merge events in computePartialGroupbyStreaming, compare the
+  // current bufferedResult_ row count against the cumulative pre-aggregated
+  // input row count. If the ratio exceeds kPartialBypassThreshold (0.75),
+  // cross-batch merging is failing to compact (typical for high-cardinality
+  // group keys whose per-batch key ranges are disjoint, e.g., Q18
+  // lineitem-by-l_orderkey). Switch to bypass mode: subsequent batches'
+  // pre-aggregated results are flushed downstream directly without merging
+  // into bufferedResult_. Avoids the O(N^2) D2D cost of repeatedly
+  // concatenating with a growing buffered state that never compacts.
+  bool partialBypassMode_{false};
+  int partialConcatEvents_{0};
+  int64_t partialCumulativeSmallRows_{0};
 };
 
 // Step-aware aggregation function registry

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -183,10 +183,10 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
   // batch into bufferedResult_" behavior.
   int streamingBatchK_{1};
 
-  // Partial-streaming convergence detection. After at least 2 cross-batch
-  // concat+merge events in computePartialGroupbyStreaming, compare the
-  // current bufferedResult_ row count against the cumulative pre-aggregated
-  // input row count. If the ratio exceeds kPartialBypassThreshold (0.75),
+  // Partial-streaming convergence detection. After each cross-batch
+  // concat+merge in computePartialGroupbyStreaming, compare the current
+  // bufferedResult_ row count against the cumulative pre-aggregated input
+  // row count. If the ratio exceeds kPartialBypassThreshold (0.75),
   // cross-batch merging is failing to compact (typical for high-cardinality
   // group keys whose per-batch key ranges are disjoint, e.g., Q18
   // lineitem-by-l_orderkey). Switch to bypass mode: subsequent batches'
@@ -194,7 +194,6 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
   // into bufferedResult_. Avoids the O(N^2) D2D cost of repeatedly
   // concatenating with a growing buffered state that never compacts.
   bool partialBypassMode_{false};
-  int partialConcatEvents_{0};
   int64_t partialCumulativeSmallRows_{0};
 };
 

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -169,19 +169,8 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
 
   void computeSingleGroupbyStreaming(CudfVectorPtr tbl);
 
-  // K-batched streaming: when streamingBatchK_ > 1, addInput pushes the
-  // per-batch pre-aggregated result onto pendingResults_ instead of
-  // immediately merging into bufferedResult_. Merging happens once every
-  // K batches, reducing total D2D copy cost from O(M^2) to O(M^2/K).
-  void flushPendingToBufferedSingle();
-
   CudfVectorPtr bufferedResult_;
   RowTypePtr bufferedResultType_;
-  std::vector<cudf_velox::CudfVectorPtr> pendingResults_;
-  // K for K-batched streaming, read once from CUDF_STREAMING_BATCH_K env
-  // var in initialize(). Default 1 preserves the original "merge every
-  // batch into bufferedResult_" behavior.
-  int streamingBatchK_{1};
 
   // Partial-streaming convergence detection. After each cross-batch
   // concat+merge in computePartialGroupbyStreaming, compare the current

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -169,8 +169,19 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
 
   void computeSingleGroupbyStreaming(CudfVectorPtr tbl);
 
+  // K-batched streaming: when streamingBatchK_ > 1, addInput pushes the
+  // per-batch pre-aggregated result onto pendingResults_ instead of
+  // immediately merging into bufferedResult_. Merging happens once every
+  // K batches, reducing total D2D copy cost from O(M^2) to O(M^2/K).
+  void flushPendingToBufferedSingle();
+
   CudfVectorPtr bufferedResult_;
   RowTypePtr bufferedResultType_;
+  std::vector<cudf_velox::CudfVectorPtr> pendingResults_;
+  // K for K-batched streaming, read once from CUDF_STREAMING_BATCH_K env
+  // var in initialize(). Default 1 preserves the original "merge every
+  // batch into bufferedResult_" behavior.
+  int streamingBatchK_{1};
 };
 
 // Step-aware aggregation function registry

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -142,7 +142,11 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
   const bool isDistinct_;
   // Single means it's a single step aggregation (partial + final combined).
   const bool isSingleStep_;
-  // Streaming aggregation is disabled if companion aggregates are present.
+  // Streaming aggregation is enabled when (a) the aggregate is grouped (not
+  // global) AND (b) either no companion aggregates are present OR the step
+  // is kPartial with all-`_partial` companions (the latter carve-out lets
+  // Spark MPP partial-stage groupbys stream; see CudfHashAggregation::initialize
+  // for the gating logic and the canStreamPartialCompanions flag).
   bool streamingEnabled_{true};
 
   // Maximum memory usage for partial aggregation.
@@ -175,13 +179,25 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
   // Partial-streaming convergence detection. After each cross-batch
   // concat+merge in computePartialGroupbyStreaming, compare the current
   // bufferedResult_ row count against the cumulative pre-aggregated input
-  // row count. If the ratio exceeds kPartialBypassThreshold (0.75),
-  // cross-batch merging is failing to compact (typical for high-cardinality
-  // group keys whose per-batch key ranges are disjoint, e.g., Q18
-  // lineitem-by-l_orderkey). Switch to bypass mode: subsequent batches'
+  // row count.
+  //
+  // Threshold kPartialBypassThreshold = 0.75: derived from "if 2 batches
+  // pre-aggregated to S rows each fail to combine below 1.5*S after merge,
+  // future batches won't help" -- i.e. group-key ranges are effectively
+  // disjoint and continued merging is wasted D2D work. 0.75 = 1.5/2 leaves
+  // some margin around the threshold for noise. Anything > 0.75 is treated
+  // as "not converging".
+  //
+  // If the ratio exceeds 0.75, switch to bypass mode: subsequent batches'
   // pre-aggregated results are flushed downstream directly without merging
   // into bufferedResult_. Avoids the O(N^2) D2D cost of repeatedly
   // concatenating with a growing buffered state that never compacts.
+  // Typical trip cases: high-cardinality group keys whose per-batch key
+  // ranges are disjoint (e.g., Q18 lineitem-by-l_orderkey, ratio = 1.0 on
+  // first concat).
+  //
+  // partialBypassMode_ is sticky: once set, the operator stays in bypass
+  // for the rest of its lifetime (no transition back to compacting mode).
   bool partialBypassMode_{false};
   int64_t partialCumulativeSmallRows_{0};
 };

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -199,7 +199,7 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
   // partialBypassMode_ is sticky: once set, the operator stays in bypass
   // for the rest of its lifetime (no transition back to compacting mode).
   bool partialBypassMode_{false};
-  int64_t partialCumulativeSmallRows_{0};
+  int64_t partialCumulativeInputRows_{0};
 };
 
 // Step-aware aggregation function registry

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -170,9 +170,13 @@ void CudfLocalPartition::enqueuePartition(
     return;
   }
 
+  // estimateFlatSize() returns the real GPU device buffer size; size() is
+  // the row count (mistakenly used as bytes in upstream baseline) and
+  // retainedSize() returns ~0 for cudf-owned tables (children list empty),
+  // both of which defeat LocalExchangeMemoryManager backpressure.
   ContinueFuture future;
-  auto blockingReason =
-      queues_[partitionIndex]->enqueue(cudfVector, cudfVector->size(), &future);
+  auto blockingReason = queues_[partitionIndex]->enqueue(
+      cudfVector, cudfVector->estimateFlatSize(), &future);
   if (blockingReason != exec::BlockingReason::kNotBlocked) {
     blockingReasons_.push_back(blockingReason);
     futures_.push_back(std::move(future));
@@ -255,10 +259,13 @@ void CudfLocalPartition::addInput(RowVectorPtr input) {
       enqueuePartition(i, partitionCudfVector);
     }
   } else {
-    // Single partition case.
+    // Single partition case. Use estimateFlatSize() for CudfVector since
+    // retainedSize() returns ~0 for cudf tables (children list is empty).
     ContinueFuture future;
-    auto blockingReason =
-        queues_[0]->enqueue(input, input->retainedSize(), &future);
+    auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
+    const uint64_t bytes =
+        cudfInput ? cudfInput->estimateFlatSize() : input->retainedSize();
+    auto blockingReason = queues_[0]->enqueue(input, bytes, &future);
     if (blockingReason != exec::BlockingReason::kNotBlocked) {
       blockingReasons_.push_back(blockingReason);
       futures_.push_back(std::move(future));

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -190,6 +190,25 @@ void CudfLocalPartition::addInput(RowVectorPtr input) {
   auto cudfVector = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK(cudfVector, "Input must be a CudfVector");
   auto stream = cudfVector->stream();
+  // Diagnose per-driver addInput counts for Q8 fragmentation
+  // investigation. Sampled to avoid log explosion.
+  {
+    static thread_local int64_t addCounter{0};
+    static thread_local int64_t addedRows{0};
+    ++addCounter;
+    addedRows += cudfVector->size();
+    if (addCounter <= 5 || addCounter % 100 == 0) {
+      LOG(WARNING) << "LP_ADD task="
+                   << operatorCtx_->driverCtx()->task->taskId()
+                   << " pipe=" << operatorCtx_->driverCtx()->pipelineId
+                   << " drv=" << operatorCtx_->driverCtx()->driverId
+                   << " numQueues=" << queues_.size()
+                   << " numPartitions=" << numPartitions_
+                   << " add#" << addCounter
+                   << " rows=" << cudfVector->size()
+                   << " totalRows=" << addedRows;
+    }
+  }
 
   if (numPartitions_ > 1) {
     if (partitionFunctionType_ == PartitionFunctionType::kRoundRobin) {

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -169,6 +169,9 @@ void CudfLocalPartition::enqueuePartition(
     // Skip empty partitions.
     return;
   }
+  // Diagnostic: count actual enqueue events (post-hash-partition).
+  ++lpEnqueueCount_;
+  lpEnqueueRows_ += cudfVector->size();
 
   // estimateFlatSize() returns the real GPU device buffer size; size() is
   // the row count (mistakenly used as bytes in upstream baseline) and
@@ -191,24 +194,10 @@ void CudfLocalPartition::addInput(RowVectorPtr input) {
   VELOX_CHECK(cudfVector, "Input must be a CudfVector");
   auto stream = cudfVector->stream();
   // Diagnose per-driver addInput counts for Q8 fragmentation
-  // investigation. Sampled to avoid log explosion.
-  {
-    static thread_local int64_t addCounter{0};
-    static thread_local int64_t addedRows{0};
-    ++addCounter;
-    addedRows += cudfVector->size();
-    if (addCounter <= 5 || addCounter % 100 == 0) {
-      LOG(WARNING) << "LP_ADD task="
-                   << operatorCtx_->driverCtx()->task->taskId()
-                   << " pipe=" << operatorCtx_->driverCtx()->pipelineId
-                   << " drv=" << operatorCtx_->driverCtx()->driverId
-                   << " numQueues=" << queues_.size()
-                   << " numPartitions=" << numPartitions_
-                   << " add#" << addCounter
-                   << " rows=" << cudfVector->size()
-                   << " totalRows=" << addedRows;
-    }
-  }
+  // investigation. Track per-operator-instance totals; flush at
+  // noMoreInput via separate path below.
+  ++lpAddCount_;
+  lpAddRows_ += cudfVector->size();
 
   if (numPartitions_ > 1) {
     if (partitionFunctionType_ == PartitionFunctionType::kRoundRobin) {
@@ -309,6 +298,17 @@ void CudfLocalPartition::noMoreInput() {
   for (const auto& queue : queues_) {
     queue->noMoreData();
   }
+  // Flush diagnostic counts at producer-side end-of-data.
+  LOG(WARNING) << "LP_SUMMARY task="
+               << operatorCtx_->driverCtx()->task->taskId()
+               << " node=" << planNodeId()
+               << " pipe=" << operatorCtx_->driverCtx()->pipelineId
+               << " drv=" << operatorCtx_->driverCtx()->driverId
+               << " numQueues=" << queues_.size()
+               << " addInputCount=" << lpAddCount_
+               << " addInputRows=" << lpAddRows_
+               << " enqueueCount=" << lpEnqueueCount_
+               << " enqueueRows=" << lpEnqueueRows_;
 }
 
 bool CudfLocalPartition::isFinished() {

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -273,6 +273,13 @@ void CudfLocalPartition::addInput(RowVectorPtr input) {
     auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
     const uint64_t bytes =
         cudfInput ? cudfInput->estimateFlatSize() : input->retainedSize();
+    // Diagnostic: count enqueue on the single-partition pass-through path
+    // too, so LP_SUMMARY's enqueueCount/enqueueRows include both fan-out
+    // and pass-through topologies. cudfVector is the validated downcast
+    // from addInput's top, so size() here matches the actual enqueued
+    // payload rather than input->size() of the unchecked upstream type.
+    ++lpEnqueueCount_;
+    lpEnqueueRows_ += cudfVector->size();
     auto blockingReason = queues_[0]->enqueue(input, bytes, &future);
     if (blockingReason != exec::BlockingReason::kNotBlocked) {
       blockingReasons_.push_back(blockingReason);

--- a/velox/experimental/cudf/exec/CudfLocalPartition.h
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.h
@@ -77,6 +77,12 @@ class CudfLocalPartition : public exec::Operator, public NvtxHelper {
   std::vector<ContinueFuture> futures_;
 
   std::vector<column_index_t> partitionKeyIndices_;
+
+  // Diagnostic counters for Q8 batch fragmentation investigation.
+  int64_t lpAddCount_{0};
+  int64_t lpAddRows_{0};
+  int64_t lpEnqueueCount_{0};
+  int64_t lpEnqueueRows_{0};
 };
 
 } // namespace facebook::velox::cudf_velox


### PR DESCRIPTION
## Summary

Brings `mahone-option3-merge-stream-260515` up to `origin/stream` (sperlingxx).

**Merge of origin/stream (3 commits)** — `763463d09` stream Spark partial companion aggregates + `d89c4f92d` BP fix revert + `79f54f5d2` BP fix in CudfLocalPartition enqueue.

**Production cuDF features**:
- `4807894fd cudf: detect non-converging PARTIAL streaming, switch to bypass mode` — runtime safety net for high-cardinality groupby (Q18 trip ratio 1.0 → bypass)
- `fca3b6a91 cudf: lower bypass detection threshold to first concat event`
- `c65bd2c8f cudf: extend slot-aware getCompanionStep to _partial companions` — correct companion-step routing for Spark MPP plans
- `b0780b5d1 cudf: env-var override to disable agg streaming` (diagnostic hook)

**Diagnostic / EXPERIMENT commits** — sampled logs, env-gated reverts. To be squashed.

## Validation

Same 22q regression as the matching spark-gluten PR — 22/22 correctness, 22q SUM 73.88s.

## Test plan

- [ ] CI cudf unit tests green
- [ ] Reviewer evaluates bypass mode logic against \`streamingEnabled_\` gating
- [ ] Squash / drop EXPERIMENT commits before final merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)