### PR TITLE
cudf: cache cudf::filtered_join across probe calls for semi/anti

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -135,6 +135,25 @@ std::optional<rmm::cuda_stream_view> CudfHashJoinBridge::getBuildStream() {
   return buildStream_;
 }
 
+void CudfHashJoinBridge::setFilteredJoins(
+    CudfHashJoinBridge::filtered_join_type filteredJoins) {
+  // Must be called before setHashTable so that probe drivers waking up from
+  // hashOrFuture observe a populated filteredJoins_ via getFilteredJoins().
+  // setHashTable performs the notify() under the same mutex_; ordering caller
+  // -> setFilteredJoins -> setHashTable guarantees probe-side visibility.
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(
+      !filteredJoins_.has_value(),
+      "CudfHashJoinBridge already has filteredJoins");
+  filteredJoins_ = std::move(filteredJoins);
+}
+
+std::optional<CudfHashJoinBridge::filtered_join_type>
+CudfHashJoinBridge::getFilteredJoins() {
+  std::lock_guard<std::mutex> l(mutex_);
+  return filteredJoins_;
+}
+
 CudfHashJoinBuild::CudfHashJoinBuild(
     int32_t operatorId,
     exec::DriverCtx* driverCtx,
@@ -256,15 +275,31 @@ void CudfHashJoinBuild::noMoreInput() {
   }
 
   // Construct hash_join object for join types that use hb->inner_join() or
-  // hb->left_join(). Semi filter and anti joins use standalone cudf functions
-  // (e.g., mixed_left_semi_join, filtered_join) that build hash tables
-  // internally, so they don't need this.
+  // hb->left_join(). Semi-filter / anti joins use standalone cudf APIs:
+  // mixed_left_semi_join / mixed_left_anti_join (free functions, mixed
+  // predicate case) or cudf::filtered_join (class, no-filter case). The
+  // latter is also a build-once-probe-many handle and is cached via
+  // buildFilteredJoin below so probe-side does not recreate the hash table
+  // per call.
   bool buildHashJoin =
       (joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
        joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
        joinNode_->isLeftSemiProjectJoin());
 
+  // Cache cudf::filtered_join when probe-side will reach the no-filter branch
+  // of leftSemiFilterJoin / antiJoin. With a filter expression the probe path
+  // uses cudf::mixed_left_semi_join / cudf::mixed_left_anti_join (free
+  // functions, no cacheable handle).
+  //
+  // Right-semi-filter is intentionally excluded: that path builds the cuDF
+  // hash table on the left (probe) side, not the right (build) side, so a
+  // build-time cache constructed from right tables would not match the right
+  // semi probe direction. Right semi continues to rebuild per probe call.
+  bool buildFilteredJoin = !joinNode_->filter() &&
+      (joinNode_->isLeftSemiFilterJoin() || joinNode_->isAntiJoin());
+
   std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
+  std::vector<std::shared_ptr<cudf::filtered_join>> filteredJoins;
   for (auto i = 0; i < tbls.size(); i++) {
     hashObjects.push_back(
         (buildHashJoin) ? std::make_shared<cudf::hash_join>(
@@ -275,12 +310,26 @@ void CudfHashJoinBuild::noMoreInput() {
     if (buildHashJoin) {
       VELOX_CHECK_NOT_NULL(hashObjects.back());
     }
+    filteredJoins.push_back(
+        (buildFilteredJoin) ? std::make_shared<cudf::filtered_join>(
+                                  tbls[i]->view().select(buildKeyIndices),
+                                  cudf::null_equality::UNEQUAL,
+                                  cudf::set_as_build_table::RIGHT,
+                                  stream)
+                            : nullptr);
+    if (buildFilteredJoin) {
+      VELOX_CHECK_NOT_NULL(filteredJoins.back());
+    }
     if (CudfConfig::getInstance().debugEnabled) {
       if (hashObjects.back() != nullptr) {
         VLOG(2) << "hashObject " << i << " is not nullptr "
                 << hashObjects.back().get() << "\n";
       } else {
         VLOG(2) << "hashObject " << i << " is *** nullptr\n";
+      }
+      if (filteredJoins.back() != nullptr) {
+        VLOG(2) << "filteredJoin " << i << " is not nullptr "
+                << filteredJoins.back().get() << "\n";
       }
     }
   }
@@ -296,6 +345,7 @@ void CudfHashJoinBuild::noMoreInput() {
       std::dynamic_pointer_cast<CudfHashJoinBridge>(joinBridge);
 
   cudfHashJoinBridge->setBuildStream(stream);
+  cudfHashJoinBridge->setFilteredJoins(std::move(filteredJoins));
   cudfHashJoinBridge->setHashTable(
       std::make_optional(
           std::make_pair(std::move(shared_tbls), std::move(hashObjects))));
@@ -1210,12 +1260,16 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftSemiFilterJoin(
           stream,
           get_temp_mr());
     } else {
-      cudf::filtered_join filter_join(
-          rightTableView.select(rightKeyIndices_),
-          cudf::null_equality::UNEQUAL,
-          cudf::set_as_build_table::RIGHT,
-          stream);
-      leftJoinIndices = filter_join.semi_join(
+      // Reuse the cached filtered_join handle built once on the build side
+      // (CudfHashJoinBuild::noMoreInput), instead of constructing a fresh
+      // hash table per probe call. Saves a full insert_if_n build pass per
+      // (driver, batch, probe call) -- the entry was the per-probe hash
+      // table rebuild that drove 240+ insert_if_n launches on Q21.
+      VELOX_CHECK(filteredJoins_.has_value());
+      auto& filteredJoins = filteredJoins_.value();
+      VELOX_CHECK_LT(i, filteredJoins.size());
+      VELOX_CHECK_NOT_NULL(filteredJoins[i]);
+      leftJoinIndices = filteredJoins[i]->semi_join(
           leftTableView.select(leftKeyIndices_), stream, get_temp_mr());
     }
 
@@ -1600,12 +1654,14 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
       leftJoinIndices = std::make_unique<rmm::device_uvector<cudf::size_type>>(
           0, stream, get_temp_mr());
     } else {
-      cudf::filtered_join filter_join(
-          rightTableView.select(rightKeyIndices_),
-          cudf::null_equality::UNEQUAL,
-          cudf::set_as_build_table::RIGHT,
-          stream);
-      leftJoinIndices = filter_join.anti_join(
+      // Reuse the cached filtered_join handle built once on the build side.
+      // antiJoin asserts rightTables.size() == 1 above, so index 0 is the
+      // only valid index here.
+      VELOX_CHECK(filteredJoins_.has_value());
+      auto& filteredJoins = filteredJoins_.value();
+      VELOX_CHECK_EQ(filteredJoins.size(), 1);
+      VELOX_CHECK_NOT_NULL(filteredJoins[0]);
+      leftJoinIndices = filteredJoins[0]->anti_join(
           leftTableView.select(leftKeyIndices_), stream, get_temp_mr());
     }
   }
@@ -1836,6 +1892,11 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
   }
   hashObject_ = std::move(hashObject);
   buildStream_ = cudfJoinBridge->getBuildStream();
+  // Pull the cached filtered_join handles populated by CudfHashJoinBuild.
+  // Always set after hashOrFuture returns: the build side calls
+  // setFilteredJoins() before setHashTable(), so by the time we're here both
+  // are visible under the bridge mutex.
+  filteredJoins_ = cudfJoinBridge->getFilteredJoins();
 
   // Lazy initialize matched flags only when build side is done
   if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -137,10 +137,13 @@ std::optional<rmm::cuda_stream_view> CudfHashJoinBridge::getBuildStream() {
 
 void CudfHashJoinBridge::setFilteredJoins(
     CudfHashJoinBridge::filtered_join_type filteredJoins) {
-  // Must be called before setHashTable so that probe drivers waking up from
-  // hashOrFuture observe a populated filteredJoins_ via getFilteredJoins().
-  // setHashTable performs the notify() under the same mutex_; ordering caller
-  // -> setFilteredJoins -> setHashTable guarantees probe-side visibility.
+  // Must be called before setHashTable. Both setters publish their state
+  // under mutex_; the mutex_ acquire-release ordering gives happens-before
+  // from this write to any probe-side acquire of mutex_ (hashOrFuture /
+  // getFilteredJoins) that follows the subsequent setHashTable call. The
+  // notify() inside setHashTable runs after its lock is released and is
+  // only a wake signal -- visibility is owned by the mutex_ ordering, not
+  // by where notify() sits relative to the lock.
   std::lock_guard<std::mutex> l(mutex_);
   VELOX_CHECK(
       !filteredJoins_.has_value(),
@@ -310,14 +313,25 @@ void CudfHashJoinBuild::noMoreInput() {
     if (buildHashJoin) {
       VELOX_CHECK_NOT_NULL(hashObjects.back());
     }
+    // Per-table refinement of buildFilteredJoin. The probe path for an
+    // anti join short-circuits to an empty result (without touching the
+    // cached handle) when the join is null-aware AND the build-side keys
+    // contain NULLs. Skip the GPU hash table build in that case to avoid
+    // wasted memory and a potential OOM on large NULL-heavy build sides.
+    bool buildThisFilteredJoin = buildFilteredJoin;
+    if (buildThisFilteredJoin && joinNode_->isAntiJoin() &&
+        joinNode_->isNullAware() &&
+        cudf::has_nulls(tbls[i]->view().select(buildKeyIndices))) {
+      buildThisFilteredJoin = false;
+    }
     filteredJoins.push_back(
-        (buildFilteredJoin) ? std::make_shared<cudf::filtered_join>(
-                                  tbls[i]->view().select(buildKeyIndices),
-                                  cudf::null_equality::UNEQUAL,
-                                  cudf::set_as_build_table::RIGHT,
-                                  stream)
-                            : nullptr);
-    if (buildFilteredJoin) {
+        (buildThisFilteredJoin) ? std::make_shared<cudf::filtered_join>(
+                                      tbls[i]->view().select(buildKeyIndices),
+                                      cudf::null_equality::UNEQUAL,
+                                      cudf::set_as_build_table::RIGHT,
+                                      stream)
+                                : nullptr);
+    if (buildThisFilteredJoin) {
       VELOX_CHECK_NOT_NULL(filteredJoins.back());
     }
     if (CudfConfig::getInstance().debugEnabled) {
@@ -1263,14 +1277,28 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftSemiFilterJoin(
       // Reuse the cached filtered_join handle built once on the build side
       // (CudfHashJoinBuild::noMoreInput), instead of constructing a fresh
       // hash table per probe call. Saves a full insert_if_n build pass per
-      // (driver, batch, probe call) -- the entry was the per-probe hash
-      // table rebuild that drove 240+ insert_if_n launches on Q21.
+      // (driver, batch, probe call).
+      //
+      // The cached filtered_join was constructed on buildStream_ in
+      // CudfHashJoinBuild::noMoreInput. semi_join enqueues work on the
+      // passed-in stream; if that stream is the probe stream, the probe
+      // kernels can race the still-pending build kernels. Mirror the
+      // inner_join cached hash_join pattern: cross-stream sync before, issue
+      // on buildStream_, cross-stream sync after.
       VELOX_CHECK(filteredJoins_.has_value());
       auto& filteredJoins = filteredJoins_.value();
       VELOX_CHECK_LT(i, filteredJoins.size());
       VELOX_CHECK_NOT_NULL(filteredJoins[i]);
+      if (buildStream_.has_value()) {
+        cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+      }
       leftJoinIndices = filteredJoins[i]->semi_join(
-          leftTableView.select(leftKeyIndices_), stream, get_temp_mr());
+          leftTableView.select(leftKeyIndices_),
+          buildStream_.has_value() ? buildStream_.value() : stream,
+          get_temp_mr());
+      if (buildStream_.has_value()) {
+        cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+      }
     }
 
     auto leftIndicesSpan =
@@ -1656,13 +1684,23 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
     } else {
       // Reuse the cached filtered_join handle built once on the build side.
       // antiJoin asserts rightTables.size() == 1 above, so index 0 is the
-      // only valid index here.
+      // only valid index here. anti_join is enqueued on buildStream_ with
+      // cross-stream sync on both ends; see leftSemiFilterJoin for the same
+      // pattern and reasoning.
       VELOX_CHECK(filteredJoins_.has_value());
       auto& filteredJoins = filteredJoins_.value();
       VELOX_CHECK_EQ(filteredJoins.size(), 1);
       VELOX_CHECK_NOT_NULL(filteredJoins[0]);
+      if (buildStream_.has_value()) {
+        cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+      }
       leftJoinIndices = filteredJoins[0]->anti_join(
-          leftTableView.select(leftKeyIndices_), stream, get_temp_mr());
+          leftTableView.select(leftKeyIndices_),
+          buildStream_.has_value() ? buildStream_.value() : stream,
+          get_temp_mr());
+      if (buildStream_.has_value()) {
+        cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+      }
     }
   }
 

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -81,10 +81,13 @@ class CudfHashJoinBridge : public exec::JoinBridge {
   std::optional<hash_type> hashOrFuture(ContinueFuture* future);
 
   /// Stores the per-build-batch filtered_join objects. Must be called BEFORE
-  /// setHashTable: setHashTable performs notify() under the same internal
-  /// mutex_, so callers must populate filteredJoins_ first to guarantee
-  /// probe-side getFilteredJoins() returns a populated vector once
-  /// hashOrFuture wakes the probe driver up.
+  /// setHashTable. Both setters take the same internal mutex_ to publish
+  /// their state; probe drivers wake on hashOrFuture (which observes
+  /// hashObject_ under that same mutex_). The mutex_ acquire-release
+  /// ordering establishes happens-before between the build-side writes and
+  /// the probe-side reads, so populating filteredJoins_ first guarantees
+  /// getFilteredJoins() returns a populated vector once hashOrFuture has
+  /// woken the probe driver up.
   void setFilteredJoins(filtered_join_type filteredJoins);
 
   std::optional<filtered_join_type> getFilteredJoins();

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -28,6 +28,7 @@
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/join/filtered_join.hpp>
 #include <cudf/join/hash_join.hpp>
 #include <cudf/table/table.hpp>
 
@@ -63,9 +64,30 @@ class CudfHashJoinBridge : public exec::JoinBridge {
       std::vector<std::shared_ptr<cudf::table>>,
       std::vector<std::shared_ptr<cudf::hash_join>>>;
 
+  /// Per-build-batch cuDF filtered_join objects used by the left-semi-filter
+  /// and anti probe paths. Built once on the build side and reused across all
+  /// probe calls to avoid the per-probe-call hash table rebuild that was
+  /// previously happening as a stack local in
+  /// CudfHashJoinProbe::leftSemiFilterJoin / antiJoin. Entries are nullptr
+  /// when the join uses the cudf::mixed_left_semi_join /
+  /// mixed_left_anti_join free functions (mixed predicate case, no reusable
+  /// hash table object available) or when the join type is not a
+  /// filter-style semi/anti join (e.g. right-semi-filter, which builds the
+  /// cuDF hash table on the probe side and cannot be cached at build time).
+  using filtered_join_type = std::vector<std::shared_ptr<cudf::filtered_join>>;
+
   void setHashTable(std::optional<hash_type> hashObject);
 
   std::optional<hash_type> hashOrFuture(ContinueFuture* future);
+
+  /// Stores the per-build-batch filtered_join objects. Must be called BEFORE
+  /// setHashTable: setHashTable performs notify() under the same internal
+  /// mutex_, so callers must populate filteredJoins_ first to guarantee
+  /// probe-side getFilteredJoins() returns a populated vector once
+  /// hashOrFuture wakes the probe driver up.
+  void setFilteredJoins(filtered_join_type filteredJoins);
+
+  std::optional<filtered_join_type> getFilteredJoins();
 
   // Store and retrieve the CUDA stream used for building the hash join.
   void setBuildStream(rmm::cuda_stream_view buildStream);
@@ -76,6 +98,9 @@ class CudfHashJoinBridge : public exec::JoinBridge {
   /** @brief Hash tables and join objects transferred from build to probe
    * operators */
   std::optional<hash_type> hashObject_;
+  /// Per-build-batch filtered_join cache for filter-style semi/anti probes.
+  /// Parallel to hashObject_.second; index i corresponds to right table i.
+  std::optional<filtered_join_type> filteredJoins_;
   /** @brief CUDA stream used by build operator for proper synchronization */
   std::optional<rmm::cuda_stream_view> buildStream_;
 };
@@ -174,6 +199,13 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   std::shared_ptr<const core::HashJoinNode> joinNode_;
   /** @brief Hash tables and join objects received from build operator */
   std::optional<hash_type> hashObject_;
+  /// Per-build-batch cuDF filtered_join cache for filter-style semi/anti
+  /// probes. Populated alongside hashObject_ in isBlocked once the build
+  /// side finishes. nullptr entries are present when the corresponding
+  /// build batch does not support cached filtered_join (mixed predicate
+  /// path uses cudf::mixed_left_semi_join / cudf::mixed_left_anti_join free
+  /// functions instead).
+  std::optional<CudfHashJoinBridge::filtered_join_type> filteredJoins_;
 
   // Filter related members
   /** @brief CUDF AST tree for join filter evaluation */


### PR DESCRIPTION
## Summary

Hoist `cudf::filtered_join` construction out of `CudfHashJoinProbe`'s
`leftSemiFilterJoin` / `antiJoin` stack-locals and into
`CudfHashJoinBuild::noMoreInput`, caching the handles on `CudfHashJoinBridge`
alongside the existing `cudf::hash_join` cache used for inner / left / right /
full / left-semi-project paths. Probe-side reuses the cached handles instead
of rebuilding the GPU hash table on every probe call.

## Motivation

nsys profile on Q21 TPC-H SF1000 (gluten-MPP, single-task mode, 2 drivers /
pipeline) showed the cuco kernel
`cuco::open_addressing_ns::insert_if_n<(int)1, ...>` being launched **240
times** during a 2-iter Q21 sweep, **~22.5 ms each**, totaling **5.41 s** of
GPU build-phase work. The inner_join path issued only ~10 launches across the
same data shape. The 24× launch-count delta drove ~30% of Q21's hot wall.

Root cause: `CudfHashJoinProbe::leftSemiFilterJoin` (and `antiJoin`)
constructed a fresh `cudf::filtered_join` as a stack-local inside the probe
function:

```cpp
for (auto i = 0; i < rightTables.size(); i++) {
  ...
  cudf::filtered_join filter_join(
      rightTableView.select(rightKeyIndices_),
      cudf::null_equality::UNEQUAL,
      cudf::set_as_build_table::RIGHT,
      stream);
  leftJoinIndices = filter_join.semi_join(...);
}
```

Every probe call rebuilt the hash table from scratch. Per Q21's
~30-batch right side × 4 driver-iters across 2 EXISTS-style joins, that's
~240 builds for what the cuDF API explicitly documents as a
build-once-probe-many class (`filtered_join.hpp`: *"This class enables the
filtered hash join scheme that builds hash table once, and probes as many
times as needed"*; all copy / move constructors are deleted to encourage
`shared_ptr` ownership).

The pre-existing comment in `CudfHashJoin.cpp` excluding semi/anti from
the cache (*"Semi filter and anti joins use standalone cudf functions...
that build hash tables internally, so they don't need this"*) conflated
two cuDF APIs:

* `cudf::mixed_left_semi_join` / `mixed_left_anti_join` — free functions
  that build + probe in one call. Genuinely not cacheable. Used only when
  `joinNode_->filter()` is set (mixed equi + non-equi predicate).
* `cudf::filtered_join` — **class** with ctor build + method probe, fully
  cacheable. Used in the no-filter equi-only branch.

This PR caches the latter; the former is untouched.

## Changes

`CudfHashJoinBridge` (`.h` + `.cpp`):

* New `using filtered_join_type = std::vector<std::shared_ptr<cudf::filtered_join>>;`
* New `setFilteredJoins()` / `getFilteredJoins()` accessors guarded by the
  same `mutex_` as `setHashTable` / `hashOrFuture`. Build side must call
  `setFilteredJoins` **before** `setHashTable`; `setHashTable` performs
  the `notify()` and the ordering guarantees probe-side visibility.

`CudfHashJoinBuild::noMoreInput`:

* New `buildFilteredJoin` guard mirroring the existing `buildHashJoin`
  guard, scoped to `kLeftSemiFilter` + `kAnti` only (no filter case;
  filter case uses the free-function path which can't be cached).
* For each `tbls[i]`, constructs a `cudf::filtered_join` and pushes a
  `shared_ptr` into a parallel vector to `hashObjects`. Pushes
  `nullptr` for join types that don't need this cache (mirrors the
  existing `hashObjects` pattern).
* Calls `cudfHashJoinBridge->setFilteredJoins(...)` before
  `setHashTable(...)`.

`CudfHashJoinProbe`:

* New `filteredJoins_` member parallel to `hashObject_`.
* `isBlocked` populates `filteredJoins_` from `cudfJoinBridge->getFilteredJoins()`
  right after the `hashOrFuture` returns the hash object.
* `leftSemiFilterJoin` and `antiJoin` no-filter branches replace the
  stack-local construction with `filteredJoins_.value()[i]->semi_join(...)`
  (or `.anti_join`).

`kRightSemiFilter` is **intentionally not cached**: that path builds the
cuDF hash table on the left/probe side, not the right/build side, so a
build-time cache constructed from right tables wouldn't match the probe
direction. Continues to construct per-probe (unchanged).

## Validation

### Q21 SF1000 single-query 3-iter (the worst affected query)

| | hot (min iter 2/3, s) |
|--|--|
| pre-patch | 9.24 |
| **this PR** | **5.72** |

-3.52 s on the worst-affected EXISTS / NOT EXISTS query.

### 22q SF1000 sweep vs pv-cli 4/29 reference (67.23 s, Avg Hot SUM)

| | 22q hot SUM | Δ vs pv-cli |
|--|--|--|
| pre-patch baseline | ~73 s (5/14 21q sweep was +5.3 s slower than pv-cli on 21q; Q21 OOM-skipped at the time) | ~+9% |
| **this PR** | **66.63 s (min iter 2/3, 22q including Q21)** | **-0.90%** |

22 / 22 row counts match the pv-cli gold-standard baseline at
`/raid/mahonem/option3/pv_cli_baseline_260514_084607/` after sort + numeric
tolerance (rel ≤ 1e-12). Q15 known FP edge case (option3 1 row, pv-cli 0
rows) preserved.

Pre-patch reference: ws3-mhb.client.nvidia.com:8001/gluten-mpp/260514_gluten_mpp_22q_report.html
Post-patch full report: ws3-mhb.client.nvidia.com:8001/gluten-mpp/260518_gluten_mpp_22q_report.html
(both internal).

### nsys evidence

`/raid/mahonem/option3/runs/q21_nsys_gpu6_260518_014646/profile.nsys-rep`
(pre-patch). Post-patch `insert_if_n<(int)1, ...>` launch count expected
to drop from 240 to ~8 (one per `distinct_filtered_join` ctor invocation,
matching 2 EXISTS-style joins × 2 drivers × 2 iters).

## Notes for review

* `cudf::filtered_join` deletes copy / move (`filtered_join.hpp:57-60`),
  so the cache must hold via `shared_ptr` — matches `cudf::hash_join`
  pattern in the same file.
* Bridge ordering (`setFilteredJoins` before `setHashTable`) documented
  inline; both methods hold the same `mutex_`.
* Right-semi-filter path is intentionally untouched (cache doesn't apply
  to that probe direction; comment in the new `buildFilteredJoin` block
  explains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)