### PR TITLE
Defer CudfHashJoinProbe allocations out of the constructor

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -82,7 +82,27 @@ void CudfHashJoinProbe::close() {
   Operator::close();
   filterEvaluator_.reset();
   scalars_.clear();
-  tree_ = {};
+  tree_.reset();
+  cudaEvent_.reset();
+}
+
+cudf::ast::tree& CudfHashJoinProbe::filterTree() {
+  if (!tree_) {
+    tree_ = std::make_unique<cudf::ast::tree>();
+  }
+  return *tree_;
+}
+
+const cudf::ast::expression& CudfHashJoinProbe::filterExpression() const {
+  VELOX_CHECK(tree_ != nullptr, "Filter AST has not been initialized");
+  return tree_->back();
+}
+
+CudaEvent& CudfHashJoinProbe::cudaEvent() {
+  if (!cudaEvent_) {
+    cudaEvent_ = std::make_unique<CudaEvent>(cudaEventDisableTiming);
+  }
+  return *cudaEvent_;
 }
 
 void CudfHashJoinBridge::setHashTable(
@@ -393,8 +413,7 @@ CudfHashJoinProbe::CudfHashJoinProbe(
           fmt::format("[{}]", joinNode->id())),
       joinNode_(joinNode),
       probeType_(joinNode_->sources()[0]->outputType()),
-      buildType_(joinNode_->sources()[1]->outputType()),
-      cudaEvent_(std::make_unique<CudaEvent>(cudaEventDisableTiming)) {
+      buildType_(joinNode_->sources()[1]->outputType()) {
   if (CudfConfig::getInstance().debugEnabled) {
     VLOG(2) << "CudfHashJoinProbe constructor";
   }
@@ -482,8 +501,11 @@ CudfHashJoinProbe::CudfHashJoinProbe(
               << rightColumnIndicesToGather_[i];
     }
   }
+}
 
-  // Setup filter in case it exists
+void CudfHashJoinProbe::initialize() {
+  Operator::initialize();
+
   if (joinNode_->filter()) {
     // simplify expression
     exec::ExprSet exprs({joinNode_->filter()}, operatorCtx_->execCtx());
@@ -504,10 +526,11 @@ CudfHashJoinProbe::CudfHashJoinProbe(
     // in whole tables
 
     // create ast tree
+    auto& tree = filterTree();
     if (joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin()) {
       createAstTree(
           exprs.exprs()[0],
-          tree_,
+          tree,
           scalars_,
           buildType_,
           probeType_,
@@ -516,7 +539,7 @@ CudfHashJoinProbe::CudfHashJoinProbe(
     } else {
       createAstTree(
           exprs.exprs()[0],
-          tree_,
+          tree,
           scalars_,
           probeType_,
           buildType_,
@@ -718,7 +741,7 @@ std::unique_ptr<cudf::table> CudfHashJoinProbe::unfilteredOutput(
   }
   if (buildStream_.has_value()) {
     // Ensure deallocation of build table happens after probe gathers
-    cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+    cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
   }
   stream.synchronize();
   return std::make_unique<cudf::table>(std::move(joinedCols));
@@ -774,7 +797,7 @@ std::unique_ptr<cudf::table> CudfHashJoinProbe::filteredOutput(
   joinedCols = std::move(filteredjoinedCols);
   if (buildStream_.has_value()) {
     // Ensure any deallocation of join indices is ordered wrt probe gathers
-    cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+    cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
   }
   stream.synchronize();
   return std::make_unique<cudf::table>(std::move(joinedCols));
@@ -796,7 +819,7 @@ std::unique_ptr<cudf::table> CudfHashJoinProbe::filteredOutputIndices(
           extendedRightView,
           leftIndicesCol,
           rightIndicesCol,
-          tree_.back(),
+          filterExpression(),
           joinKind,
           stream,
           get_temp_mr());
@@ -852,7 +875,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::innerJoin(
     VELOX_CHECK_NOT_NULL(hb);
     if (buildStream_.has_value()) {
       // Make build stream wait for probe tables to become valid
-      cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+      cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
     }
     auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
         leftTableView.select(leftKeyIndices_),
@@ -861,7 +884,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::innerJoin(
         get_temp_mr());
     if (buildStream_.has_value()) {
       // Make probe stream wait for join completion before using indices
-      cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+      cudaEvent().recordFrom(buildStream_.value()).waitOn(stream);
     }
 
     auto leftIndicesSpan =
@@ -928,7 +951,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftJoin(
 
     VELOX_CHECK_NOT_NULL(hb);
     if (buildStream_.has_value()) {
-      cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+      cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
     }
     auto [leftJoinIndices, rightJoinIndices] = hb->left_join(
         leftTableView.select(leftKeyIndices_),
@@ -936,7 +959,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftJoin(
         buildStream_.has_value() ? buildStream_.value() : stream,
         get_temp_mr());
     if (buildStream_.has_value()) {
-      cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+      cudaEvent().recordFrom(buildStream_.value()).waitOn(stream);
     }
 
     auto leftIndicesSpan =
@@ -983,7 +1006,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::rightJoin(
 
     VELOX_CHECK_NOT_NULL(hb);
     if (buildStream_.has_value()) {
-      cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+      cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
     }
     auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
         leftTableView.select(leftKeyIndices_),
@@ -991,7 +1014,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::rightJoin(
         buildStream_.has_value() ? buildStream_.value() : stream,
         get_temp_mr());
     if (buildStream_.has_value()) {
-      cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+      cudaEvent().recordFrom(buildStream_.value()).waitOn(stream);
     }
     if (!joinNode_->filter()) {
       // Mark matched build rows by checking which row indices appear in
@@ -1125,7 +1148,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::fullJoin(
 
     VELOX_CHECK_NOT_NULL(hb);
     if (buildStream_.has_value()) {
-      cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+      cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
     }
     // Use left_join to get all probe rows (matched + unmatched).
     // Track matched build rows in rightMatchedFlags_ for last driver to emit
@@ -1136,7 +1159,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::fullJoin(
         buildStream_.has_value() ? buildStream_.value() : stream,
         get_temp_mr());
     if (buildStream_.has_value()) {
-      cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+      cudaEvent().recordFrom(buildStream_.value()).waitOn(stream);
     }
     if (!joinNode_->filter()) {
       // Mark matched build rows by checking which row indices appear in
@@ -1189,7 +1212,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::fullJoin(
               rightTableView,
               leftIndicesCol,
               rightIndicesCol,
-              tree_.back(),
+              filterExpression(),
               cudf::join_kind::LEFT_JOIN,
               stream,
               get_temp_mr());
@@ -1269,7 +1292,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftSemiFilterJoin(
           rightTableView.select(rightKeyIndices_),
           leftTableView,
           rightTableView,
-          tree_.back(),
+          filterExpression(),
           cudf::null_equality::UNEQUAL,
           stream,
           get_temp_mr());
@@ -1290,14 +1313,14 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftSemiFilterJoin(
       VELOX_CHECK_LT(i, filteredJoins.size());
       VELOX_CHECK_NOT_NULL(filteredJoins[i]);
       if (buildStream_.has_value()) {
-        cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+        cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
       }
       leftJoinIndices = filteredJoins[i]->semi_join(
           leftTableView.select(leftKeyIndices_),
           buildStream_.has_value() ? buildStream_.value() : stream,
           get_temp_mr());
       if (buildStream_.has_value()) {
-        cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+        cudaEvent().recordFrom(buildStream_.value()).waitOn(stream);
       }
     }
 
@@ -1437,7 +1460,7 @@ CudfHashJoinProbe::leftSemiProjectJoin(
     VELOX_CHECK_NOT_NULL(hb);
     if (buildStream_.has_value()) {
       // Make build stream wait for probe tables to become valid
-      cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+      cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
     }
     auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
         leftTableView.select(leftKeyIndices_),
@@ -1446,7 +1469,7 @@ CudfHashJoinProbe::leftSemiProjectJoin(
         get_temp_mr());
     if (buildStream_.has_value()) {
       // Make probe stream wait for join completion before using indices
-      cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+      cudaEvent().recordFrom(buildStream_.value()).waitOn(stream);
     }
 
     if (leftJoinIndices->size() == 0) {
@@ -1471,7 +1494,7 @@ CudfHashJoinProbe::leftSemiProjectJoin(
           extendedRightView,
           leftIndicesSpan,
           rightIndicesSpan,
-          tree_.back(),
+          filterExpression(),
           cudf::join_kind::INNER_JOIN,
           stream,
           get_temp_mr());
@@ -1572,7 +1595,7 @@ CudfHashJoinProbe::leftSemiProjectJoin(
   outputCols.back() = std::move(matchCol);
 
   if (buildStream_.has_value()) {
-    cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+    cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
   }
   stream.synchronize();
 
@@ -1601,7 +1624,7 @@ CudfHashJoinProbe::rightSemiFilterJoin(
         leftTableView.select(leftKeyIndices_),
         rightTableView,
         leftTableView,
-        tree_.back(),
+        filterExpression(),
         cudf::null_equality::UNEQUAL,
         stream,
         get_temp_mr());
@@ -1670,7 +1693,7 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
         rightTableView.select(rightKeyIndices_),
         leftTableView,
         rightTableView,
-        tree_.back(),
+        filterExpression(),
         cudf::null_equality::UNEQUAL,
         stream,
         get_temp_mr());
@@ -1692,14 +1715,14 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
       VELOX_CHECK_EQ(filteredJoins.size(), 1);
       VELOX_CHECK_NOT_NULL(filteredJoins[0]);
       if (buildStream_.has_value()) {
-        cudaEvent_->recordFrom(stream).waitOn(buildStream_.value());
+        cudaEvent().recordFrom(stream).waitOn(buildStream_.value());
       }
       leftJoinIndices = filteredJoins[0]->anti_join(
           leftTableView.select(leftKeyIndices_),
           buildStream_.has_value() ? buildStream_.value() : stream,
           get_temp_mr());
       if (buildStream_.has_value()) {
-        cudaEvent_->recordFrom(buildStream_.value()).waitOn(stream);
+        cudaEvent().recordFrom(buildStream_.value()).waitOn(stream);
       }
     }
   }

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -163,6 +163,8 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::HashJoinNode> joinNode);
 
+  void initialize() override;
+
   bool needsInput() const override;
 
   void addInput(RowVectorPtr input) override;
@@ -199,6 +201,12 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   bool isFinished() override;
 
  private:
+  cudf::ast::tree& filterTree();
+
+  const cudf::ast::expression& filterExpression() const;
+
+  CudaEvent& cudaEvent();
+
   std::shared_ptr<const core::HashJoinNode> joinNode_;
   /** @brief Hash tables and join objects received from build operator */
   std::optional<hash_type> hashObject_;
@@ -212,7 +220,7 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
 
   // Filter related members
   /** @brief CUDF AST tree for join filter evaluation */
-  cudf::ast::tree tree_;
+  std::unique_ptr<cudf::ast::tree> tree_;
   /** @brief Scalar values used in filter expressions */
   std::vector<std::unique_ptr<cudf::scalar>> scalars_;
   /** @brief Precompute instructions for left (probe) table columns */


### PR DESCRIPTION
Closes #34 

This PR fixes a TPC-H Q7 failure in the Spark Gluten Velox MPP cuDF hash join
path. `CudfHashJoinProbe` was allocating memory-pool-tracked resources during
operator construction, which violates Velox's driver creation contract and
trips the `pool_->reservedBytes() == 0` check in `Task::createAndStartDrivers`.

The fix moves join-filter setup into `Operator::initialize()` and lazily creates
the CUDA event and cuDF AST tree only when they are needed.

## Problem

Velox creates drivers before running them and verifies that the task memory pool
is still empty immediately after driver construction:

```cpp
std::vector<std::shared_ptr<Driver>> drivers =
    createDriversLocked(kUngroupedGroupId);
if (pool_->reservedBytes() != 0) {
  VELOX_FAIL(
      "Unexpected memory pool allocations during task[{}] driver initialization: {}",
      taskId_,
      pool_->treeMemoryUsage());
}
```

TPC-H Q7 can fail with:

```text
Unexpected memory pool allocations during task[gpu-local-mpp-1-0-p0] driver initialization:
Top 2 leaf memory pool usages:
    op.124.2.1.CudfHashJoinProbe usage 128B reserved 1.00MB peak 128B
    op.124.2.0.CudfHashJoinProbe usage 128B reserved 1.00MB peak 128B
```

The allocation happens before drivers run, while `CudfHashJoinProbe` is being
constructed.

## Root cause

The old constructor eagerly initialized resources that may allocate:

```text
CudfHashJoinProbe constructor
  |
  +-- create CudaEvent
  |
  +-- if join has filter:
        |
        +-- create ExprSet using operator exec context
        +-- create CudfExpression
        +-- create cudf::ast::tree and scalars
```

For Q7, the nation-pair predicate is represented as a hash join filter, so
`joinNode_->filter()` is non-null. That sends the constructor through the
filtered join setup path and touches the operator memory pool before Velox's
driver creation invariant has passed.

## Fix

This PR changes `CudfHashJoinProbe` initialization as follows:

- Adds `void initialize() override` to `CudfHashJoinProbe`.
- Moves join-filter setup from the constructor into `initialize()`.
- Calls `Operator::initialize()` at the start of the override.
- Changes `tree_` from an eagerly constructed `cudf::ast::tree` value to a
  lazy `std::unique_ptr<cudf::ast::tree>`.
- Adds `filterTree()` and `filterExpression()` helpers for safe lazy access.
- Lazily creates `CudaEvent` through `cudaEvent()` only when stream ordering is
  actually needed.
- Resets both lazy resources in `close()`.

Before:

```text
Task::createAndStartDrivers()
  |
  +-- createDriversLocked()
        |
        +-- CudfHashJoinProbe constructor
              |
              +-- filter AST setup
              +-- CudaEvent setup
              +-- memory pool reservation appears here
  |
  +-- assert pool_->reservedBytes() == 0
        |
        +-- fail
```

After:

```text
Task::createAndStartDrivers()
  |
  +-- createDriversLocked()
        |
        +-- CudfHashJoinProbe constructor
              |
              +-- metadata only
              +-- no filter AST allocation
              +-- no CudaEvent allocation
  |
  +-- assert pool_->reservedBytes() == 0
        |
        +-- pass

Driver::initializeOperators()
  |
  +-- CudfHashJoinProbe::initialize()
        |
        +-- filter AST setup happens after driver creation

Probe execution
  |
  +-- cudaEvent() creates event on first stream-ordering use
```

## Behavior and performance impact

The join algorithm and cuDF kernel calls are unchanged. The change only moves
one-time setup out of the constructor and makes two helper resources lazy.

Expected performance impact:

- Filtered joins: neutral. Filter expression setup still happens once per
  operator, just later in the lifecycle.
- Non-filtered joins: slightly better, because the AST tree is never created.
- Joins that do not need `buildStream_` ordering: slightly better, because the
  CUDA event is never created.
- Very small joins or many short-lived tasks: possible tiny CPU-side overhead
  from lazy helper checks and first-use event creation.
- Large GPU joins: no meaningful regression expected.

## Files changed

- `velox/experimental/cudf/exec/CudfHashJoin.h`
- `velox/experimental/cudf/exec/CudfHashJoin.cpp`

## Validation

- `git -C velox diff --check` passes.
- Source inspection confirms direct `tree_.back()` use is replaced with
  `filterExpression()`.
- Source inspection confirms direct `cudaEvent_->...` use is replaced with
  `cudaEvent(). ...`.

Native Velox build and the full TPC-H Q7 MPP harness should be run in the target
GPU environment to confirm the runtime fix end to end.

## Risk

Risk is low to moderate:

- `initialize()` is the Velox-supported place for operator setup that may
  allocate from memory pools.
- Existing CPU Velox operators use the same lifecycle pattern for allocation
  work that cannot safely run in constructors.
- The main behavioral risk is missing an initialization path for a filtered join
  consumer. The helper `filterExpression()` checks that the AST tree exists
  before use, so such a bug should fail loudly instead of silently producing
  incorrect results.

