### PR TITLE
ucx-exchange: clean up intra-node handoff

### DIFF
--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/experimental/ucx-exchange/Communicator.h"
 #include <cuda_runtime.h>
+#include <folly/system/ThreadName.h>
 #include <ucxx/api.h>
 #include <ucxx/utils/ucx.h>
 #include <algorithm>
@@ -108,6 +109,9 @@ Communicator::~Communicator() {
 /// All operations of the communicator will be carried out in the thread
 /// that calls run.
 void Communicator::run() {
+  // Name the UCX progress thread so it is identifiable in nsys / thread dumps
+  // (it carries all cross-peer send/recv progress and the rendezvous waits).
+  folly::setThreadName("ucx-progress");
   VLOG(3) << "Using error handling mode: "
           << CudfConfig::getInstance().ucxxErrorHandling << std::endl;
   VLOG(3) << "Using blocking progress mode: "

--- a/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.cpp
+++ b/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.cpp
@@ -72,6 +72,7 @@ std::future<void> IntraNodeTransferRegistry::publish(
   }
 
   // Update the entry with data (under entry's own mutex)
+  std::vector<std::function<void()>> toWake;
   {
     std::lock_guard<std::mutex> entryLock(entry->entryMutex);
     entry->data = std::move(data);
@@ -80,10 +81,20 @@ std::future<void> IntraNodeTransferRegistry::publish(
     entry->ready = true;
     // Get the future while holding the lock to avoid race with consumer
     future = entry->retrievedPromise.get_future();
+    // Collect one-shot wakeups registered before the data was ready. Setting
+    // ready and draining wakeCallbacks under the same entryMutex that
+    // registerWaiter() takes guarantees no lost wakeup: a registerWaiter() that
+    // ran first added its callback here; one that runs later sees ready==true.
+    toWake.swap(entry->wakeCallbacks);
   }
 
   // Notify waiting source
   entry->dataAvailable.notify_one();
+
+  // Fire the dormant-source wakeups outside the entry lock.
+  for (auto& wake : toWake) {
+    wake();
+  }
 
   VLOG(2) << "[INTRA-REG] publish: task=" << key.taskId
           << " dest=" << key.destination << " seq=" << key.sequenceNumber
@@ -152,6 +163,38 @@ std::optional<IntraNodeTransferResult> IntraNodeTransferRegistry::poll(
           << " atEnd=" << result.atEnd;
 
   return result;
+}
+
+bool IntraNodeTransferRegistry::registerWaiter(
+    const IntraNodeTransferKey& key,
+    std::function<void()> wake) {
+  std::shared_ptr<IntraNodeTransferEntry> entry;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    // A cancelled task will never publish; tell the caller to re-poll so it
+    // observes the atEnd result instead of going dormant forever.
+    if (cancelledTasks_.count(key.taskId)) {
+      return true;
+    }
+    auto it = registry_.find(key);
+    if (it != registry_.end()) {
+      entry = it->second;
+    } else {
+      // Create the entry so a subsequent publish() finds it and fires the
+      // wakeup, mirroring waitFor()'s create-on-miss behavior.
+      entry = std::make_shared<IntraNodeTransferEntry>();
+      registry_[key] = entry;
+    }
+  }
+
+  // Check ready and enqueue the wakeup under the same entryMutex that publish()
+  // takes, so the register-vs-publish race cannot drop a wakeup.
+  std::lock_guard<std::mutex> entryLock(entry->entryMutex);
+  if (entry->ready) {
+    return true;
+  }
+  entry->wakeCallbacks.push_back(std::move(wake));
+  return false;
 }
 
 IntraNodeTransferResult IntraNodeTransferRegistry::waitFor(
@@ -259,17 +302,27 @@ void IntraNodeTransferRegistry::cancelTask(const std::string& taskId) {
   }
 
   // Fulfill promises outside the lock to avoid potential deadlocks.
+  std::vector<std::function<void()>> toWake;
   for (auto& entry : entriesToFulfill) {
     std::lock_guard<std::mutex> entryLock(entry->entryMutex);
     if (!entry->ready) {
       entry->ready = true;
       entry->atEnd = true;
     }
+    // Wake any dormant source so it re-polls and observes the atEnd result.
+    for (auto& wake : entry->wakeCallbacks) {
+      toWake.push_back(std::move(wake));
+    }
+    entry->wakeCallbacks.clear();
     try {
       entry->retrievedPromise.set_value();
     } catch (const std::future_error&) {
       // Promise already satisfied — safe to ignore.
     }
+  }
+
+  for (auto& wake : toWake) {
+    wake();
   }
 
   VLOG(2) << "[INTRA-REG] cancelTask: task=" << taskId

--- a/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
+++ b/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
@@ -18,6 +18,7 @@
 #include <cudf/contiguous_split.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <condition_variable>
+#include <functional>
 #include <future>
 #include <map>
 #include <memory>
@@ -25,6 +26,7 @@
 #include <optional>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 namespace facebook::velox::ucx_exchange {
 
@@ -64,6 +66,11 @@ struct IntraNodeTransferEntry {
   std::condition_variable dataAvailable; // Source waits on this for data
   std::mutex entryMutex;
   bool ready{false}; // True when data is ready to retrieve
+  // One-shot wakeups for sources that registered via registerWaiter() before
+  // the data was ready, so a same-process consumer can stay dormant instead of
+  // busy-polling the single-threaded Communicator work queue. Fired and cleared
+  // by publish()/cancelTask(). Guarded by entryMutex.
+  std::vector<std::function<void()>> wakeCallbacks;
 };
 
 /// @brief Singleton registry for intra-node data transfers.
@@ -106,6 +113,20 @@ class IntraNodeTransferRegistry {
   ///         Data is nullptr when atEnd is true.
   [[nodiscard]] std::optional<IntraNodeTransferResult> poll(
       const IntraNodeTransferKey& key);
+
+  /// @brief Register a one-shot wakeup for a same-process consumer that polled
+  /// and found no data, so it can go dormant instead of busy-re-queuing on the
+  /// single-threaded Communicator. @p wake is invoked exactly once when
+  /// publish() (or cancelTask()) makes data available for @p key.
+  /// @param key The unique key identifying this transfer
+  /// @param wake Callback fired once when data becomes available or the task is
+  ///        cancelled; must be safe to call from the Communicator thread.
+  /// @return true if data is ALREADY available (or the task is cancelled) — the
+  ///         caller should re-poll instead of going dormant; false if registered
+  ///         (the caller should go dormant and will be woken via @p wake).
+  [[nodiscard]] bool registerWaiter(
+      const IntraNodeTransferKey& key,
+      std::function<void()> wake);
 
   /// @brief Wait for and retrieve data from intra-node transfer registry.
   /// Source calls this - blocks until data is available or timeout.

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -277,12 +277,13 @@ void UcxExchangeServer::sendData() {
 
       IntraNodeTransferKey key{
           partitionKey_.taskId, partitionKey_.destination, sequenceNumber_};
-      // Stream value is unused: the consumer (UcxExchangeSource::
-      // onIntraNodeData) allocates its own pool stream for downstream ops.
+      const auto stream = dataPtr_->gpu_data->stream();
+      // The consumer tags uniquely owned pages with this stream so downstream
+      // reads and stream-ordered async frees remain ordered with the buffer.
       // dataPtr_ is already a shared_ptr, pass directly to share ownership.
       intraNodeRetrieveFuture_ =
           IntraNodeTransferRegistry::getInstance()->publish(
-              key, dataPtr_, rmm::cuda_stream_default, /*atEnd=*/false);
+              key, dataPtr_, stream, /*atEnd=*/false);
       dataPtr_.reset();
       intraNodeAtEndPublished_ = false;
 

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -744,13 +744,28 @@ void UcxExchangeSource::waitForIntraNodeData() {
   auto result = IntraNodeTransferRegistry::getInstance()->poll(key);
 
   if (!result.has_value()) {
-    // Data not ready yet, re-queue to try again
-    ++intraNodePollCount_;
-    if (intraNodePollCount_ % 100 == 0) {
-      VLOG(2) << "[INTRA] [ExSrc " << toString() << " seq=" << sequenceNumber_
-              << "] still polling for data, polls=" << intraNodePollCount_;
+    // Event-driven wait: re-queuing here would busy-spin the single-threaded
+    // Communicator and can starve the same-process producer's publish() (which
+    // needs that same thread), livelocking the intra-node transfer. Instead
+    // register a one-shot wakeup and go dormant; publish()/cancelTask()
+    // re-enqueues this source exactly once when data is available. The weak_ptr
+    // keeps the wakeup safe if the source is destroyed first; the Communicator
+    // outlives its sources, so capturing it by shared_ptr is safe.
+    auto self = getSelfPtr();
+    std::weak_ptr<CommElement> weakSelf = self;
+    auto communicator = communicator_;
+    const bool readyNow =
+        IntraNodeTransferRegistry::getInstance()->registerWaiter(
+            key, [weakSelf, communicator]() {
+              if (auto source = weakSelf.lock()) {
+                communicator->addToWorkQueue(source);
+              }
+            });
+    if (readyNow) {
+      // Data landed (or the task was cancelled) between poll and register —
+      // re-poll once instead of going dormant.
+      communicator_->addToWorkQueue(self);
     }
-    communicator_->addToWorkQueue(getSelfPtr());
     return;
   }
 

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
@@ -183,12 +183,13 @@ bool UcxOutputQueueManager::canUseIntraNode(const std::string& taskId) {
   if (!queue) {
     return true;
   }
-  // Placeholder partitioned queues are safe for intra-node: the server will
-  // wait until initializeTask() upgrades the queue and data arrives. Broadcast
-  // is the unsafe case because one packed_columns may be shared by
-  // destinations.
-  return !queue->isInitialized() ||
-      queue->kind() != core::PartitionedOutputNode::Kind::kBroadcast;
+  // Placeholder partitioned queues are safe for intra-node: the server waits
+  // until initializeTask() upgrades the queue and data arrives. Broadcast is
+  // also safe: a broadcast packed_columns is shared (use_count > 1) across
+  // destinations, and UcxExchangeSource::onIntraNodeData clones such shared
+  // pages (DtoD) instead of moving the device buffer out, so a consuming
+  // destination never corrupts the shared source for the others.
+  return true;
 }
 
 std::string UcxOutputQueueManager::describeQueueForIntraNode(

--- a/velox/experimental/ucx-exchange/tests/CMakeLists.txt
+++ b/velox/experimental/ucx-exchange/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   ucx_exchange_test
   UcxOutputQueueManagerTest.cpp
   UcxExchangeTest.cpp
+  IntraNodeTransferRegistryTest.cpp
   Main.cpp
   UcxTestHelpers.cpp
   UcxTestData.cpp

--- a/velox/experimental/ucx-exchange/tests/IntraNodeTransferRegistryTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/IntraNodeTransferRegistryTest.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h"
+#include <gtest/gtest.h>
+#include <rmm/cuda_stream_view.hpp>
+#include <atomic>
+
+using namespace facebook::velox::ucx_exchange;
+
+namespace {
+// Distinct task ids keep tests independent despite the process-wide singleton.
+IntraNodeTransferKey makeKey(const std::string& taskId) {
+  return IntraNodeTransferKey{taskId, /*destination=*/0, /*sequenceNumber=*/0};
+}
+} // namespace
+
+// A waiter registered before publish goes dormant (returns false) and is woken
+// exactly once when publish lands the data — the event-driven replacement for
+// the old poll/self-requeue busy spin that livelocked the single-threaded
+// Communicator.
+TEST(IntraNodeTransferRegistryTest, registerWaiterWokenByPublish) {
+  auto registry = IntraNodeTransferRegistry::getInstance();
+  const auto key = makeKey("registerWaiterWokenByPublish");
+
+  std::atomic<int> woken{0};
+  const bool readyNow = registry->registerWaiter(key, [&woken]() { ++woken; });
+  EXPECT_FALSE(readyNow);
+  EXPECT_EQ(woken.load(), 0);
+
+  auto future = registry->publish(
+      key, /*data=*/nullptr, rmm::cuda_stream_default, /*atEnd=*/false);
+  EXPECT_EQ(woken.load(), 1);
+
+  // The woken consumer would now poll and retrieve the data.
+  auto result = registry->poll(key);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(result->atEnd);
+}
+
+// A waiter registered after the data is already published returns true (re-poll,
+// no dormancy) and does not leave a stale wakeup behind.
+TEST(IntraNodeTransferRegistryTest, registerWaiterReadyReturnsTrue) {
+  auto registry = IntraNodeTransferRegistry::getInstance();
+  const auto key = makeKey("registerWaiterReadyReturnsTrue");
+
+  auto future = registry->publish(
+      key, /*data=*/nullptr, rmm::cuda_stream_default, /*atEnd=*/true);
+
+  std::atomic<int> woken{0};
+  const bool readyNow = registry->registerWaiter(key, [&woken]() { ++woken; });
+  EXPECT_TRUE(readyNow);
+  EXPECT_EQ(woken.load(), 0);
+
+  auto result = registry->poll(key);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->atEnd);
+}
+
+// cancelTask wakes a dormant waiter so it re-polls and observes the atEnd result
+// instead of waiting forever for a producer that will never publish.
+TEST(IntraNodeTransferRegistryTest, registerWaiterWokenByCancel) {
+  auto registry = IntraNodeTransferRegistry::getInstance();
+  const std::string taskId = "registerWaiterWokenByCancel";
+  const auto key = makeKey(taskId);
+
+  std::atomic<int> woken{0};
+  const bool readyNow = registry->registerWaiter(key, [&woken]() { ++woken; });
+  EXPECT_FALSE(readyNow);
+
+  registry->cancelTask(taskId);
+  EXPECT_EQ(woken.load(), 1);
+
+  auto result = registry->poll(key);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->atEnd);
+
+  // Clear singleton state so the cancelled task does not leak into other tests.
+  registry->clearCancelledTask(taskId);
+}


### PR DESCRIPTION
## Summary

This PR cleans up the cuDF UCX intra-node exchange path and adds a small profiling aid:

- make intra-node transfer waiting event-driven through `IntraNodeTransferRegistry`
- keep local broadcast transfer on a safe clone path instead of sharing mutable packed buffers directly
- publish intra-node data with the producer buffer stream instead of `rmm::cuda_stream_default`
- name the UCX progress thread `ucx-progress` so it is identifiable in profilers and thread dumps
- add focused registry coverage for publish/wait/cancel behavior

## Reproduction / Runtime Configuration

To reproduce the patched 2-GPU Spark Gluten run reported below, use this Velox branch with Spark Gluten origin-stream and enable the existing cuDF intra-node exchange path:

```text
spark.gluten.sql.columnar.backend.velox.cudf.intra_node_exchange=true
```

Also set the Spark Gluten broadcast bootstrap wait to 0 ms:

```text
spark.executorEnv.GLUTEN_MPP_BROADCAST_BOOTSTRAP_WAIT_MS=0
spark.driverEnv.GLUTEN_MPP_BROADCAST_BOOTSTRAP_WAIT_MS=0
```

The local measurement used 2 B200 GPUs and 3 iterations per query, reporting min hot time.

Without `spark.gluten.sql.columnar.backend.velox.cudf.intra_node_exchange=true`, the intra-node bypass path is not selected; the branch still includes the harmless UCX progress-thread naming change, but the stream-handoff fix is not covered by the run.

## Performance Snapshot

TPC-H SF1000-style 2-GPU sweep, 3 iterations per query, reporting min hot time. The pv-cli column is the comparable 2-GPU presto-velox-cudf result.

Important caveat: the origin baseline and patched intra-node numbers below were produced with different bootstrap wait settings: baseline used 500 ms and patched used 0 ms. Therefore this table is a useful performance snapshot, but not a fully controlled A-B proof of the Velox-only change.

Q21 is excluded from the PR gate because this origin-stream/Spark Gluten environment already treats Q21 as a known baseline/gating issue, so Q21 is not attributed to this PR. The pv-cli Q21 number was 4634 ms, and the pv-cli full Q1-Q22 sum was 48281 ms; the main comparison below uses Q1-Q20,Q22 for all engines.

| Query | Origin baseline (ms) | Patched intra-node (ms) | pv-cli / presto-velox-cudf (ms) | Patched vs baseline | Patched vs pv-cli |
|---|---:|---:|---:|---:|---:|
| Q1 | 3198 | 3158 | 2656 | -40 | +502 |
| Q2 | 1701 | 855 | 771 | -846 | +84 |
| Q3 | 7244 | 1723 | 1860 | -5521 | -137 |
| Q4 | 1902 | 1175 | 1526 | -727 | -351 |
| Q5 | 2824 | 2133 | 2044 | -691 | +89 |
| Q6 | 1249 | 1134 | 1080 | -115 | +54 |
| Q7 | 3498 | 2113 | 2254 | -1385 | -141 |
| Q8 | 3347 | 2286 | 2672 | -1061 | -386 |
| Q9 | 6155 | 2994 | 5960 | -3161 | -2966 |
| Q10 | 8075 | 2321 | 2400 | -5754 | -79 |
| Q11 | 2464 | 2410 | 636 | -54 | +1774 |
| Q12 | 3117 | 1571 | 1394 | -1546 | +177 |
| Q13 | 3276 | 2106 | 1729 | -1170 | +377 |
| Q14 | 3364 | 1518 | 1416 | -1846 | +102 |
| Q15 | 3431 | 2770 | 2408 | -661 | +362 |
| Q16 | 1257 | 623 | 846 | -634 | -223 |
| Q17 | 10714 | 2966 | 3192 | -7748 | -226 |
| Q18 | 13851 | 2886 | 4209 | -10965 | -1323 |
| Q19 | 2219 | 2174 | 1500 | -45 | +674 |
| Q20 | 2431 | 2557 | 1699 | +126 | +858 |
| Q22 | 1625 | 1293 | 1395 | -332 | -102 |
| **Total excl. Q21** | **86942** | **42766** | **43647** | **-44176** | **-881** |

## Correctness Validation

Collected row outputs were compared between baseline and patched runs for Q1-Q20 and Q22. Q21 is excluded for the baseline/gating reason above.

- Non-floating fields were required to match exactly.
- Floating fields serialized as `{"float":"..."}` were compared numerically with tolerance `abs <= 1e-6` or `rel <= 1e-12`.
- Result: all compared queries passed.
- Large-output queries were covered, including Q11 with 936,989 rows, Q16 with 27,840 rows, and Q20 with 112,013 rows.

## Known Follow-up

- Q21 still needs follow-up. It is excluded here because the origin-stream/Spark Gluten baseline/gating environment is not clean for Q21, while pv-cli has a 2-GPU Q21 result of 4634 ms.
- One patched collect-output attempt for Q17 hit an intermittent cuDF parquet scan decompression failure:

```text
Reason: Operator::getOutput failed for [operator: TableScan, plan node ID: 0]: CUDF failure at: /opt/velox/_build/release/_deps/cudf-src/cpp/src/io/parquet/reader_impl_chunking_utils.cu:629: Error during decompression
```

The same Q17 query subsequently reran successfully and its output matched the baseline within floating-point tolerance. This failure currently looks intermittent and scan-side; it is not proven to be caused by this PR, but it remains a known follow-up item.
