### PR TITLE
ucx-exchange: make output buffer completion event-driven

### DIFF
--- a/velox/experimental/ucx-exchange/Acceptor.cpp
+++ b/velox/experimental/ucx-exchange/Acceptor.cpp
@@ -33,6 +33,23 @@ void Acceptor::cStyleAMCallback(
   auto buffer =
       std::dynamic_pointer_cast<ucxx::Buffer>(request->getRecvBuffer());
   VELOX_CHECK(buffer != nullptr, "AMCallback: failed to get receive buffer.");
+  if (buffer->getSize() >= sizeof(UcxControlMsg)) {
+    const auto* controlPtr =
+        reinterpret_cast<const UcxControlMsg*>(buffer->data());
+    if (controlPtr->magic == kControlMagicNumber) {
+      VELOX_CHECK_EQ(
+          controlPtr->type,
+          static_cast<uint32_t>(UcxControlMessageType::kAbortResults),
+          "Unknown UCX exchange control message type {}",
+          controlPtr->type);
+      const PartitionKey key = {controlPtr->taskId, controlPtr->destination};
+      VLOG(2) << "[UCX-ACCEPTOR-ABORT-RESULTS] task=" << key.taskId
+              << " destination=" << key.destination;
+      UcxOutputQueueManager::getInstanceRef()->deleteResults(
+          key.taskId, key.destination);
+      return;
+    }
+  }
   // Validate buffer size BEFORE casting to prevent reading past buffer bounds.
   VELOX_CHECK_GE(
       buffer->getSize(),

--- a/velox/experimental/ucx-exchange/UcxExchangeProtocol.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeProtocol.h
@@ -78,6 +78,24 @@ struct HandshakeMsg {
   uint64_t workerId{0};
 };
 
+constexpr uint32_t kControlMagicNumber = 0x55435843; // "UCXC"
+
+enum class UcxControlMessageType : uint32_t {
+  kAbortResults = 1,
+};
+
+/// Best-effort consumer-to-producer control message. This mirrors Presto's
+/// DELETE /v1/task/<task>/results/<destination>: the downstream source is
+/// closing early, so the producer can destroy the corresponding destination
+/// buffer. The message is intentionally idempotent.
+struct UcxControlMsg {
+  uint32_t magic{kControlMagicNumber};
+  uint32_t type{0};
+  char taskId[256];
+  uint32_t destination{0};
+  uint32_t padding{0};
+};
+
 /// @brief Response sent from server to source after handshake.
 /// Informs the source whether intra-node transfer optimization is available,
 /// allowing the source to bypass UCXX for all subsequent data transfers.

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -159,6 +159,9 @@ void UcxExchangeServer::process() {
       // Waiting for send complete is handled by an upcall from UCXX. Nothing to
       // do
       break;
+    case ServerState::WaitingForEndMarkerSendComplete:
+      // Waiting for the final atEnd metadata send to complete.
+      break;
     case ServerState::WaitingForIntraNodeRetrieve:
       // Intra-node transfer: check if the source has retrieved the data
       if (intraNodeRetrieveFuture_.valid()) {
@@ -208,7 +211,7 @@ void UcxExchangeServer::close() {
           << " hasDataRequest=" << (dataRequest_ != nullptr)
           << " hasDataPtr=" << (dataPtr_ != nullptr);
 
-  if (queueMgr_) {
+  if (queueMgr_ && !remoteEndMarkerSent_) {
     queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
   }
 
@@ -303,8 +306,6 @@ void UcxExchangeServer::sendData() {
               key, nullptr, rmm::cuda_stream_default, /*atEnd=*/true);
       intraNodeAtEndPublished_ = true;
 
-      queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
-
       // Wait for source to acknowledge atEnd before finishing
       setState(ServerState::WaitingForIntraNodeRetrieve);
       communicator_->addToWorkQueue(getSelfPtr());
@@ -312,6 +313,7 @@ void UcxExchangeServer::sendData() {
   } else {
     // REMOTE EXCHANGE PATH: Use UCXX for metadata and data transfer
     std::shared_ptr<MetadataMsg> metadataMsg = std::make_shared<MetadataMsg>();
+    const bool isEndMarker = dataPtr_ == nullptr;
 
     if (dataPtr_) {
       // Copy metadata (not move) because in broadcast mode, the same
@@ -332,6 +334,10 @@ void UcxExchangeServer::sendData() {
     }
 
     auto [serializedMetadata, serMetaSize] = metadataMsg->serialize();
+    if (isEndMarker) {
+      remoteEndMarkerInFlight_ = true;
+      setState(ServerState::WaitingForEndMarkerSendComplete);
+    }
 
     // send metadata.
     uint64_t metadataTag =
@@ -375,6 +381,23 @@ void UcxExchangeServer::sendData() {
             VLOG(3) << "@" << self->partitionKey_.taskId
                     << " metadata successfully sent to " << tid
                     << " with tag: " << std::hex << metadataTag;
+            if (self->remoteEndMarkerInFlight_) {
+              self->remoteEndMarkerInFlight_ = false;
+              self->remoteEndMarkerSent_ = true;
+              // Match Presto's output-buffer state model: after the producer
+              // has flushed the final marker to the consumer, the destination
+              // buffer can be destroyed. Source abortResults() remains a
+              // best-effort DELETE/abort signal for early close paths, but
+              // normal task completion does not depend on a reverse control
+              // message.
+              if (self->queueMgr_) {
+                self->queueMgr_->deleteResults(
+                    self->partitionKey_.taskId,
+                    self->partitionKey_.destination);
+              }
+              self->setState(ServerState::Done);
+              self->communicator_->addToWorkQueue(self);
+            }
           } else {
             VLOG(0) << "[UCX-SERVER-METADATA-SEND-ERROR] task="
                     << self->partitionKey_.taskId << " key=" << tid
@@ -440,9 +463,9 @@ void UcxExchangeServer::sendData() {
       VLOG(3) << "@" << partitionKey_.taskId
               << " Finished transferring partition for task "
               << partitionKey_.toString();
-      queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
-      setState(ServerState::Done);
-      communicator_->addToWorkQueue(getSelfPtr());
+      // The producer-side destination buffer is destroyed when this final
+      // marker send completes. Source abortResults() is reserved for early
+      // close/retry paths.
     }
   }
 }
@@ -517,6 +540,7 @@ void UcxExchangeServer::onIntraNodeRetrieveComplete() {
     // This was the final atEnd marker, we're done
     VLOG(3) << "@" << partitionKey_.taskId
             << " Intra-node transfer: atEnd acknowledged, finishing";
+    queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
     setState(ServerState::Done);
   } else {
     // More data may be coming, continue transfer loop

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.h
@@ -70,6 +70,7 @@ class UcxExchangeServer
     WaitingForDataFromQueue,
     DataReady,
     WaitingForSendComplete,
+    WaitingForEndMarkerSendComplete,
     WaitingForIntraNodeRetrieve, // Intra-node transfer: waiting for source to
                                  // retrieve
     Done
@@ -112,6 +113,7 @@ class UcxExchangeServer
         "WaitingForDataFromQueue",
         "DataReady",
         "WaitingForSendComplete",
+        "WaitingForEndMarkerSendComplete",
         "WaitingForIntraNodeRetrieve",
         "Done"};
     return stateMap[static_cast<uint32_t>(s)];
@@ -140,6 +142,13 @@ class UcxExchangeServer
 
   /// For intra-node transfer: true if the last published entry was atEnd.
   bool intraNodeAtEndPublished_{false};
+
+  /// True while the remote path is sending the final atEnd metadata marker.
+  bool remoteEndMarkerInFlight_{false};
+
+  /// True after the remote final atEnd marker has been sent successfully and
+  /// the producer destination buffer has been destroyed.
+  bool remoteEndMarkerSent_{false};
 
   uint32_t sequenceNumber_{0};
   uint32_t intraNodePollCount_{0};

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -216,6 +216,9 @@ void UcxExchangeSource::cleanUp() {
     if (request_) {
       communicator_->deferRequestCleanup(std::move(request_));
     }
+    if (abortRequest_) {
+      communicator_->deferRequestCleanup(std::move(abortRequest_));
+    }
     for (auto& req : completedRequests_) {
       communicator_->deferRequestCleanup(std::move(req));
     }
@@ -248,6 +251,8 @@ void UcxExchangeSource::close() {
   VLOG(2) << "[UCX-SOURCE-CLOSE] " << toString()
           << " state=" << getStateAsString() << " seq=" << sequenceNumber_
           << " hasRequest=" << (request_ != nullptr) << " atEnd=" << atEnd_;
+
+  abortResults();
 
   // Guarantee the end marker is delivered before transitioning to Done.
   deliverEndMarker();
@@ -342,6 +347,62 @@ void UcxExchangeSource::deliverEndMarker() {
   }
   VLOG(3) << toString() << " delivering end-of-stream marker to queue";
   enqueue(nullptr);
+}
+
+void UcxExchangeSource::abortResults() {
+  bool expected = false;
+  if (!abortResultsIssued_.compare_exchange_strong(
+          expected, true, std::memory_order_acq_rel)) {
+    return;
+  }
+
+  if (!endpointRef_ || !endpointRef_->endpoint_ ||
+      !endpointRef_->endpoint_->isAlive()) {
+    VLOG(2) << "[UCX-SOURCE-ABORT-RESULTS-SKIP] " << toString()
+            << " endpoint unavailable";
+    return;
+  }
+
+  auto abortMsg = std::make_shared<UcxControlMsg>();
+  abortMsg->type =
+      static_cast<uint32_t>(UcxControlMessageType::kAbortResults);
+  strncpy(
+      abortMsg->taskId,
+      partitionKey_.taskId.c_str(),
+      sizeof(abortMsg->taskId) - 1);
+  abortMsg->taskId[sizeof(abortMsg->taskId) - 1] = '\0';
+  abortMsg->destination = partitionKey_.destination;
+
+  VLOG(2) << "[UCX-SOURCE-ABORT-RESULTS] localTask=" << taskId_
+          << " remoteTask=" << partitionKey_.taskId
+          << " destination=" << partitionKey_.destination << " peer=" << host_
+          << ":" << port_;
+
+  ucxx::AmReceiverCallbackInfo info(
+      communicator_->kAmCallbackOwner, communicator_->kAmCallbackId);
+  std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
+  if (abortRequest_) {
+    completedRequests_.push_back(std::move(abortRequest_));
+  }
+  abortRequest_ = endpointRef_->endpoint_->amSend(
+      abortMsg.get(),
+      sizeof(*abortMsg),
+      UCS_MEMORY_TYPE_HOST,
+      info,
+      false,
+      [weak](ucs_status_t status, std::shared_ptr<void> /*arg*/) {
+        if (auto self = weak.lock()) {
+          if (status == UCS_OK) {
+            VLOG(3) << "[UCX-SOURCE-ABORT-RESULTS-ACK] "
+                    << self->toString();
+          } else {
+            VLOG(2) << "[UCX-SOURCE-ABORT-RESULTS-ERROR] "
+                    << self->toString()
+                    << " status=" << ucs_status_string(status);
+          }
+        }
+      },
+      abortMsg);
 }
 
 void UcxExchangeSource::setEndpoint(std::shared_ptr<EndpointRef> endpointRef) {

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -262,6 +262,10 @@ class UcxExchangeSource
   /// with the queue (i.e., registered_ is false).
   void deliverEndMarker();
 
+  /// @brief Best-effort abort for the producer-side destination buffer during
+  /// early source close. Modeled after Presto's abortResults().
+  void abortResults();
+
   /// @brief Sets the state to "desired" if and only if the current
   /// state is "expected".
   /// @param expected The expected state
@@ -292,6 +296,9 @@ class UcxExchangeSource
   /// Only one thread can win the CAS and call enqueue(nullptr).
   std::atomic<bool> endMarkerDelivered_{false};
 
+  /// @brief Guards exactly-once producer-side destination abort.
+  std::atomic<bool> abortResultsIssued_{false};
+
   /// @brief True only after addSourceLocked() has been called for this source.
   /// Prevents deliverEndMarker() from incrementing numCompleted_ for sources
   /// that were never registered with the queue (e.g., created after client
@@ -318,6 +325,9 @@ class UcxExchangeSource
   // NOTE: The request owns/holds a reference to the upcall function
   // and must therefore exist until the upcall is done.
   std::shared_ptr<ucxx::Request> request_{nullptr};
+
+  // Best-effort control request used for producer-side destination abort.
+  std::shared_ptr<ucxx::Request> abortRequest_{nullptr};
 
   // Completed UCXX requests are kept alive here to prevent use-after-free.
   // UCP's ucp_wireup_replay_pending_requests can fire callbacks on already-

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
@@ -87,7 +87,47 @@ bool UcxOutputQueueManager::checkBlocked(
 }
 
 void UcxOutputQueueManager::noMoreData(const std::string& taskId) {
-  getQueue(taskId)->noMoreData();
+  auto queue = getQueueIfExists(taskId);
+  if (queue != nullptr) {
+    queue->noMoreData();
+    return;
+  }
+  if (removedTasks_.withLock(
+          [&](auto& removed) { return removed.count(taskId) > 0; })) {
+    VLOG(2) << "[QUEUE-MGR] task=" << taskId
+            << " noMoreData ignored (task already removed)";
+    return;
+  }
+  VELOX_FAIL("Output cudf queue for task not found: {}", taskId);
+}
+
+void UcxOutputQueueManager::onNoMoreData(
+    const std::string& taskId,
+    UcxNoMoreDataCallback notify) {
+  auto queue = getQueueIfExists(taskId);
+  if (queue != nullptr) {
+    queue->onNoMoreData(std::move(notify));
+    return;
+  }
+  if (removedTasks_.withLock(
+          [&](auto& removed) { return removed.count(taskId) > 0; })) {
+    if (notify) {
+      notify(UcxOutputQueueEndState::kTerminated);
+    }
+    return;
+  }
+  VELOX_FAIL("Output cudf queue for task not found: {}", taskId);
+}
+
+bool UcxOutputQueueManager::onFinished(
+    const std::string& taskId,
+    UcxOutputQueueFinishedCallback notify) {
+  auto queue = getQueueIfExists(taskId);
+  if (queue != nullptr) {
+    queue->onFinished(std::move(notify));
+    return true;
+  }
+  return false;
 }
 
 bool UcxOutputQueueManager::isFinished(const std::string& taskId) {

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
@@ -79,6 +79,16 @@ class UcxOutputQueueManager {
   /// @brief Indicates that no more data will be coming for this task.
   void noMoreData(const std::string& taskId);
 
+  /// @brief Registers a callback that fires when the task output queue reaches
+  /// noMoreData. If the task is already at end, fires immediately. If the
+  /// queue is terminated before noMoreData, fires with kTerminated.
+  void onNoMoreData(const std::string& taskId, UcxNoMoreDataCallback notify);
+
+  /// @brief Registers a callback that fires when the task output queue has no
+  /// remaining destination buffers. Returns false when no queue exists for the
+  /// task (for example, tasks with no UCX partitioned output).
+  bool onFinished(const std::string& taskId, UcxOutputQueueFinishedCallback notify);
+
   /// @returns true if noMoreData has been called and all the accumulated data
   /// have been fetched and acknowledged.
   bool isFinished(const std::string& taskId);

--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -465,8 +465,40 @@ void UcxOutputQueue::noMoreDrivers() {
   checkIfDone(false);
 }
 
+void UcxOutputQueue::onNoMoreData(UcxNoMoreDataCallback notify) {
+  UcxNoMoreDataCallback readyCallback;
+  UcxOutputQueueEndState readyState{UcxOutputQueueEndState::kNoMoreData};
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (atEnd_) {
+      readyCallback = std::move(notify);
+    } else {
+      noMoreDataCallbacks_.push_back(std::move(notify));
+    }
+  }
+  if (readyCallback) {
+    readyCallback(readyState);
+  }
+}
+
+void UcxOutputQueue::onFinished(UcxOutputQueueFinishedCallback notify) {
+  UcxOutputQueueFinishedCallback readyCallback;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (isFinishedLocked()) {
+      readyCallback = std::move(notify);
+    } else {
+      finishedCallbacks_.push_back(std::move(notify));
+    }
+  }
+  if (readyCallback) {
+    readyCallback();
+  }
+}
+
 void UcxOutputQueue::checkIfDone(bool oneDriverFinished) {
   std::vector<UcxDataAvailable> finished;
+  std::vector<UcxNoMoreDataCallback> noMoreDataCallbacks;
   {
     std::lock_guard<std::mutex> l(mutex_);
     if (oneDriverFinished) {
@@ -476,6 +508,7 @@ void UcxOutputQueue::checkIfDone(bool oneDriverFinished) {
         numFinished_,
         numDrivers_,
         "Each driver should call noMoreData exactly once");
+    const bool wasAtEnd = atEnd_;
     atEnd_ = numFinished_ == numDrivers_;
     if (!atEnd_) {
       return;
@@ -496,10 +529,18 @@ void UcxOutputQueue::checkIfDone(bool oneDriverFinished) {
         finished.push_back(queue->getAndClearNotify());
       }
     }
+    if (!wasAtEnd) {
+      noMoreDataCallbacks = std::move(noMoreDataCallbacks_);
+    }
   }
   // Notify outside of mutex.
   for (auto& notification : finished) {
     notification.notify();
+  }
+  for (auto& callback : noMoreDataCallbacks) {
+    if (callback) {
+      callback(UcxOutputQueueEndState::kNoMoreData);
+    }
   }
 }
 
@@ -560,15 +601,27 @@ bool UcxOutputQueue::isFinishedLocked() {
 void UcxOutputQueue::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
   using Kind = core::PartitionedOutputNode::Kind;
   if (kind_ == Kind::kPartitioned) {
-    std::lock_guard<std::mutex> l(mutex_);
-    VELOX_CHECK_EQ(queues_.size(), numBuffers);
-    VELOX_CHECK(noMoreBuffers);
-    noMoreQueues_ = true;
+    std::vector<UcxOutputQueueFinishedCallback> finishedCallbacks;
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      VELOX_CHECK_EQ(queues_.size(), numBuffers);
+      VELOX_CHECK(noMoreBuffers);
+      noMoreQueues_ = true;
+      if (isFinishedLocked()) {
+        finishedCallbacks = std::move(finishedCallbacks_);
+      }
+    }
+    for (auto& callback : finishedCallbacks) {
+      if (callback) {
+        callback();
+      }
+    }
     return;
   }
 
   VELOX_CHECK_EQ(kind_, Kind::kBroadcast);
   bool isFinished;
+  std::vector<UcxOutputQueueFinishedCallback> finishedCallbacks;
   {
     std::lock_guard<std::mutex> l(mutex_);
 
@@ -599,10 +652,18 @@ void UcxOutputQueue::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
     noMoreQueues_ = true;
     dataToBroadcast_.clear();
     isFinished = isFinishedLocked();
+    if (isFinished) {
+      finishedCallbacks = std::move(finishedCallbacks_);
+    }
   }
 
   if (isFinished && task_) {
     task_->setAllOutputConsumed();
+  }
+  for (auto& callback : finishedCallbacks) {
+    if (callback) {
+      callback();
+    }
   }
 }
 
@@ -610,6 +671,7 @@ void UcxOutputQueue::deleteResults(int destination) {
   bool isFinished;
   UcxDataAvailable dataAvailable;
   std::vector<ContinuePromise> promises;
+  std::vector<UcxOutputQueueFinishedCallback> finishedCallbacks;
   {
     std::lock_guard<std::mutex> l(mutex_);
     if (destination >= queues_.size()) {
@@ -629,6 +691,9 @@ void UcxOutputQueue::deleteResults(int destination) {
     queue->finish();
     queues_[destination] = nullptr;
     isFinished = isFinishedLocked();
+    if (isFinished) {
+      finishedCallbacks = std::move(finishedCallbacks_);
+    }
     // update UcxOutputQueue stats
     if (bytes > 0 || packedCols > 0) {
       updateStatsWithFreedLocked(bytes, packedCols, promises);
@@ -647,10 +712,16 @@ void UcxOutputQueue::deleteResults(int destination) {
   if (isFinished && task_) {
     task_->setAllOutputConsumed();
   }
+  for (auto& callback : finishedCallbacks) {
+    if (callback) {
+      callback();
+    }
+  }
 }
 
 void UcxOutputQueue::terminate() {
   std::vector<UcxDataAvailable> pendingCallbacks;
+  std::vector<UcxNoMoreDataCallback> noMoreDataCallbacks;
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -669,11 +740,17 @@ void UcxOutputQueue::terminate() {
     }
     // Release any outstanding producer-side promises (blocked on queue-full).
     promises = std::move(promises_);
+    noMoreDataCallbacks = std::move(noMoreDataCallbacks_);
   }
 
   // Fire callbacks outside of mutex to avoid potential deadlocks.
   for (auto& callback : pendingCallbacks) {
     callback.notify();
+  }
+  for (auto& callback : noMoreDataCallbacks) {
+    if (callback) {
+      callback(UcxOutputQueueEndState::kTerminated);
+    }
   }
   // Unblock any blocked producers.
   for (auto& promise : promises) {

--- a/velox/experimental/ucx-exchange/UcxQueues.h
+++ b/velox/experimental/ucx-exchange/UcxQueues.h
@@ -41,6 +41,16 @@ using UcxDataAvailableCallbackV2 = std::function<void(
     int64_t sequence,
     std::vector<int64_t> remainingBytes)>;
 
+enum class UcxOutputQueueEndState {
+  kNoMoreData,
+  kTerminated,
+};
+
+using UcxNoMoreDataCallback =
+    std::function<void(UcxOutputQueueEndState state)>;
+
+using UcxOutputQueueFinishedCallback = std::function<void()>;
+
 struct UcxDataAvailable {
   UcxDataAvailableCallback callback{nullptr};
   UcxDataAvailableCallbackV2 callbackV2{nullptr};
@@ -222,6 +232,15 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   /// @brief Indicates that a driver is done and won't enqueue any more data.
   void noMoreData();
 
+  /// @brief Registers a callback that fires when all producer drivers have
+  /// reported noMoreData. If the queue is already at end, fires immediately.
+  void onNoMoreData(UcxNoMoreDataCallback notify);
+
+  /// @brief Registers a callback that fires when all destination queues have
+  /// been consumed and deleted. If the queue is already finished, fires
+  /// immediately.
+  void onFinished(UcxOutputQueueFinishedCallback notify);
+
   /// @brief Updates the number of destination buffers. For broadcast mode,
   /// new destinations are backfilled with previously broadcast data.
   /// Modeled on OutputBuffer::updateOutputBuffers().
@@ -328,6 +347,12 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
 
   // promises when buffer reached capacity and blocked further enqueueing.
   std::vector<ContinuePromise> promises_;
+
+  // callbacks waiting for all producer drivers to reach noMoreData.
+  std::vector<UcxNoMoreDataCallback> noMoreDataCallbacks_;
+
+  // callbacks waiting for all destination buffers to be consumed.
+  std::vector<UcxOutputQueueFinishedCallback> finishedCallbacks_;
 
   // actual data in 'queues_'
   int64_t queuedBytes_{0};

--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -714,6 +714,34 @@ TEST_F(UcxOutputQueueManagerTest, callbackFiredOnTerminateAfterInit) {
   EXPECT_TRUE(callback1Nullptr);
 }
 
+TEST_F(UcxOutputQueueManagerTest, onNoMoreDataAfterRemoveReportsTerminated) {
+  const std::string taskId = "removedNoMoreDataCallback";
+  auto task = initializeTask(taskId, 1 /* numDestinations */, 1 /* numDrivers */);
+
+  queueManager_->removeTask(taskId);
+
+  bool callbackFired = false;
+  UcxOutputQueueEndState callbackState{UcxOutputQueueEndState::kNoMoreData};
+  queueManager_->onNoMoreData(
+      taskId,
+      [&](UcxOutputQueueEndState state) {
+        callbackFired = true;
+        callbackState = state;
+      });
+
+  EXPECT_TRUE(callbackFired);
+  EXPECT_EQ(callbackState, UcxOutputQueueEndState::kTerminated);
+}
+
+TEST_F(UcxOutputQueueManagerTest, noMoreDataAfterRemoveIsIgnored) {
+  const std::string taskId = "removedNoMoreData";
+  auto task = initializeTask(taskId, 1 /* numDestinations */, 1 /* numDrivers */);
+
+  queueManager_->removeTask(taskId);
+
+  EXPECT_NO_THROW(queueManager_->noMoreData(taskId));
+}
+
 // --- Broadcast tests ---
 
 // Basic broadcast: enqueue data, all destinations receive the same data.


### PR DESCRIPTION
Add noMoreData and finished callbacks to UCX output queues so consumers can release producer buffers by state transition instead of timing.

Wait for final remote end-marker send completion, and intra-node end-marker retrieval, before deleting destination results. Keep abortResults as an idempotent early-close control path.