### PR TITLE
ucx-exchange: make intra-node handoff event driven

### DIFF
--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -229,7 +229,6 @@ void Communicator::run() {
                 [](const auto& req) { return req->isCompleted(); }),
             deferredRequests_.end());
       }
-
       // All queues are drained. Now wait for UCXX network events.
       // In blocking mode, this will block until a UCXX event arrives
       // or worker_->signal() is called (from addToWorkQueue,

--- a/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.cpp
+++ b/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.cpp
@@ -33,7 +33,8 @@ std::future<void> IntraNodeTransferRegistry::publish(
     const IntraNodeTransferKey& key,
     std::shared_ptr<cudf::packed_columns> data,
     rmm::cuda_stream_view stream,
-    bool atEnd) {
+    bool atEnd,
+    std::function<void()> onRetrieved) {
   std::shared_ptr<IntraNodeTransferEntry> entry;
   std::future<void> future;
   bool entryExisted;
@@ -66,6 +67,9 @@ std::future<void> IntraNodeTransferRegistry::publish(
     VLOG(2) << "[INTRA-REG] publish skipped (task cancelled): task="
             << key.taskId << " dest=" << key.destination
             << " seq=" << key.sequenceNumber;
+    if (onRetrieved) {
+      onRetrieved();
+    }
     std::promise<void> p;
     p.set_value();
     return p.get_future();
@@ -86,6 +90,9 @@ std::future<void> IntraNodeTransferRegistry::publish(
     // registerWaiter() takes guarantees no lost wakeup: a registerWaiter() that
     // ran first added its callback here; one that runs later sees ready==true.
     toWake.swap(entry->wakeCallbacks);
+    if (onRetrieved) {
+      entry->retrievedCallbacks.push_back(std::move(onRetrieved));
+    }
   }
 
   // Notify waiting source
@@ -133,6 +140,7 @@ std::optional<IntraNodeTransferResult> IntraNodeTransferRegistry::poll(
   // race conditions. Previously, the lock was released before accessing
   // entry->data, entry->atEnd, and entry->retrievedPromise.
   IntraNodeTransferResult result;
+  std::vector<std::function<void()>> retrievedCallbacks;
   {
     std::lock_guard<std::mutex> entryLock(entry->entryMutex);
     if (!entry->ready) {
@@ -149,6 +157,7 @@ std::optional<IntraNodeTransferResult> IntraNodeTransferRegistry::poll(
 
     // Fulfill the promise to notify the server while still holding entry lock
     entry->retrievedPromise.set_value();
+    retrievedCallbacks.swap(entry->retrievedCallbacks);
   }
 
   // Remove entry from registry (after releasing entry lock but before
@@ -161,6 +170,10 @@ std::optional<IntraNodeTransferResult> IntraNodeTransferRegistry::poll(
   VLOG(2) << "[INTRA-REG] poll hit: task=" << key.taskId
           << " dest=" << key.destination << " seq=" << key.sequenceNumber
           << " atEnd=" << result.atEnd;
+
+  for (auto& wake : retrievedCallbacks) {
+    wake();
+  }
 
   return result;
 }
@@ -220,6 +233,7 @@ IntraNodeTransferResult IntraNodeTransferRegistry::waitFor(
   // to prevent race conditions. Previously, the lock was released before
   // accessing entry->data, entry->atEnd, and entry->retrievedPromise.
   IntraNodeTransferResult result;
+  std::vector<std::function<void()>> retrievedCallbacks;
   {
     std::unique_lock<std::mutex> entryLock(entry->entryMutex);
     if (!entry->ready) {
@@ -240,6 +254,7 @@ IntraNodeTransferResult IntraNodeTransferRegistry::waitFor(
 
     // Fulfill the promise to notify the server while still holding entry lock
     entry->retrievedPromise.set_value();
+    retrievedCallbacks.swap(entry->retrievedCallbacks);
   }
 
   // Remove entry from registry (after releasing entry lock but before
@@ -253,31 +268,47 @@ IntraNodeTransferResult IntraNodeTransferRegistry::waitFor(
           << " dest=" << key.destination << " seq=" << key.sequenceNumber
           << " atEnd=" << result.atEnd;
 
+  for (auto& wake : retrievedCallbacks) {
+    wake();
+  }
+
   return result;
 }
 
 std::shared_ptr<cudf::packed_columns> IntraNodeTransferRegistry::retrieve(
     const IntraNodeTransferKey& key) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<std::function<void()>> retrievedCallbacks;
+  std::shared_ptr<cudf::packed_columns> data;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
 
-  auto it = registry_.find(key);
-  if (it == registry_.end()) {
-    VLOG(0) << "Intra-node transfer entry not found: " << key.taskId
-            << " dest=" << key.destination << " seq=" << key.sequenceNumber;
-    return nullptr;
+    auto it = registry_.find(key);
+    if (it == registry_.end()) {
+      VLOG(0) << "Intra-node transfer entry not found: " << key.taskId
+              << " dest=" << key.destination << " seq=" << key.sequenceNumber;
+      return nullptr;
+    }
+
+    auto entry = it->second;
+    {
+      std::lock_guard<std::mutex> entryLock(entry->entryMutex);
+      data = std::move(entry->data);
+
+      // Fulfill the promise to notify the server that data has been retrieved
+      entry->retrievedPromise.set_value();
+      retrievedCallbacks.swap(entry->retrievedCallbacks);
+    }
+
+    // Remove the entry from the registry
+    registry_.erase(it);
   }
-
-  auto entry = it->second;
-  auto data = std::move(entry->data);
-
-  // Fulfill the promise to notify the server that data has been retrieved
-  entry->retrievedPromise.set_value();
-
-  // Remove the entry from the registry
-  registry_.erase(it);
 
   VLOG(3) << "Retrieved intra-node transfer: " << key.taskId
           << " dest=" << key.destination << " seq=" << key.sequenceNumber;
+
+  for (auto& wake : retrievedCallbacks) {
+    wake();
+  }
 
   return data;
 }
@@ -303,6 +334,7 @@ void IntraNodeTransferRegistry::cancelTask(const std::string& taskId) {
 
   // Fulfill promises outside the lock to avoid potential deadlocks.
   std::vector<std::function<void()>> toWake;
+  std::vector<std::function<void()>> retrievedCallbacks;
   for (auto& entry : entriesToFulfill) {
     std::lock_guard<std::mutex> entryLock(entry->entryMutex);
     if (!entry->ready) {
@@ -314,6 +346,10 @@ void IntraNodeTransferRegistry::cancelTask(const std::string& taskId) {
       toWake.push_back(std::move(wake));
     }
     entry->wakeCallbacks.clear();
+    for (auto& wake : entry->retrievedCallbacks) {
+      retrievedCallbacks.push_back(std::move(wake));
+    }
+    entry->retrievedCallbacks.clear();
     try {
       entry->retrievedPromise.set_value();
     } catch (const std::future_error&) {
@@ -322,6 +358,9 @@ void IntraNodeTransferRegistry::cancelTask(const std::string& taskId) {
   }
 
   for (auto& wake : toWake) {
+    wake();
+  }
+  for (auto& wake : retrievedCallbacks) {
     wake();
   }
 

--- a/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
+++ b/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
@@ -71,6 +71,10 @@ struct IntraNodeTransferEntry {
   // busy-polling the single-threaded Communicator work queue. Fired and cleared
   // by publish()/cancelTask(). Guarded by entryMutex.
   std::vector<std::function<void()>> wakeCallbacks;
+  // One-shot wakeups for producers waiting until the source has retrieved the
+  // published data. Fired and cleared when poll()/waitFor()/retrieve() consumes
+  // the entry, or when cancelTask() completes it as at-end.
+  std::vector<std::function<void()>> retrievedCallbacks;
 };
 
 /// @brief Singleton registry for intra-node data transfers.
@@ -104,7 +108,8 @@ class IntraNodeTransferRegistry {
       const IntraNodeTransferKey& key,
       std::shared_ptr<cudf::packed_columns> data,
       rmm::cuda_stream_view stream,
-      bool atEnd);
+      bool atEnd,
+      std::function<void()> onRetrieved = {});
 
   /// @brief Non-blocking poll for intra-node transfer data.
   /// Returns immediately whether data is available or not.

--- a/velox/experimental/ucx-exchange/UcxExchangeClient.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeClient.cpp
@@ -173,7 +173,7 @@ UcxExchangeClient::next(int consumerId, bool* atEnd, ContinueFuture* future) {
         VLOG(1) << "[PROGRESS] @" << taskId_ << " consumer=" << consumerId
                 << " dequeued=" << totalDequeued_
                 << " queueSize=" << queue_->sizeLocked()
-                << " queueBytes=" << queue_->totalBytes();
+                << " queueBytes=" << queue_->totalBytesLocked();
       }
     }
 

--- a/velox/experimental/ucx-exchange/UcxExchangeQueue.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeQueue.cpp
@@ -40,7 +40,8 @@ void UcxExchangeQueue::close() {
 
 void UcxExchangeQueue::enqueueLocked(
     PackedTableWithStreamPtr&& data,
-    std::vector<ContinuePromise>& promises) {
+    std::vector<ContinuePromise>& promises,
+    int64_t reservedReceiveBytes) {
   if (data == nullptr) {
     ++numCompleted_;
     VLOG(2) << "[EX-QUEUE] source completed (null enqueued)"
@@ -56,6 +57,10 @@ void UcxExchangeQueue::enqueueLocked(
   }
 
   auto dataSize = data->gpuDataSize();
+  if (reservedReceiveBytes > 0) {
+    VELOX_CHECK_GE(pendingReceiveBytes_, reservedReceiveBytes);
+    pendingReceiveBytes_ -= reservedReceiveBytes;
+  }
   totalBytes_ += dataSize;
   if (peakBytes_ < totalBytes_) {
     peakBytes_ = totalBytes_;
@@ -97,6 +102,49 @@ void UcxExchangeQueue::enqueueLocked(
     VLOG(2) << "[EX-QUEUE] waking " << wokenConsumers << " consumers"
             << " queueSize=" << queue_.size();
   }
+}
+
+bool UcxExchangeQueue::shouldPauseReceive(
+    int32_t highWaterMark,
+    int64_t maxInFlightBytes,
+    BackpressureStats* stats) const {
+  std::lock_guard<std::mutex> l(mutex_);
+  auto current = backpressureStatsLocked();
+  if (stats != nullptr) {
+    *stats = current;
+  }
+  return current.queueSize > highWaterMark ||
+      current.inFlightBytes > maxInFlightBytes;
+}
+
+bool UcxExchangeQueue::tryReserveReceive(
+    int64_t bytes,
+    int64_t maxInFlightBytes,
+    BackpressureStats* stats) {
+  VELOX_CHECK_GE(bytes, 0);
+  std::lock_guard<std::mutex> l(mutex_);
+  auto current = backpressureStatsLocked();
+  if (stats != nullptr) {
+    *stats = current;
+  }
+  if (maxInFlightBytes > 0 && current.inFlightBytes > 0 &&
+      current.inFlightBytes + bytes > maxInFlightBytes) {
+    return false;
+  }
+  pendingReceiveBytes_ += bytes;
+  if (stats != nullptr) {
+    *stats = backpressureStatsLocked();
+  }
+  return true;
+}
+
+void UcxExchangeQueue::releaseReservedReceive(int64_t bytes) {
+  if (bytes <= 0) {
+    return;
+  }
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_GE(pendingReceiveBytes_, bytes);
+  pendingReceiveBytes_ -= bytes;
 }
 
 void UcxExchangeQueue::addPromiseLocked(

--- a/velox/experimental/ucx-exchange/UcxExchangeQueue.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeQueue.h
@@ -47,6 +47,13 @@ using PackedTableWithStreamPtr = std::unique_ptr<PackedTableWithStream>;
 
 class UcxExchangeQueue {
  public:
+  struct BackpressureStats {
+    int32_t queueSize{0};
+    int64_t queuedBytes{0};
+    int64_t pendingReceiveBytes{0};
+    int64_t inFlightBytes{0};
+  };
+
   explicit UcxExchangeQueue(int32_t numberOfConsumers)
       : numberOfConsumers_{numberOfConsumers} {
     VELOX_CHECK_GE(numberOfConsumers, 1);
@@ -72,7 +79,8 @@ class UcxExchangeQueue {
   /// not completed serving data, no 'promises' will be added and returned.
   void enqueueLocked(
       PackedTableWithStreamPtr&& data,
-      std::vector<ContinuePromise>& promises);
+      std::vector<ContinuePromise>& promises,
+      int64_t reservedReceiveBytes = 0);
 
   /// If data is permanently not available, e.g. the source cannot be
   /// contacted, this registers an error message and causes the reading
@@ -107,8 +115,33 @@ class UcxExchangeQueue {
 
   /// Returns the total bytes held by packed tables in 'this'.
   int64_t totalBytes() const {
+    std::lock_guard<std::mutex> l(mutex_);
+    return totalBytesLocked();
+  }
+
+  int64_t totalBytesLocked() const {
     return totalBytes_;
   }
+
+  BackpressureStats backpressureStatsLocked() const {
+    return BackpressureStats{
+        sizeLocked(),
+        totalBytes_,
+        pendingReceiveBytes_,
+        totalBytes_ + pendingReceiveBytes_};
+  }
+
+  bool shouldPauseReceive(
+      int32_t highWaterMark,
+      int64_t maxInFlightBytes,
+      BackpressureStats* stats = nullptr) const;
+
+  bool tryReserveReceive(
+      int64_t bytes,
+      int64_t maxInFlightBytes,
+      BackpressureStats* stats = nullptr);
+
+  void releaseReservedReceive(int64_t bytes);
 
   /// Returns the maximum value of total bytes.
   uint64_t peakBytes() const {
@@ -138,6 +171,7 @@ class UcxExchangeQueue {
  private:
   std::vector<ContinuePromise> closeLocked() {
     queue_.clear();
+    totalBytes_ = 0;
     return clearAllPromisesLocked();
   }
 
@@ -198,6 +232,8 @@ class UcxExchangeQueue {
   std::string error_;
   // Total size of packed tables in queue.
   int64_t totalBytes_{0};
+  // Bytes reserved for posted UCX receives that have not been enqueued yet.
+  int64_t pendingReceiveBytes_{0};
   // Number of packed tables received.
   int64_t receivedTables_{0};
   // Total size of packed tables received. Used to calculate an average

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -16,7 +16,9 @@
 #include "velox/experimental/ucx-exchange/UcxExchangeServer.h"
 #include <glog/logging.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <cstdlib>
 #include <limits>
+#include <string>
 #include "cuda_runtime.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
@@ -24,6 +26,36 @@
 #include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"
 
 namespace facebook::velox::ucx_exchange {
+
+namespace {
+
+bool intraNodeProducerPollRequeueEnabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("GLUTEN_UCX_INTRANODE_PRODUCER_POLL_REQUEUE");
+    return value != nullptr && value[0] != '\0' &&
+        !(value[0] == '0' && value[1] == '\0');
+  }();
+  return enabled;
+}
+
+int64_t intraNodeProducerPollRequeueLimit() {
+  static const int64_t limit = [] {
+    const char* value =
+        std::getenv("GLUTEN_UCX_INTRANODE_PRODUCER_POLL_REQUEUE_LIMIT");
+    if (value == nullptr || value[0] == '\0') {
+      return int64_t{-1};
+    }
+    try {
+      return static_cast<int64_t>(std::stoll(value));
+    } catch (...) {
+      return int64_t{-1};
+    }
+  }();
+  return limit;
+}
+
+} // namespace
 
 // Context wrappers for UCXX tagSend callbackData. These decouple the
 // ucxx::Request lifetime (which must survive for UCP wireup replay) from
@@ -160,7 +192,9 @@ void UcxExchangeServer::process() {
       // do
       break;
     case ServerState::WaitingForIntraNodeRetrieve:
-      // Intra-node transfer: check if the source has retrieved the data
+      // Intra-node transfer: the registry re-enqueues us when the source has
+      // retrieved the data. Do a non-blocking check only for that wakeup (or a
+      // defensive spurious work item); do not self-requeue and spin.
       if (intraNodeRetrieveFuture_.valid()) {
         auto status =
             intraNodeRetrieveFuture_.wait_for(std::chrono::milliseconds(0));
@@ -168,8 +202,11 @@ void UcxExchangeServer::process() {
           intraNodeRetrieveFuture_.get(); // Clear the future
           intraNodePollCount_ = 0;
           onIntraNodeRetrieveComplete();
-        } else {
-          // Not ready yet, re-queue to check later
+        } else if (
+            intraNodeProducerPollRequeueEnabled() &&
+            (intraNodeProducerPollRequeueLimit() < 0 ||
+             intraNodePollCount_ <
+                 static_cast<uint32_t>(intraNodeProducerPollRequeueLimit()))) {
           ++intraNodePollCount_;
           if (intraNodePollCount_ % 100 == 0) {
             VLOG(2) << "[INTRA] [ExSrv " << partitionKey_.toString()
@@ -283,13 +320,20 @@ void UcxExchangeServer::sendData() {
       // dataPtr_ is already a shared_ptr, pass directly to share ownership.
       intraNodeRetrieveFuture_ =
           IntraNodeTransferRegistry::getInstance()->publish(
-              key, dataPtr_, stream, /*atEnd=*/false);
+              key,
+              dataPtr_,
+              stream,
+              /*atEnd=*/false,
+              makeIntraNodeRetrieveWakeup());
       dataPtr_.reset();
       intraNodeAtEndPublished_ = false;
 
-      // Transition to WaitingForIntraNodeRetrieve state
+      // Go dormant until the source retrieves the entry and the registry wakeup
+      // re-enqueues this server.
       setState(ServerState::WaitingForIntraNodeRetrieve);
-      communicator_->addToWorkQueue(getSelfPtr());
+      if (intraNodeProducerPollRequeueEnabled()) {
+        communicator_->addToWorkQueue(getSelfPtr());
+      }
     } else {
       // Data pointer is null, so no more data will be coming.
       // Publish atEnd marker to registry
@@ -301,14 +345,21 @@ void UcxExchangeServer::sendData() {
           partitionKey_.taskId, partitionKey_.destination, sequenceNumber_};
       intraNodeRetrieveFuture_ =
           IntraNodeTransferRegistry::getInstance()->publish(
-              key, nullptr, rmm::cuda_stream_default, /*atEnd=*/true);
+              key,
+              nullptr,
+              rmm::cuda_stream_default,
+              /*atEnd=*/true,
+              makeIntraNodeRetrieveWakeup());
       intraNodeAtEndPublished_ = true;
 
       queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
 
-      // Wait for source to acknowledge atEnd before finishing
+      // Wait for source to acknowledge atEnd before finishing. The registry
+      // wakeup re-enqueues this server when that happens.
       setState(ServerState::WaitingForIntraNodeRetrieve);
-      communicator_->addToWorkQueue(getSelfPtr());
+      if (intraNodeProducerPollRequeueEnabled()) {
+        communicator_->addToWorkQueue(getSelfPtr());
+      }
     }
   } else {
     // REMOTE EXCHANGE PATH: Use UCXX for metadata and data transfer
@@ -488,6 +539,16 @@ void UcxExchangeServer::sendComplete(
     setState(ServerState::Done);
   }
   communicator_->addToWorkQueue(getSelfPtr());
+}
+
+std::function<void()> UcxExchangeServer::makeIntraNodeRetrieveWakeup() {
+  std::weak_ptr<CommElement> weakSelf = getSelfPtr();
+  auto communicator = communicator_;
+  return [weakSelf, communicator]() {
+    if (auto server = weakSelf.lock()) {
+      communicator->addToWorkQueue(server);
+    }
+  };
 }
 
 void UcxExchangeServer::onIntraNodeRetrieveComplete() {

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.h
@@ -22,6 +22,7 @@
 #include <velox/exec/Task.h>
 #include <velox/experimental/ucx-exchange/UcxOutputQueueManager.h>
 #include <chrono>
+#include <functional>
 #include <future>
 #include <memory>
 #include <tuple>
@@ -93,6 +94,10 @@ class UcxExchangeServer
   /// @brief Completion handler for intra-node transfer after source retrieves
   /// data.
   void onIntraNodeRetrieveComplete();
+
+  /// Registers a one-shot wakeup for the server after a published intra-node
+  /// entry is retrieved by the source.
+  std::function<void()> makeIntraNodeRetrieveWakeup();
 
   /// @brief Sets the new state of this exchange server using
   /// sequential consistency. Logs transitions at VLOG(2).

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -142,19 +142,19 @@ void UcxExchangeSource::process() {
       // This creates natural backpressure: the server's tagSend for data
       // will block at rendezvous until we post a matching tagRecv. For
       // intra-node: the server's publish future won't resolve until we poll.
-      int32_t queueSize = queue_->size();
-      int64_t queueBytes = queue_->totalBytes();
+      UcxExchangeQueue::BackpressureStats stats;
       // Backpressure on BOTH item count and aggregate bytes. The byte cap is
       // what bounds the off-pool receive-buffer footprint that otherwise scales
       // O(#peers) and OOMs/deadlocks the GPU at 4 peers (the count cap alone
       // let a few large chunks fill the device before pausing).
-      if (queueSize > kBackpressureHighWaterMark ||
-          queueBytes > maxInFlightRecvBytes()) {
+      if (queue_->shouldPauseReceive(
+              kBackpressureHighWaterMark, maxInFlightRecvBytes(), &stats)) {
         if (!backpressureActive_.exchange(true, std::memory_order_acq_rel)) {
           VLOG(1) << "[BACKPRESSURE] [ExSrc " << toString()
-                  << "] pausing, queueSize=" << queueSize
+                  << "] pausing, queueSize=" << stats.queueSize
                   << " (high=" << kBackpressureHighWaterMark
-                  << "), queueBytes=" << queueBytes
+                  << "), queueBytes=" << stats.queuedBytes
+                  << ", pendingReceiveBytes=" << stats.pendingReceiveBytes
                   << " (cap=" << maxInFlightRecvBytes() << ")";
         }
         // Go dormant — do NOT re-enqueue into work queue.
@@ -180,6 +180,9 @@ void UcxExchangeSource::process() {
     case ReceiverState::WaitingForMetadata:
       // Waiting for metadata is handled by an upcall from UCXX. Nothing to do
       break;
+    case ReceiverState::WaitingForReceiveCredit:
+      tryStartDataReceive(pendingReceive_, ReceiverState::WaitingForReceiveCredit);
+      break;
     case ReceiverState::WaitingForData:
       // Waiting for data is handled by an upcall from UCXX. Nothing to do.
       break;
@@ -195,6 +198,9 @@ void UcxExchangeSource::process() {
 }
 
 void UcxExchangeSource::cleanUp() {
+  releaseReceiveReservation();
+  pendingReceive_.reset();
+
   uint32_t value = static_cast<uint32_t>(getState());
   if (value != static_cast<uint32_t>(ReceiverState::Done)) {
     // Unexpected cleanup
@@ -315,12 +321,14 @@ std::shared_ptr<UcxExchangeSource> UcxExchangeSource::getSelfPtr() {
   return ptr;
 }
 
-void UcxExchangeSource::enqueue(PackedTableWithStreamPtr data) {
+void UcxExchangeSource::enqueue(
+    PackedTableWithStreamPtr data,
+    int64_t reservedReceiveBytes) {
   std::vector<velox::ContinuePromise> queuePromises;
   {
     std::lock_guard<std::mutex> l(queue_->mutex());
 
-    queue_->enqueueLocked(std::move(data), queuePromises);
+    queue_->enqueueLocked(std::move(data), queuePromises, reservedReceiveBytes);
   }
   // wake up consumers of the UcxExchangeQueue
   for (auto& promise : queuePromises) {
@@ -342,6 +350,14 @@ void UcxExchangeSource::deliverEndMarker() {
   }
   VLOG(3) << toString() << " delivering end-of-stream marker to queue";
   enqueue(nullptr);
+}
+
+void UcxExchangeSource::releaseReceiveReservation() {
+  if (reservedReceiveBytes_ <= 0) {
+    return;
+  }
+  queue_->releaseReservedReceive(reservedReceiveBytes_);
+  reservedReceiveBytes_ = 0;
 }
 
 void UcxExchangeSource::setEndpoint(std::shared_ptr<EndpointRef> endpointRef) {
@@ -520,77 +536,99 @@ void UcxExchangeSource::onMetadata(
       return;
     }
 
-    // REMOTE EXCHANGE PATH: Allocate buffer and receive via UCXX
-    // Get a stream from the global stream pool
-    auto stream =
-        facebook::velox::cudf_velox::cudfGlobalStreamPool().get_stream();
-    // Store the stream in the DataAndMetadata struct so it can be used later
-    // in onData() when creating the PackedTableWithStream.
-    ptr->stream = stream;
-    // Receive buffers MUST come from a dedicated, synchronous, fresh-memory
-    // resource — NOT the shared RMM pool. UCX RDMA-writes this buffer from the
-    // progress thread, out of band of any CUDA stream. The two pool-based
-    // alternatives both fail:
-    //   * pool alloc + stream.synchronize() -> deadlocks the UCX progress
-    //   thread
-    //     (hang on heavy multi-fragment queries, e.g. Q18).
-    //   * pool alloc + no synchronize -> the pool may hand back a block still
-    //     in flight on another stream; UCX writing into it corrupts memory and
-    //     SIGSEGVs the process (observed crashing the driver at Q14).
-    // cuda_memory_resource (raw cudaMalloc) returns fresh, never-reused memory
-    // that is valid immediately, so no stream sync is needed and there is no
-    // reuse race. These buffers are short-lived (freed once consumed) and bound
-    // by the queue's count backpressure, so staying off the pool does not leak.
-    static rmm::mr::cuda_memory_resource recvMemoryResource;
-    try {
-      ptr->dataBuf = std::make_unique<rmm::device_buffer>(
-          ptr->metadata.dataSizeBytes, stream, &recvMemoryResource);
-    } catch (const rmm::bad_alloc& e) {
-      VLOG(0) << toString() << " *** RMM  failed to allocate: " << e.what();
-      queue_->setError("Failed to alloc GPU memory"); // Let the operator know
-                                                      // via the queue
-      deliverEndMarker();
-      setState(ReceiverState::Done);
-      communicator_->addToWorkQueue(getSelfPtr());
-      return;
-    }
-
-    VLOG(3) << toString() << " Allocated " << ptr->metadata.dataSizeBytes
-            << " bytes of device memory";
-
-    // Initiate the transfer of the actual data from GPU-2-GPU. This must be
-    // posted before any blocking CUDA synchronization in this callback:
-    // onMetadata() runs on the UCX progress thread, and a server-side
-    // rendezvous data send can timeout if the matching receive is delayed.
-    uint64_t dataTag = getDataTag(partitionKeyHash_, sequenceNumber_);
-    VLOG(3) << toString() << " waiting for data for chunk: " << sequenceNumber_
-            << " using tag: " << std::hex << dataTag << std::dec;
-
-    if (!setStateIf(
-            ReceiverState::WaitingForMetadata, ReceiverState::WaitingForData)) {
-      VLOG(1) << toString() << " onMetadata Invalid previous state ";
-      return;
-    }
-    // Use weak_ptr to prevent use-after-free if close() is called during
-    // callback
-    std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
-    if (request_) {
-      completedRequests_.push_back(std::move(request_));
-    }
-    request_ = endpointRef_->endpoint_->tagRecv(
-        ptr->dataBuf->data(),
-        ptr->metadata.dataSizeBytes,
-        ucxx::Tag{dataTag},
-        ucxx::TagMaskFull,
-        false,
-        [weak](ucs_status_t status, std::shared_ptr<void> arg) {
-          if (auto self = weak.lock()) {
-            self->onData(status, arg);
-          }
-        },
-        ptr // DataAndMetadata
-    );
+    pendingReceive_ = ptr;
+    tryStartDataReceive(pendingReceive_, ReceiverState::WaitingForMetadata);
   }
+}
+
+bool UcxExchangeSource::tryStartDataReceive(
+    const std::shared_ptr<DataAndMetadata>& ptr,
+    ReceiverState expectedState) {
+  if (ptr == nullptr) {
+    return false;
+  }
+
+  UcxExchangeQueue::BackpressureStats stats;
+  if (!queue_->tryReserveReceive(
+          ptr->metadata.dataSizeBytes, maxInFlightRecvBytes(), &stats)) {
+    if (!backpressureActive_.exchange(true, std::memory_order_acq_rel)) {
+      VLOG(1) << "[BACKPRESSURE] [ExSrc " << toString()
+              << "] waiting for receive credit, requestedBytes="
+              << ptr->metadata.dataSizeBytes
+              << ", queueBytes=" << stats.queuedBytes
+              << ", pendingReceiveBytes=" << stats.pendingReceiveBytes
+              << " (cap=" << maxInFlightRecvBytes() << ")";
+    }
+    if (getState() == expectedState) {
+      setStateIf(expectedState, ReceiverState::WaitingForReceiveCredit);
+    }
+    return false;
+  }
+  reservedReceiveBytes_ = ptr->metadata.dataSizeBytes;
+
+  // REMOTE EXCHANGE PATH: Allocate buffer and receive via UCXX.
+  auto stream =
+      facebook::velox::cudf_velox::cudfGlobalStreamPool().get_stream();
+  ptr->stream = stream;
+
+  // Receive buffers MUST come from a dedicated, synchronous, fresh-memory
+  // resource — NOT the shared RMM pool. UCX RDMA-writes this buffer from the
+  // progress thread, out of band of any CUDA stream. The two pool-based
+  // alternatives both fail:
+  //   * pool alloc + stream.synchronize() -> deadlocks the UCX progress thread
+  //     (hang on heavy multi-fragment queries, e.g. Q18).
+  //   * pool alloc + no synchronize -> the pool may hand back a block still in
+  //     flight on another stream; UCX writing into it corrupts memory and
+  //     SIGSEGVs the process (observed crashing the driver at Q14).
+  // cuda_memory_resource (raw cudaMalloc) returns fresh, never-reused memory
+  // that is valid immediately, so no stream sync is needed and there is no reuse
+  // race. These buffers are short-lived and bounded by queue receive credit.
+  static rmm::mr::cuda_memory_resource recvMemoryResource;
+  try {
+    ptr->dataBuf = std::make_unique<rmm::device_buffer>(
+        ptr->metadata.dataSizeBytes, stream, &recvMemoryResource);
+  } catch (const rmm::bad_alloc& e) {
+    releaseReceiveReservation();
+    VLOG(0) << toString() << " *** RMM failed to allocate "
+            << ptr->metadata.dataSizeBytes << " bytes: " << e.what();
+    queue_->setError("Failed to alloc GPU memory");
+    deliverEndMarker();
+    setState(ReceiverState::Done);
+    communicator_->addToWorkQueue(getSelfPtr());
+    return false;
+  }
+
+  VLOG(3) << toString() << " Allocated " << ptr->metadata.dataSizeBytes
+          << " bytes of device memory";
+
+  uint64_t dataTag = getDataTag(partitionKeyHash_, sequenceNumber_);
+  VLOG(3) << toString() << " waiting for data for chunk: " << sequenceNumber_
+          << " using tag: " << std::hex << dataTag << std::dec;
+
+  if (!setStateIf(expectedState, ReceiverState::WaitingForData)) {
+    releaseReceiveReservation();
+    VLOG(1) << toString() << " tryStartDataReceive Invalid previous state ";
+    return false;
+  }
+
+  std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
+  if (request_) {
+    completedRequests_.push_back(std::move(request_));
+  }
+  request_ = endpointRef_->endpoint_->tagRecv(
+      ptr->dataBuf->data(),
+      ptr->metadata.dataSizeBytes,
+      ucxx::Tag{dataTag},
+      ucxx::TagMaskFull,
+      false,
+      [weak](ucs_status_t status, std::shared_ptr<void> arg) {
+        if (auto self = weak.lock()) {
+          self->onData(status, arg);
+        }
+      },
+      ptr);
+  pendingReceive_.reset();
+  return true;
 }
 
 void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
@@ -599,6 +637,7 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
     VLOG(2) << "[UCX-SOURCE-DATA-AFTER-CLOSE] " << toString()
             << " seq=" << sequenceNumber_
             << " status=" << ucs_status_string(status);
+    releaseReceiveReservation();
     deliverEndMarker();
     return;
   }
@@ -620,6 +659,7 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
     VLOG(0) << "[UCX-SOURCE-DATA-ERROR] " << toString()
             << " seq=" << sequenceNumber_ << " state=" << getStateAsString()
             << " error=" << errorMsg;
+    releaseReceiveReservation();
     queue_->setError(errorMsg);
     deliverEndMarker();
     setState(ReceiverState::Done);
@@ -648,7 +688,9 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
     auto data = std::make_unique<PackedTableWithStream>(
         std::move(packedTable), ptr->stream);
 
-    enqueue(std::move(data));
+    const int64_t reservedReceiveBytes = reservedReceiveBytes_;
+    enqueue(std::move(data), reservedReceiveBytes);
+    reservedReceiveBytes_ = 0;
     setStateIf(ReceiverState::WaitingForData, ReceiverState::ReadyToReceive);
   }
   communicator_->addToWorkQueue(getSelfPtr());

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -142,6 +142,7 @@ class UcxExchangeSource
     WaitingForHandshakeResponse, // Waiting for server's HandshakeResponse
     ReadyToReceive,
     WaitingForMetadata,
+    WaitingForReceiveCredit,
     WaitingForData,
     WaitingForIntraNodeData, // Intra-node transfer: waiting on registry
     Done
@@ -178,7 +179,7 @@ class UcxExchangeSource
   std::shared_ptr<UcxExchangeSource> getSelfPtr();
 
   // Put the received data into the exchange queue.
-  void enqueue(PackedTableWithStreamPtr data);
+  void enqueue(PackedTableWithStreamPtr data, int64_t reservedReceiveBytes = 0);
 
   /// @brief Sets the endpoint for this receiver.
   void setEndpoint(std::shared_ptr<EndpointRef> endpointRef);
@@ -198,6 +199,12 @@ class UcxExchangeSource
   /// @param status indication by transport layer of transfer status
   /// @param arg the serialized form of the metadata
   void onMetadata(ucs_status_t status, std::shared_ptr<void> arg);
+
+  /// @brief Reserves receive credit and posts the data receive for a metadata
+  /// packet that has already arrived.
+  bool tryStartDataReceive(
+      const std::shared_ptr<DataAndMetadata>& ptr,
+      ReceiverState expectedState);
 
   /// @brief Called by the transport layer when data is available
   /// @param status indication by transport layer of transfer status
@@ -241,6 +248,7 @@ class UcxExchangeSource
         "WaitingForHandshakeResponse",
         "ReadyToReceive",
         "WaitingForMetadata",
+        "WaitingForReceiveCredit",
         "WaitingForData",
         "WaitingForIntraNodeData",
         "Done"};
@@ -261,6 +269,8 @@ class UcxExchangeSource
   /// Returns early without enqueuing if the source was never registered
   /// with the queue (i.e., registered_ is false).
   void deliverEndMarker();
+
+  void releaseReceiveReservation();
 
   /// @brief Sets the state to "desired" if and only if the current
   /// state is "expected".
@@ -309,6 +319,8 @@ class UcxExchangeSource
   // goes dormant. The consumer thread wakes it via resumeFromBackpressure()
   // when the queue drains to kBackpressureLowWaterMark.
   std::atomic<bool> backpressureActive_{false};
+  std::shared_ptr<DataAndMetadata> pendingReceive_;
+  int64_t reservedReceiveBytes_{0};
 
   // Some metrics/counters:
   UcxExchangeMetrics metrics_;

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Assisted by watsonx Code Assistant
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/io/types.hpp>
@@ -181,14 +180,11 @@ void UcxOutputQueueManager::getData(
 bool UcxOutputQueueManager::canUseIntraNode(const std::string& taskId) {
   auto queue = getQueueIfExists(taskId);
   if (!queue) {
-    return true;
+    return false;
   }
-  // Placeholder partitioned queues are safe for intra-node: the server waits
-  // until initializeTask() upgrades the queue and data arrives. Broadcast is
-  // also safe: a broadcast packed_columns is shared (use_count > 1) across
-  // destinations, and UcxExchangeSource::onIntraNodeData clones such shared
-  // pages (DtoD) instead of moving the device buffer out, so a consuming
-  // destination never corrupts the shared source for the others.
+  if (!queue->isInitialized()) {
+    return false;
+  }
   return true;
 }
 

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
@@ -108,10 +108,8 @@ class UcxOutputQueueManager {
       UcxDataAvailableCallbackV2 notify);
 
   /// Returns true if the given task can use intra-node transfer.
-  /// Returns false if the task is not yet initialized (placeholder queue
-  /// from early sink connections) or if the task uses broadcast mode
-  /// (broadcast shares packed_columns across destinations — the intra-node
-  /// source's destructive move would corrupt data for other servers).
+  /// Returns false until the task queue is initialized. Initialized broadcast
+  /// queues are safe because shared pages are cloned by UcxExchangeSource.
   bool canUseIntraNode(const std::string& taskId);
 
   std::string describeQueueForIntraNode(const std::string& taskId);


### PR DESCRIPTION
This PR cleans up the UCX intra-node exchange handoff and removes producer polling from the normal path.

  Summary:
  - Add retrieved callbacks to IntraNodeTransferRegistry.
  - Re-enqueue intra-node producers only when the source retrieves published data.
  - Add receive-credit/backpressure accounting for UCX exchange queues.
  - Keep initialized broadcast queues on the intra-node path; shared pages are cloned by the source when needed.
  - Remove stale diagnostic/cleanup helpers from the prior UCX debugging iteration.

  Validation:
  - velox_cudf_exec rebuilt and libgluten.so relinked.
  - Final libgluten.so no longer contains removed UCX diagnostic symbols.
  - Spark Gluten full22 4GPU run completed successfully with this Velox artifact.