### PR TITLE
Add cuDF collect_list and nested empty-column handling

### DIFF
--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -781,6 +781,45 @@ struct GroupbyCollectSetAggregator : GroupbyAggregator {
   uint32_t outputIdx_{0};
 };
 
+struct GroupbyCollectListAggregator : GroupbyAggregator {
+  GroupbyCollectListAggregator(
+      core::AggregationNode::Step step,
+      uint32_t inputIndex,
+      VectorPtr constant,
+      const TypePtr& resultType)
+      : GroupbyAggregator(step, inputIndex, constant, resultType) {}
+
+  void addGroupbyRequest(
+      cudf::table_view const& tbl,
+      std::vector<cudf::groupby::aggregation_request>& requests,
+      rmm::cuda_stream_view stream) override {
+    VELOX_CHECK(
+        constant == nullptr,
+        "GroupbyCollectListAggregator does not support constant input");
+    auto& request = requests.emplace_back();
+    outputIdx_ = requests.size() - 1;
+    request.values = tbl.column(inputIndex);
+    if (exec::isRawInput(step)) {
+      request.aggregations.push_back(
+          cudf::make_collect_list_aggregation<cudf::groupby_aggregation>(
+              cudf::null_policy::EXCLUDE));
+      return;
+    }
+    request.aggregations.push_back(
+        cudf::make_merge_lists_aggregation<cudf::groupby_aggregation>());
+  }
+
+  std::unique_ptr<cudf::column> makeOutputColumn(
+      std::vector<cudf::groupby::aggregation_result>& results,
+      rmm::cuda_stream_view /*stream*/,
+      rmm::device_async_resource_ref /*mr*/) override {
+    return std::move(results[outputIdx_].results[0]);
+  }
+
+ private:
+  uint32_t outputIdx_{0};
+};
+
 std::unique_ptr<GroupbyAggregator> createGroupbyAggregator(
     const ResolvedAggregateInfo& p) {
   auto const& kind = p.kind;
@@ -815,6 +854,9 @@ std::unique_ptr<GroupbyAggregator> createGroupbyAggregator(
   } else if (kind.rfind(prefix + "stddev", 0) == 0) {
     // stddev is an alias for stddev_samp
     return std::make_unique<GroupbyStddevSampAggregator>(
+        p.companionStep, p.inputIndex, p.constant, p.resultType);
+  } else if (kind.rfind(prefix + "collect_list", 0) == 0) {
+    return std::make_unique<GroupbyCollectListAggregator>(
         p.companionStep, p.inputIndex, p.constant, p.resultType);
   } else if (kind.rfind(prefix + "collect_set", 0) == 0) {
     return std::make_unique<GroupbyCollectSetAggregator>(

--- a/velox/experimental/cudf/exec/SparkAggregateFunctions.cpp
+++ b/velox/experimental/cudf/exec/SparkAggregateFunctions.cpp
@@ -79,32 +79,48 @@ void registerSparkAggregateFunctions(const std::string& prefix) {
           .build());
   // AVG final: row(DOUBLE,BIGINT)->DOUBLE already registered.
 
-  auto collectSetRawSignature = FunctionSignatureBuilder()
-                                    .typeVariable("T")
-                                    .returnType("array(T)")
-                                    .argumentType("T")
-                                    .build();
-  auto collectSetMergeSignature = FunctionSignatureBuilder()
-                                      .typeVariable("T")
-                                      .returnType("array(T)")
-                                      .argumentType("array(T)")
-                                      .build();
+  auto collectRawSignature = FunctionSignatureBuilder()
+                                 .typeVariable("T")
+                                 .returnType("array(T)")
+                                 .argumentType("T")
+                                 .build();
+  auto collectMergeSignature = FunctionSignatureBuilder()
+                                   .typeVariable("T")
+                                   .returnType("array(T)")
+                                   .argumentType("array(T)")
+                                   .build();
+  appendGroupbyAggregationFunctionForStep(
+      prefix + "collect_list",
+      core::AggregationNode::Step::kSingle,
+      collectRawSignature);
+  appendGroupbyAggregationFunctionForStep(
+      prefix + "collect_list",
+      core::AggregationNode::Step::kPartial,
+      collectRawSignature);
+  appendGroupbyAggregationFunctionForStep(
+      prefix + "collect_list",
+      core::AggregationNode::Step::kIntermediate,
+      collectMergeSignature);
+  appendGroupbyAggregationFunctionForStep(
+      prefix + "collect_list",
+      core::AggregationNode::Step::kFinal,
+      collectMergeSignature);
   appendGroupbyAggregationFunctionForStep(
       prefix + "collect_set",
       core::AggregationNode::Step::kSingle,
-      collectSetRawSignature);
+      collectRawSignature);
   appendGroupbyAggregationFunctionForStep(
       prefix + "collect_set",
       core::AggregationNode::Step::kPartial,
-      collectSetRawSignature);
+      collectRawSignature);
   appendGroupbyAggregationFunctionForStep(
       prefix + "collect_set",
       core::AggregationNode::Step::kIntermediate,
-      collectSetMergeSignature);
+      collectMergeSignature);
   appendGroupbyAggregationFunctionForStep(
       prefix + "collect_set",
       core::AggregationNode::Step::kFinal,
-      collectSetMergeSignature);
+      collectMergeSignature);
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -79,6 +79,70 @@ vector_size_t checkedVectorSize(size_t rowCount) {
       "cuDF vector row count exceeds Velox vector size limit");
   return static_cast<vector_size_t>(rowCount);
 }
+
+std::unique_ptr<cudf::column> makeZeroOffsetsColumn(
+    cudf::size_type rowCount,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  std::vector<cudf::size_type> offsets(rowCount + 1, 0);
+  rmm::device_buffer offsetsBuffer(
+      offsets.data(), offsets.size() * sizeof(cudf::size_type), stream, mr);
+  return std::make_unique<cudf::column>(
+      cudf::data_type{cudf::type_id::INT32},
+      static_cast<cudf::size_type>(offsets.size()),
+      std::move(offsetsBuffer),
+      rmm::device_buffer{},
+      0);
+}
+
+std::unique_ptr<cudf::column> makeEmptyColumnForType(
+    TypePtr const& type,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  switch (type->kind()) {
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+      return cudf::make_strings_column(
+          0,
+          makeZeroOffsetsColumn(0, stream, mr),
+          rmm::device_buffer{},
+          0,
+          rmm::device_buffer{});
+    case TypeKind::ARRAY:
+      return cudf::make_lists_column(
+          0,
+          makeZeroOffsetsColumn(0, stream, mr),
+          makeEmptyColumnForType(type->childAt(0), stream, mr),
+          0,
+          rmm::device_buffer{});
+    case TypeKind::MAP: {
+      std::vector<std::unique_ptr<cudf::column>> entryChildren;
+      entryChildren.push_back(
+          makeEmptyColumnForType(type->childAt(0), stream, mr));
+      entryChildren.push_back(
+          makeEmptyColumnForType(type->childAt(1), stream, mr));
+      auto entries = cudf::make_structs_column(
+          0, std::move(entryChildren), 0, rmm::device_buffer{}, stream, mr);
+      return cudf::make_lists_column(
+          0,
+          makeZeroOffsetsColumn(0, stream, mr),
+          std::move(entries),
+          0,
+          rmm::device_buffer{});
+    }
+    case TypeKind::ROW: {
+      std::vector<std::unique_ptr<cudf::column>> children;
+      children.reserve(type->size());
+      for (size_t i = 0; i < type->size(); ++i) {
+        children.push_back(makeEmptyColumnForType(type->childAt(i), stream, mr));
+      }
+      return cudf::make_structs_column(
+          0, std::move(children), 0, rmm::device_buffer{}, stream, mr);
+    }
+    default:
+      return cudf::make_empty_column(cudf_velox::veloxToCudfDataType(type));
+  }
+}
 } // namespace
 
 std::unique_ptr<cudf::table> concatenateTables(
@@ -101,25 +165,13 @@ std::unique_ptr<cudf::table> concatenateTables(
   return cudf::concatenate(tableViews, stream, mr);
 }
 
-std::unique_ptr<cudf::table> makeEmptyTable(TypePtr const& inputType) {
+std::unique_ptr<cudf::table> makeEmptyTable(
+    TypePtr const& inputType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
   std::vector<std::unique_ptr<cudf::column>> emptyColumns;
   for (size_t i = 0; i < inputType->size(); ++i) {
-    if (auto const& childType = inputType->childAt(i);
-        childType->kind() == TypeKind::ROW) {
-      auto tbl = makeEmptyTable(childType);
-      auto structColumn = std::make_unique<cudf::column>(
-          cudf::data_type(cudf::type_id::STRUCT),
-          0,
-          rmm::device_buffer(),
-          rmm::device_buffer(),
-          0,
-          tbl->release());
-      emptyColumns.push_back(std::move(structColumn));
-    } else {
-      auto emptyColumn = cudf::make_empty_column(
-          cudf_velox::veloxToCudfDataType(inputType->childAt(i)));
-      emptyColumns.push_back(std::move(emptyColumn));
-    }
+    emptyColumns.push_back(makeEmptyColumnForType(inputType->childAt(i), stream, mr));
   }
   return std::make_unique<cudf::table>(std::move(emptyColumns));
 }
@@ -131,7 +183,7 @@ std::unique_ptr<cudf::table> getConcatenatedTable(
     rmm::device_async_resource_ref mr) {
   // Check for empty vector
   if (tables.size() == 0) {
-    return makeEmptyTable(tableType);
+    return makeEmptyTable(tableType, stream, mr);
   }
 
   auto inputStreams = std::vector<rmm::cuda_stream_view>();
@@ -167,7 +219,7 @@ std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
   std::vector<std::unique_ptr<cudf::table>> concatTables;
   // Check for empty vector
   if (tables.size() == 0) {
-    concatTables.push_back(makeEmptyTable(tableType));
+    concatTables.push_back(makeEmptyTable(tableType, stream, mr));
     return concatTables;
   }
 
@@ -264,7 +316,7 @@ std::vector<CudfVectorPtr> getConcatenatedCudfVectorsBatched(
             pool,
             tableType,
             checkedVectorSize(chunkRows),
-            makeEmptyTable(tableType),
+            makeEmptyTable(tableType, stream, mr),
             stream));
     remainingRows -= chunkRows;
   } while (remainingRows > 0);

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -4069,7 +4069,23 @@ class HashFunction : public CudfFunction {
       std::vector<ColumnOrView>& inputColumns,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const override {
-    VELOX_CHECK(!inputColumns.empty());
+    return eval(
+        inputColumns,
+        inputColumns.empty() ? cudf::size_type{0}
+                             : asView(inputColumns[0]).size(),
+        stream,
+        mr);
+  }
+
+  ColumnOrView eval(
+      std::vector<ColumnOrView>& inputColumns,
+      cudf::size_type inputRowCount,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const override {
+    if (inputColumns.empty()) {
+      cudf::numeric_scalar<int32_t> seedScalar(seedValue_, true, stream, mr);
+      return cudf::make_column_from_scalar(seedScalar, inputRowCount, stream, mr);
+    }
     std::vector<cudf::column_view> columns;
     columns.reserve(inputColumns.size());
     for (auto& col : inputColumns) {
@@ -4099,7 +4115,24 @@ class XxHash64Function : public CudfFunction {
       std::vector<ColumnOrView>& inputColumns,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const override {
-    VELOX_CHECK(!inputColumns.empty());
+    return eval(
+        inputColumns,
+        inputColumns.empty() ? cudf::size_type{0}
+                             : asView(inputColumns[0]).size(),
+        stream,
+        mr);
+  }
+
+  ColumnOrView eval(
+      std::vector<ColumnOrView>& inputColumns,
+      cudf::size_type inputRowCount,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const override {
+    if (inputColumns.empty()) {
+      cudf::numeric_scalar<int64_t> seedScalar(
+          static_cast<int64_t>(seedValue_), true, stream, mr);
+      return cudf::make_column_from_scalar(seedScalar, inputRowCount, stream, mr);
+    }
     std::vector<cudf::column_view> columns;
     columns.reserve(inputColumns.size());
     for (auto& col : inputColumns) {

--- a/velox/experimental/cudf/expression/sparksql/HashFunction.cpp
+++ b/velox/experimental/cudf/expression/sparksql/HashFunction.cpp
@@ -18,7 +18,9 @@
 #include "velox/expression/ConstantExpr.h"
 #include "velox/vector/BaseVector.h"
 
+#include <cudf/column/column_factories.hpp>
 #include <cudf/hashing.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/table/table.hpp>
 
 namespace facebook::velox::cudf_velox::sparksql {
@@ -50,7 +52,22 @@ ColumnOrView HashFunction::eval(
     std::vector<ColumnOrView>& inputColumns,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const {
-  VELOX_CHECK(!inputColumns.empty());
+  return eval(
+      inputColumns,
+      inputColumns.empty() ? cudf::size_type{0} : asView(inputColumns[0]).size(),
+      stream,
+      mr);
+}
+
+ColumnOrView HashFunction::eval(
+    std::vector<ColumnOrView>& inputColumns,
+    cudf::size_type inputRowCount,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  if (inputColumns.empty()) {
+    cudf::numeric_scalar<int32_t> seedScalar(seedValue_, true, stream, mr);
+    return cudf::make_column_from_scalar(seedScalar, inputRowCount, stream, mr);
+  }
   auto inputTableView = convertToTableView(inputColumns);
   return cudf::hashing::murmurhash3_x86_32(
       inputTableView, seedValue_, stream, mr);

--- a/velox/experimental/cudf/expression/sparksql/HashFunction.h
+++ b/velox/experimental/cudf/expression/sparksql/HashFunction.h
@@ -30,6 +30,12 @@ class HashFunction : public CudfFunction {
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const override;
 
+  ColumnOrView eval(
+      std::vector<ColumnOrView>& inputColumns,
+      cudf::size_type inputRowCount,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const override;
+
  private:
   // Constant non-negative seed extracted from the first argument.
   uint32_t seedValue_;


### PR DESCRIPTION
  ## Summary
  - Add cuDF groupby support for Spark `collect_list`, including partial/final `COLLECT_LIST` and `MERGE_LISTS` paths.
  - Handle empty-input Spark hash expressions by returning seed-filled result columns.
  - Build empty cuDF columns for nested Velox types recursively, including arrays, maps, rows, strings, and binary types.

  ## Validation
  - Built `velox_cudf_exec` and related cuDF targets with the existing 2026-Q3 container build.
  - Rebuilt downstream native library against this Velox change.
  - Verified targeted MPP + cuDF strict workloads covering collect-list aggregation, nested/empty input handling, and hash expressions.