### PR TITLE
feat(cudf): Add bounded-memory cuDF execution and resilient UCX flow control

### DIFF
--- a/.github/scripts/gh-api-retry.sh
+++ b/.github/scripts/gh-api-retry.sh
@@ -44,8 +44,9 @@ gh_api() {
   while [ "$attempt" -le "$max_attempts" ]; do
     if gh api "$@"; then
       return 0
+    else
+      exit_code=$?
     fi
-    exit_code=$?
     if [ "$attempt" -lt "$max_attempts" ]; then
       local wait_secs=$((sleep_base ** attempt))
       echo "::warning::gh api attempt ${attempt}/${max_attempts} failed (exit ${exit_code}); retrying in ${wait_secs}s" >&2

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -62,7 +62,9 @@ jobs:
         id: changes
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
           BASE_REF: ${{ github.base_ref }}
+          BASE_OWNER: ${{ github.event.pull_request.base.repo.owner.login }}
           HEAD_REF: ${{ github.head_ref }}
           PR_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -72,7 +74,7 @@ jobs:
           if [[ "$JOB_TRIGGER" == "pull_request" ]]; then
             source .github/scripts/gh-api-retry.sh
             merge_base_commit=$(gh_api -q '.merge_base_commit.sha' \
-              /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_OWNER:$HEAD_REF \
+              /repos/$REPOSITORY/compare/$BASE_OWNER:$BASE_REF...$PR_OWNER:$HEAD_REF \
             )
 
             range="$merge_base_commit..$HEAD_SHA"

--- a/CMake/Finducx.cmake
+++ b/CMake/Finducx.cmake
@@ -19,10 +19,7 @@ find_library(UCX_UCT_LIBRARY NAMES uct libuct)
 find_library(UCX_UCM_LIBRARY NAMES ucm libucm)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(
-  ucx
-  REQUIRED_VARS UCX_INCLUDE_DIR UCX_UCP_LIBRARY UCX_UCS_LIBRARY
-)
+find_package_handle_standard_args(ucx REQUIRED_VARS UCX_INCLUDE_DIR UCX_UCP_LIBRARY UCX_UCS_LIBRARY)
 
 if(ucx_FOUND)
   foreach(component UCP UCS UCT UCM)

--- a/velox/common/CMakeLists.txt
+++ b/velox/common/CMakeLists.txt
@@ -38,6 +38,9 @@ velox_add_library(velox_enum_declare INTERFACE HEADERS EnumDeclare.h)
 
 velox_add_library(velox_enum_define INTERFACE HEADERS EnumDefine.h)
 
+velox_add_library(velox_enums INTERFACE HEADERS Enums.h)
+velox_link_libraries(velox_enums INTERFACE velox_enum_declare velox_enum_define)
+
 velox_add_library(velox_casts INTERFACE HEADERS Casts.h)
 
 velox_add_library(velox_scoped_registry INTERFACE HEADERS ScopedRegistry.h)

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
@@ -23,6 +23,7 @@
 
 #include <aws/core/Aws.h>
 #include <aws/s3/S3Client.h>
+#include <aws/s3/model/AbortMultipartUploadRequest.h>
 #include <aws/s3/model/CompleteMultipartUploadRequest.h>
 #include <aws/s3/model/CompletedMultipartUpload.h>
 #include <aws/s3/model/CompletedPart.h>
@@ -190,6 +191,24 @@ class S3WriteFile::Impl {
     currentPart_->clear();
   }
 
+  void abort() {
+    if (closed()) {
+      return;
+    }
+    if (!uploadState_.id.empty()) {
+      Aws::S3::Model::AbortMultipartUploadRequest request;
+      request.SetBucket(awsString(bucket_));
+      request.SetKey(awsString(key_));
+      request.SetUploadId(uploadState_.id);
+      auto outcome = client_->AbortMultipartUpload(request);
+      currentPart_->clear();
+      VELOX_CHECK_AWS_OUTCOME(
+          outcome, "Failed to abort multiple part upload", bucket_, key_);
+      return;
+    }
+    currentPart_->clear();
+  }
+
   // Current file size, i.e. the sum of all previous appends.
   uint64_t size() const {
     return fileSize_;
@@ -294,6 +313,10 @@ void S3WriteFile::flush() {
 
 void S3WriteFile::close() {
   impl_->close();
+}
+
+void S3WriteFile::abort() {
+  impl_->abort();
 }
 
 uint64_t S3WriteFile::size() const {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
@@ -68,6 +68,9 @@ class S3WriteFile : public WriteFile {
   /// Close the file. Any cleanup (disk flush, etc.) will be done here.
   void close() override;
 
+  /// Discard buffered data and cancel an in-progress multipart upload.
+  void abort();
+
   /// Current file size, i.e. the sum of all previous Appends.
   uint64_t size() const override;
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -321,6 +321,31 @@ TEST_F(S3FileSystemTest, writeFileAndRead) {
   ASSERT_TRUE(s3fs.exists(s3File));
 }
 
+TEST_F(S3FileSystemTest, abortWrite) {
+  const auto bucketName = "abortwrite";
+  addBucket(bucketName);
+  auto hiveConfig = minioServer_->hiveConfig();
+  filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
+  auto pool = memory::memoryManager()->addLeafPool("S3AbortWriteTest");
+
+  for (const auto& [file, size] :
+       std::vector<std::pair<std::string, size_t>>{
+           {"small.parquet", 1024}, {"multipart.parquet", 11 << 20}}) {
+    const auto s3File = s3URI(bucketName, file);
+    auto writeFile =
+        s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
+    auto* s3WriteFile =
+        dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
+    ASSERT_NE(s3WriteFile, nullptr);
+    std::string data(size, 'x');
+    writeFile->append(data);
+    s3WriteFile->abort();
+
+    ASSERT_FALSE(s3fs.exists(s3File));
+    VELOX_ASSERT_THROW(writeFile->append("x"), "File is closed");
+  }
+}
+
 TEST_F(S3FileSystemTest, invalidConnectionSettings) {
   auto hiveConfig =
       minioServer_->hiveConfig({{"hive.s3.connect-timeout", "400"}});

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -54,6 +54,8 @@ struct CudfConfig {
   static constexpr const char* kCudfFunctionEngine{"cudf.function_engine"};
   /// Query session configs for the cuDF Operators.
   static constexpr const char* kCudfTopNBatchSize{"cudf.topk_batch_size"};
+  static constexpr const char* kCudfSkipOutputToVelox{
+      "velox.cudf.skip_output_to_velox"};
 
   static constexpr const char* kUcxExchange{"cudf.exchange"};
   static constexpr const char* kUcxxErrorHandling{"ucxx.error_handling"};

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConfig.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConfig.cpp
@@ -51,6 +51,13 @@ std::size_t CudfHiveConfig::maxPassReadLimitSession(
       config_->get<std::size_t>(kMaxPassReadLimit, 0));
 }
 
+bool CudfHiveConfig::parquetFilterPushdownEnabledSession(
+    const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kParquetFilterPushdownEnabledSession,
+      config_->get<bool>(kParquetFilterPushdownEnabled, true));
+}
+
 bool CudfHiveConfig::isConvertStringsToCategories() const {
   return config_->get<bool>(kConvertStringsToCategories, false);
 }

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConfig.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConfig.h
@@ -44,6 +44,14 @@ class CudfHiveConfig {
   static constexpr const char* kMaxPassReadLimitSession =
       "parquet.reader.pass_read_limit";
 
+  // Whether simple filters are passed into libcudf's Parquet statistics
+  // reader.  Disabling this keeps the same filter in the post-scan cuDF
+  // expression path; it does not enable a CPU fallback.
+  static constexpr const char* kParquetFilterPushdownEnabled =
+      "parquet.reader.filter-pushdown-enabled";
+  static constexpr const char* kParquetFilterPushdownEnabledSession =
+      "parquet.reader.filter_pushdown_enabled";
+
   // Whether to store string data as categorical type
   static constexpr const char* kConvertStringsToCategories =
       "parquet.reader.convert-strings-to-categories";
@@ -134,6 +142,9 @@ class CudfHiveConfig {
 
   std::size_t maxPassReadLimit() const;
   std::size_t maxPassReadLimitSession(const config::ConfigBase* session) const;
+
+  bool parquetFilterPushdownEnabledSession(
+      const config::ConfigBase* session) const;
 
   bool isConvertStringsToCategories() const;
   bool isConvertStringsToCategoriesSession(

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -152,7 +152,15 @@ CudfHiveDataSource::CudfHiveDataSource(
   // remaining filter path to avoid invalid AST operators on MAP/ARRAY/ROW.
   common::SubfieldFilters readerSubfieldFilters;
   bool skippedReaderFilter = false;
-  if (!subfieldFilters_.empty()) {
+  const bool parquetFilterPushdownEnabled =
+      cudfHiveConfig_->parquetFilterPushdownEnabledSession(
+          connectorQueryCtx_->sessionProperties());
+  if (!parquetFilterPushdownEnabled && !subfieldFilters_.empty()) {
+    // libcudf 26.08 can crash in stats_expression_converter when many MPP scan
+    // fragments initialize Parquet statistics filters concurrently.  Keep the
+    // original predicate for the post-scan cuDF evaluator in this mode.
+    skippedReaderFilter = true;
+  } else if (!subfieldFilters_.empty()) {
     for (const auto& [field, filter] : subfieldFilters_) {
       if (field.path().size() != 1) {
         skippedReaderFilter = true;
@@ -294,6 +302,7 @@ void CudfHiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 std::optional<RowVectorPtr> CudfHiveDataSource::next(
     uint64_t size,
     velox::ContinueFuture& /* future */) {
+  CudaAllocationTraceScope allocationTrace("CudfHiveDataSource::next");
   VELOX_CHECK_NOT_NULL(split_, "No split present. Call addSplit() first.");
   VELOX_CHECK_NOT_NULL(cudfSplitReader_, "No split to process.");
   auto chunkOpt = cudfSplitReader_->next(size);

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -59,6 +59,12 @@ bool isSupportedCudfReaderFilterType(const TypePtr& type) {
   }
 }
 
+bool isStringLikeType(const TypePtr& type) {
+  return type != nullptr &&
+      (type->kind() == TypeKind::VARCHAR ||
+       type->kind() == TypeKind::VARBINARY);
+}
+
 TypePtr topLevelSubfieldType(
     const hive::HiveTableHandle& tableHandle,
     const RowTypePtr& outputType,
@@ -173,6 +179,13 @@ CudfHiveDataSource::CudfHiveDataSource(
       if (!isSupportedCudfReaderFilterType(type)) {
         skippedReaderFilter = true;
         VLOG(1) << "Skipping complex cuDF reader filter pushdown for subfield: "
+                << field.toString();
+        continue;
+      }
+
+      if (isStringLikeType(type)) {
+        skippedReaderFilter = true;
+        VLOG(1) << "Keeping string cuDF reader filter post-scan for subfield: "
                 << field.toString();
         continue;
       }

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
@@ -29,52 +29,6 @@ namespace velox_connector = ::facebook::velox::connector;
 namespace velox_hive = ::facebook::velox::connector::hive;
 namespace velox_iceberg = ::facebook::velox::connector::hive::iceberg;
 
-namespace {
-
-std::string cleanPathForCudf(std::string path) {
-  constexpr std::string_view kFilePrefix = "file:";
-  constexpr std::string_view kS3APrefix = "s3a:";
-  if (path.compare(0, kFilePrefix.size(), kFilePrefix) == 0) {
-    path = path.substr(kFilePrefix.size());
-  } else if (path.compare(0, kS3APrefix.size(), kS3APrefix) == 0) {
-    // KvikIO does not support the "s3a:" prefix.
-    path.erase(kS3APrefix.size() - 2, 1);
-  }
-  return path;
-}
-
-std::vector<velox_iceberg::IcebergDeleteFile> copyDeleteFiles(
-    const std::vector<velox_iceberg::IcebergDeleteFile>& deleteFiles) {
-  std::vector<velox_iceberg::IcebergDeleteFile> copy;
-  copy.reserve(deleteFiles.size());
-  for (const auto& deleteFile : deleteFiles) {
-    copy.emplace_back(deleteFile);
-  }
-  return copy;
-}
-
-std::optional<uint64_t> getFileSize(
-    const velox_iceberg::HiveIcebergSplit& split,
-    FileHandleFactory* fileHandleFactory,
-    const velox_connector::ConnectorQueryCtx* connectorQueryCtx,
-    IoStats* ioStats) {
-  if (split.properties && split.properties->fileSize.has_value()) {
-    return static_cast<uint64_t>(*split.properties->fileSize);
-  }
-
-  const auto fileHandleKey = FileHandleKey{
-      .filename = cleanPathForCudf(split.filePath),
-      .tokenProvider = connectorQueryCtx->fsTokenProvider()};
-  auto fileProperties = FileProperties{};
-  auto fileHandleCachePtr =
-      fileHandleFactory->generate(fileHandleKey, &fileProperties, ioStats);
-  VELOX_CHECK_NOT_NULL(fileHandleCachePtr.get());
-  VELOX_CHECK_NOT_NULL(fileHandleCachePtr->file.get());
-  return fileHandleCachePtr->file->size();
-}
-
-} // namespace
-
 CudfIcebergDataSource::CudfIcebergDataSource(
     const RowTypePtr& outputType,
     const velox_connector::ConnectorTableHandlePtr& tableHandle,
@@ -100,44 +54,16 @@ void CudfIcebergDataSource::convertSplit(
   icebergSplit_ =
       checkedPointerCast<const velox_iceberg::HiveIcebergSplit>(split);
 
+  // CudfSplitReader passes start/length to parquet_reader_options as a byte
+  // range. cuDF then selects the row groups whose starting offsets belong to
+  // that range, matching Spark's row-group-aligned Iceberg splits while
+  // keeping each decoded GPU batch bounded. Positional/equality delete state
+  // still assumes a whole-file base row offset, so reject that uncommon
+  // combination until per-split delete offsets are implemented.
   if (icebergSplit_->start != 0) {
-    const auto fileSize = getFileSize(
-        *icebergSplit_,
-        fileHandleFactory_,
-        connectorQueryCtx_,
-        ioStats_ ? ioStats_.get() : nullptr);
-    const auto splitEnd =
-        icebergSplit_->length == std::numeric_limits<uint64_t>::max()
-        ? *fileSize
-        : icebergSplit_->start + icebergSplit_->length;
-    const auto isWholeParquetSplit = icebergSplit_->fileFormat ==
-            dwio::common::FileFormat::PARQUET &&
-        icebergSplit_->start == 4 && splitEnd == *fileSize;
     VELOX_CHECK(
-        isWholeParquetSplit,
-        "Sub-splits are not yet supported in CudfIcebergDataSource. "
-        "Split start: {}, length: {}, file size: {}",
-        icebergSplit_->start,
-        icebergSplit_->length,
-        *fileSize);
-
-    auto normalizedSplit = std::make_shared<velox_iceberg::HiveIcebergSplit>(
-        icebergSplit_->connectorId,
-        icebergSplit_->filePath,
-        icebergSplit_->fileFormat,
-        0,
-        *fileSize,
-        icebergSplit_->partitionKeys,
-        icebergSplit_->tableBucketNumber,
-        icebergSplit_->customSplitInfo,
-        icebergSplit_->extraFileInfo,
-        icebergSplit_->cacheable,
-        copyDeleteFiles(icebergSplit_->deleteFiles),
-        icebergSplit_->infoColumns,
-        icebergSplit_->properties,
-        icebergSplit_->dataSequenceNumber);
-    icebergSplit_ = normalizedSplit;
-    split = normalizedSplit;
+        icebergSplit_->deleteFiles.empty(),
+        "Iceberg byte-range splits with delete files are not yet supported");
   }
 
   // Convert `ConnectorSplit` to `CudfHiveConnectorSplit`

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -121,7 +121,8 @@ CudfIcebergSplitReader::CudfIcebergSplitReader(
     const auto& readName = i < outputReadColumnNames_.size()
         ? outputReadColumnNames_[i]
         : outputType_->nameOf(i);
-    auto it = std::find(readColumnNames_.begin(), readColumnNames_.end(), readName);
+    auto it =
+        std::find(readColumnNames_.begin(), readColumnNames_.end(), readName);
     if (it == readColumnNames_.end()) {
       continue;
     }
@@ -526,8 +527,9 @@ void CudfIcebergSplitReader::adaptColumns() {
   std::unordered_set<std::string> injectedNames;
   for (size_t i = 0; i < outputType_->size(); ++i) {
     const auto& fieldName = outputType_->nameOf(i);
-    const auto& readName =
-        i < outputReadColumnNames_.size() ? outputReadColumnNames_[i] : fieldName;
+    const auto& readName = i < outputReadColumnNames_.size()
+        ? outputReadColumnNames_[i]
+        : fieldName;
 
     if (auto iter = split_->infoColumns.find(readName);
         iter != split_->infoColumns.end()) {
@@ -566,8 +568,9 @@ void CudfIcebergSplitReader::adaptColumns() {
 
     for (size_t i = 0; i < outputType_->size(); ++i) {
       const auto& fieldName = outputType_->nameOf(i);
-      const auto& readName =
-          i < outputReadColumnNames_.size() ? outputReadColumnNames_[i] : fieldName;
+      const auto& readName = i < outputReadColumnNames_.size()
+          ? outputReadColumnNames_[i]
+          : fieldName;
       if (injectedNames.contains(readName)) {
         continue;
       }

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -108,7 +108,35 @@ CudfIcebergSplitReader::CudfIcebergSplitReader(
           subfieldFilterExpr),
       icebergSplit_(std::move(icebergSplit)),
       hiveConfig_(hiveConfig),
-      outputReadColumnNames_(outputReadColumnNames) {}
+      outputReadColumnNames_(outputReadColumnNames) {
+  // Selecting only a top-level struct name makes libcudf return every child
+  // in the Parquet file's physical order. Iceberg/Spark may prune and reorder
+  // that ROW in the requested output schema, so positional dereference would
+  // read the wrong child. Request the exact nested leaf paths instead; libcudf
+  // retains the parent struct while pruning its children in selector order.
+  for (size_t i = 0; i < outputType_->size(); ++i) {
+    if (outputType_->childAt(i)->kind() != TypeKind::ROW) {
+      continue;
+    }
+    const auto& readName = i < outputReadColumnNames_.size()
+        ? outputReadColumnNames_[i]
+        : outputType_->nameOf(i);
+    auto it = std::find(readColumnNames_.begin(), readColumnNames_.end(), readName);
+    if (it == readColumnNames_.end()) {
+      continue;
+    }
+    const auto insertAt = std::distance(readColumnNames_.begin(), it);
+    readColumnNames_.erase(it);
+    const auto rowType = asRowType(outputType_->childAt(i));
+    std::vector<std::string> nested;
+    nested.reserve(rowType->size());
+    for (size_t child = 0; child < rowType->size(); ++child) {
+      nested.push_back(fmt::format("{}.{}", readName, rowType->nameOf(child)));
+    }
+    readColumnNames_.insert(
+        readColumnNames_.begin() + insertAt, nested.begin(), nested.end());
+  }
+}
 
 void CudfIcebergSplitReader::prepareSplit(
     dwio::common::RuntimeStatistics& runtimeStats) {

--- a/velox/experimental/cudf/exec/CudfAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfAggregation.cpp
@@ -461,10 +461,6 @@ bool canAggregationBeEvaluatedByRegistry(
     return true;
   }
 
-  if (hasOnlyConstantArguments(call)) {
-    return false;
-  }
-
   // Validate against step-specific signatures from registry.
   return matchTypedCallAgainstSignatures(call, stepIt->second);
 }
@@ -483,6 +479,21 @@ bool canBeEvaluatedByCudf(
 
   bool isGlobal = aggregationNode.groupingKeys().empty();
   bool isDistinct = !isGlobal && aggregationNode.aggregates().empty();
+
+  // Grouped aggregation materializes constant inputs on the GPU.  Global reduce operators still
+  // consume a real input channel, so keep non-count constant reductions on the CPU path until
+  // their adapter gains the same materialization support.
+  if (
+      isGlobal &&
+      std::any_of(
+          aggregationNode.aggregates().begin(),
+          aggregationNode.aggregates().end(),
+          [](const auto& aggregate) {
+            return !isCountFunctionName(aggregate.call->name()) &&
+                hasOnlyConstantArguments(*aggregate.call);
+          })) {
+    return false;
+  }
 
   if (isDistinct) {
     return canGroupingKeysBeEvaluatedByCudf(

--- a/velox/experimental/cudf/exec/CudfAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfAggregation.cpp
@@ -164,9 +164,8 @@ core::TypedExprPtr normalizeProjectInputReferences(
   const auto& names = projectNode->names();
   reverseMapping.reserve(names.size());
   for (size_t i = 0; i < names.size(); ++i) {
-    auto field =
-        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
-            projections[i]);
+    auto field = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+        projections[i]);
     if (field && field->inputs().empty()) {
       reverseMapping.emplace(
           field->name(),
@@ -480,11 +479,11 @@ bool canBeEvaluatedByCudf(
   bool isGlobal = aggregationNode.groupingKeys().empty();
   bool isDistinct = !isGlobal && aggregationNode.aggregates().empty();
 
-  // Grouped aggregation materializes constant inputs on the GPU.  Global reduce operators still
-  // consume a real input channel, so keep non-count constant reductions on the CPU path until
-  // their adapter gains the same materialization support.
-  if (
-      isGlobal &&
+  // Grouped aggregation materializes constant inputs on the GPU.  Global reduce
+  // operators still consume a real input channel, so keep non-count constant
+  // reductions on the CPU path until their adapter gains the same
+  // materialization support.
+  if (isGlobal &&
       std::any_of(
           aggregationNode.aggregates().begin(),
           aggregationNode.aggregates().end(),

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -23,6 +23,7 @@
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/expression/AstUtils.h"
 
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregateFunctionRegistry.h"
@@ -65,12 +66,16 @@ using cudf_velox::validateIntermediateColumnType;
         cudf::table_view const& tbl,                                     \
         std::vector<cudf::groupby::aggregation_request>& requests,       \
         rmm::cuda_stream_view stream) override {                         \
-      VELOX_CHECK(                                                       \
-          constant == nullptr,                                           \
-          #Name "Aggregator does not yet support constant input");       \
       auto& request = requests.emplace_back();                           \
       output_idx = requests.size() - 1;                                  \
-      request.values = tbl.column(inputIndex);                           \
+      if (constant != nullptr) {                                         \
+        auto scalar = cudf_velox::makeScalarFromConstantVector(constant); \
+        constant_input = cudf::make_column_from_scalar(                  \
+            *scalar, tbl.num_rows(), stream, get_temp_mr());             \
+        request.values = constant_input->view();                         \
+      } else {                                                           \
+        request.values = tbl.column(inputIndex);                         \
+      }                                                                  \
       request.aggregations.push_back(                                    \
           cudf::make_##name##_aggregation<cudf::groupby_aggregation>()); \
     }                                                                    \
@@ -89,6 +94,7 @@ using cudf_velox::validateIntermediateColumnType;
                                                                          \
    private:                                                              \
     uint32_t output_idx;                                                 \
+    std::unique_ptr<cudf::column> constant_input;                        \
   };
 
 DEFINE_SIMPLE_GROUPBY_AGGREGATOR(Sum, sum, SUM)
@@ -832,9 +838,18 @@ std::vector<std::unique_ptr<GroupbyAggregator>> toGroupbyAggregators(
     core::AggregationNode const& aggregationNode,
     core::AggregationNode::Step step,
     TypePtr const& outputType,
-    std::vector<VectorPtr> const& constants) {
+    std::vector<VectorPtr> const& constants,
+    std::optional<core::AggregationNode::Step> forcedStep) {
   auto params =
       resolveAggregateInfos(aggregationNode, step, outputType, constants);
+
+  if (forcedStep.has_value()) {
+    const auto numKeys = aggregationNode.groupingKeys().size();
+    for (size_t i = 0; i < params.size(); ++i) {
+      params[i].companionStep = *forcedStep;
+      params[i].resultType = outputType->childAt(numKeys + i);
+    }
+  }
 
   std::vector<std::unique_ptr<GroupbyAggregator>> aggregators;
   aggregators.reserve(params.size());
@@ -923,6 +938,7 @@ CudfGroupby::CudfGroupby(
           std::nullopt,
           aggregationNode),
       aggregationNode_(aggregationNode),
+      diagnosticNodeId_(aggregationNode->id()),
       isPartialOutput_(
           exec::isPartialOutput(aggregationNode->step()) &&
           !hasFinalAggs(aggregationNode->aggregates())),
@@ -958,7 +974,22 @@ void CudfGroupby::initialize() {
       aggregationNode_->step(),
       outputType_,
       aggregationInput.constants);
-  streamingEnabled_ = !hasCompanionAggregates(aggregationNode_->aggregates());
+  // The old blanket companion-aggregate guard forced every input batch into
+  // inputs_ until noMoreInput(). Large MPP final aggregates consequently
+  // retained several GiB of materialized exchange pages per
+  // executor. Companion suffixes describe the external Spark plan step; for
+  // streaming compaction we explicitly force the internal intermediate step
+  // below, so these aggregates can be compacted incrementally as well.
+  streamingEnabled_ = true;
+
+  if (deviceMemoryDiagnosticsEnabled()) {
+    for (const auto& aggregate : aggregationNode_->aggregates()) {
+      LOG(WARNING) << "CUDF_GROUPBY_AGGREGATE node=" << diagnosticNodeId_
+                   << " planStep="
+                   << core::AggregationNode::toName(aggregationNode_->step())
+                   << " function=" << aggregate.call->name();
+    }
+  }
 
   // Make aggregators for intermediate step when streaming is enabled.
   if (streamingEnabled_) {
@@ -974,19 +1005,22 @@ void CudfGroupby::initialize() {
         *aggregationNode_,
         core::AggregationNode::Step::kIntermediate,
         bufferedResultType_,
-        nullConstants);
+        nullConstants,
+        core::AggregationNode::Step::kIntermediate);
 
     if (isSingleStep_) {
       partialAggregators_ = toGroupbyAggregators(
           *aggregationNode_,
           core::AggregationNode::Step::kPartial,
           bufferedResultType_,
-          aggregationInput.constants);
+          aggregationInput.constants,
+          core::AggregationNode::Step::kPartial);
       finalAggregators_ = toGroupbyAggregators(
           *aggregationNode_,
           core::AggregationNode::Step::kFinal,
           outputType_,
-          nullConstants);
+          nullConstants,
+          core::AggregationNode::Step::kFinal);
     }
   }
 
@@ -1285,6 +1319,12 @@ RowVectorPtr CudfGroupby::doGetOutput() {
     }
     auto& aggs = isSingleStep_ ? finalAggregators_ : aggregators_;
     auto stream = bufferedResult_->stream();
+    logDeviceMemorySnapshot(fmt::format(
+        "operator=CudfGroupby node={} state=finalize.begin bufferedRows={} "
+        "bufferedBytes={}",
+        diagnosticNodeId_,
+        bufferedResult_->size(),
+        bufferedResult_->estimateFlatSize()));
     auto result = doGroupByAggregation(
         bufferedResult_->getTableView(),
         groupingKeyOutputChannels_,
@@ -1293,6 +1333,12 @@ RowVectorPtr CudfGroupby::doGetOutput() {
         stream,
         get_output_mr());
     stream.synchronize();
+    logDeviceMemorySnapshot(fmt::format(
+        "operator=CudfGroupby node={} state=finalize.end outputRows={} "
+        "bufferedBytes={}",
+        diagnosticNodeId_,
+        result == nullptr ? 0 : result->size(),
+        bufferedResult_->estimateFlatSize()));
     bufferedResult_.reset();
     return result;
   }

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -53,48 +53,48 @@ using cudf_velox::ResolvedAggregateInfo;
 using cudf_velox::serializeDecimalPartialOrIntermediateState;
 using cudf_velox::validateIntermediateColumnType;
 
-#define DEFINE_SIMPLE_GROUPBY_AGGREGATOR(Name, name, KIND)               \
-  struct Groupby##Name##Aggregator : GroupbyAggregator {                 \
-    Groupby##Name##Aggregator(                                           \
-        core::AggregationNode::Step step,                                \
-        uint32_t inputIndex,                                             \
-        VectorPtr constant,                                              \
-        const TypePtr& resultType)                                       \
-        : GroupbyAggregator(step, inputIndex, constant, resultType) {}   \
-                                                                         \
-    void addGroupbyRequest(                                              \
-        cudf::table_view const& tbl,                                     \
-        std::vector<cudf::groupby::aggregation_request>& requests,       \
-        rmm::cuda_stream_view stream) override {                         \
-      auto& request = requests.emplace_back();                           \
-      output_idx = requests.size() - 1;                                  \
-      if (constant != nullptr) {                                         \
+#define DEFINE_SIMPLE_GROUPBY_AGGREGATOR(Name, name, KIND)                \
+  struct Groupby##Name##Aggregator : GroupbyAggregator {                  \
+    Groupby##Name##Aggregator(                                            \
+        core::AggregationNode::Step step,                                 \
+        uint32_t inputIndex,                                              \
+        VectorPtr constant,                                               \
+        const TypePtr& resultType)                                        \
+        : GroupbyAggregator(step, inputIndex, constant, resultType) {}    \
+                                                                          \
+    void addGroupbyRequest(                                               \
+        cudf::table_view const& tbl,                                      \
+        std::vector<cudf::groupby::aggregation_request>& requests,        \
+        rmm::cuda_stream_view stream) override {                          \
+      auto& request = requests.emplace_back();                            \
+      output_idx = requests.size() - 1;                                   \
+      if (constant != nullptr) {                                          \
         auto scalar = cudf_velox::makeScalarFromConstantVector(constant); \
-        constant_input = cudf::make_column_from_scalar(                  \
-            *scalar, tbl.num_rows(), stream, get_temp_mr());             \
-        request.values = constant_input->view();                         \
-      } else {                                                           \
-        request.values = tbl.column(inputIndex);                         \
-      }                                                                  \
-      request.aggregations.push_back(                                    \
-          cudf::make_##name##_aggregation<cudf::groupby_aggregation>()); \
-    }                                                                    \
-                                                                         \
-    std::unique_ptr<cudf::column> makeOutputColumn(                      \
-        std::vector<cudf::groupby::aggregation_result>& results,         \
-        rmm::cuda_stream_view stream,                                    \
-        rmm::device_async_resource_ref mr) override {                    \
-      auto col = std::move(results[output_idx].results[0]);              \
-      const auto cudfType = cudf_velox::veloxToCudfDataType(resultType); \
-      if (col->type() != cudfType) {                                     \
-        col = cudf::cast(*col, cudfType, stream, mr);                    \
-      }                                                                  \
-      return col;                                                        \
-    }                                                                    \
-                                                                         \
-   private:                                                              \
-    uint32_t output_idx;                                                 \
-    std::unique_ptr<cudf::column> constant_input;                        \
+        constant_input = cudf::make_column_from_scalar(                   \
+            *scalar, tbl.num_rows(), stream, get_temp_mr());              \
+        request.values = constant_input->view();                          \
+      } else {                                                            \
+        request.values = tbl.column(inputIndex);                          \
+      }                                                                   \
+      request.aggregations.push_back(                                     \
+          cudf::make_##name##_aggregation<cudf::groupby_aggregation>());  \
+    }                                                                     \
+                                                                          \
+    std::unique_ptr<cudf::column> makeOutputColumn(                       \
+        std::vector<cudf::groupby::aggregation_result>& results,          \
+        rmm::cuda_stream_view stream,                                     \
+        rmm::device_async_resource_ref mr) override {                     \
+      auto col = std::move(results[output_idx].results[0]);               \
+      const auto cudfType = cudf_velox::veloxToCudfDataType(resultType);  \
+      if (col->type() != cudfType) {                                      \
+        col = cudf::cast(*col, cudfType, stream, mr);                     \
+      }                                                                   \
+      return col;                                                         \
+    }                                                                     \
+                                                                          \
+   private:                                                               \
+    uint32_t output_idx;                                                  \
+    std::unique_ptr<cudf::column> constant_input;                         \
   };
 
 DEFINE_SIMPLE_GROUPBY_AGGREGATOR(Sum, sum, SUM)
@@ -1064,8 +1064,8 @@ void CudfGroupby::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
   if (bufferedResult_) {
     auto partialOutputStream = bufferedResult_->stream();
     std::vector<CudfVectorPtr> tablesToConcat;
-    tablesToConcat.push_back(bufferedResult_);
-    tablesToConcat.push_back(groupbyOnInput);
+    tablesToConcat.push_back(std::exchange(bufferedResult_, nullptr));
+    tablesToConcat.push_back(std::move(groupbyOnInput));
     auto concatenatedTable = getConcatenatedTable(
         std::move(tablesToConcat),
         bufferedResultType_,
@@ -1115,18 +1115,56 @@ void CudfGroupby::computeFinalGroupbyStreaming(CudfVectorPtr tbl) {
     return;
   }
 
+  auto previousResult = std::exchange(bufferedResult_, nullptr);
   std::vector<cudf::table_view> tablesToConcat;
-  tablesToConcat.push_back(bufferedResult_->getTableView());
+  tablesToConcat.push_back(previousResult->getTableView());
   tablesToConcat.push_back(permutedInputView);
 
-  auto finalStream = bufferedResult_->stream();
-  cudf::detail::join_streams(
-      std::vector<rmm::cuda_stream_view>{inputTableStream}, finalStream);
+  auto finalStream = previousResult->stream();
+  std::vector<CudfVectorPtr> inputOwners;
+  inputOwners.push_back(std::move(previousResult));
+  inputOwners.push_back(std::move(tbl));
+  std::vector<rmm::cuda_stream_view> inputStreams{
+      finalStream, inputTableStream};
+  cudf::detail::join_streams(inputStreams, finalStream);
 
-  auto concatenatedTable =
-      cudf::concatenate(tablesToConcat, finalStream, get_temp_mr());
-  cudf::detail::join_streams(
-      std::vector<rmm::cuda_stream_view>{finalStream}, inputTableStream);
+  std::unique_ptr<cudf::table> concatenatedTable;
+  try {
+    concatenatedTable =
+        cudf::concatenate(tablesToConcat, finalStream, get_temp_mr());
+
+    // The concatenation has consumed both views. Rebind their allocations to
+    // finalStream (or order their original streams after it for packed inputs)
+    // and drop the owners now. This queues stream-ordered frees before the
+    // intermediate groupby allocates its output and workspace. Keeping these
+    // shared_ptrs until the function returns overlaps the previous buffered
+    // result and incoming batch with both the concatenated table and the next
+    // groupby output, which creates a large transient peak for high-cardinality
+    // FINAL aggregations.
+    orderCudfVectorDeallocationsAfterStream(
+        inputOwners, inputStreams, finalStream);
+    inputOwners.clear();
+
+    // Materialized precomputed columns are owned separately by preparedInput
+    // and still deallocate on inputTableStream. Keep that stream ordered after
+    // the concatenate only when such an owner exists; views need no reverse
+    // fence and preserving their input-stream concurrency avoids a regression.
+    const auto hasOwnedPrecomputed = std::any_of(
+        preparedInput.precomputedColumns.begin(),
+        preparedInput.precomputedColumns.end(),
+        [](const auto& column) {
+          return std::holds_alternative<std::unique_ptr<cudf::column>>(column);
+        });
+    if (hasOwnedPrecomputed) {
+      cudf::detail::join_streams(
+          std::vector<rmm::cuda_stream_view>{finalStream}, inputTableStream);
+    }
+  } catch (...) {
+    // concatenate can enqueue work before a later column allocation fails.
+    // Complete it before input owners unwind on their original streams.
+    finalStream.synchronize();
+    throw;
+  }
   auto compactedOutput = doGroupByAggregation(
       concatenatedTable->view(),
       groupingKeyOutputChannels_,
@@ -1158,8 +1196,8 @@ void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
   if (bufferedResult_) {
     auto partialOutputStream = bufferedResult_->stream();
     std::vector<CudfVectorPtr> tablesToConcat;
-    tablesToConcat.push_back(bufferedResult_);
-    tablesToConcat.push_back(groupbyOnInput);
+    tablesToConcat.push_back(std::exchange(bufferedResult_, nullptr));
+    tablesToConcat.push_back(std::move(groupbyOnInput));
     auto concatenatedTable = getConcatenatedTable(
         std::move(tablesToConcat),
         bufferedResultType_,
@@ -1187,16 +1225,17 @@ void CudfGroupby::doAddInput(RowVectorPtr input) {
 
   auto cudfInput = std::dynamic_pointer_cast<cudf_velox::CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput);
+  input.reset();
 
   if (streamingEnabled_) {
     if (isPartialOutput_) {
-      computePartialGroupbyStreaming(cudfInput);
+      computePartialGroupbyStreaming(std::move(cudfInput));
       return;
     } else if (isSingleStep_) {
-      computeSingleGroupbyStreaming(cudfInput);
+      computeSingleGroupbyStreaming(std::move(cudfInput));
       return;
     } else {
-      computeFinalGroupbyStreaming(cudfInput);
+      computeFinalGroupbyStreaming(std::move(cudfInput));
       return;
     }
   }
@@ -1319,12 +1358,13 @@ RowVectorPtr CudfGroupby::doGetOutput() {
     }
     auto& aggs = isSingleStep_ ? finalAggregators_ : aggregators_;
     auto stream = bufferedResult_->stream();
-    logDeviceMemorySnapshot(fmt::format(
-        "operator=CudfGroupby node={} state=finalize.begin bufferedRows={} "
-        "bufferedBytes={}",
-        diagnosticNodeId_,
-        bufferedResult_->size(),
-        bufferedResult_->estimateFlatSize()));
+    logDeviceMemorySnapshot(
+        fmt::format(
+            "operator=CudfGroupby node={} state=finalize.begin bufferedRows={} "
+            "bufferedBytes={}",
+            diagnosticNodeId_,
+            bufferedResult_->size(),
+            bufferedResult_->estimateFlatSize()));
     auto result = doGroupByAggregation(
         bufferedResult_->getTableView(),
         groupingKeyOutputChannels_,
@@ -1333,12 +1373,13 @@ RowVectorPtr CudfGroupby::doGetOutput() {
         stream,
         get_output_mr());
     stream.synchronize();
-    logDeviceMemorySnapshot(fmt::format(
-        "operator=CudfGroupby node={} state=finalize.end outputRows={} "
-        "bufferedBytes={}",
-        diagnosticNodeId_,
-        result == nullptr ? 0 : result->size(),
-        bufferedResult_->estimateFlatSize()));
+    logDeviceMemorySnapshot(
+        fmt::format(
+            "operator=CudfGroupby node={} state=finalize.end outputRows={} "
+            "bufferedBytes={}",
+            diagnosticNodeId_,
+            result == nullptr ? 0 : result->size(),
+            bufferedResult_->estimateFlatSize()));
     bufferedResult_.reset();
     return result;
   }

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -57,7 +57,8 @@ std::vector<std::unique_ptr<GroupbyAggregator>> toGroupbyAggregators(
     core::AggregationNode const& aggregationNode,
     core::AggregationNode::Step step,
     TypePtr const& outputType,
-    std::vector<VectorPtr> const& constants);
+    std::vector<VectorPtr> const& constants,
+    std::optional<core::AggregationNode::Step> forcedStep = std::nullopt);
 
 // Groupby-specific validation
 bool canGroupbyBeEvaluatedByCudf(
@@ -117,6 +118,7 @@ class CudfGroupby : public CudfOperatorBase {
   std::vector<CudfExpressionPtr> precomputedInputEvaluators_;
 
   std::shared_ptr<const core::AggregationNode> aggregationNode_;
+  const core::PlanNodeId diagnosticNodeId_;
   std::vector<std::unique_ptr<GroupbyAggregator>> aggregators_;
   std::vector<std::unique_ptr<GroupbyAggregator>> intermediateAggregators_;
   // Used for kSingle streaming: partial-step aggregators (raw -> intermediate)
@@ -126,7 +128,8 @@ class CudfGroupby : public CudfOperatorBase {
 
   const bool isPartialOutput_;
   const bool isSingleStep_;
-  // Streaming aggregation is disabled if companion aggregates are present.
+  // Companion aggregate names encode the Spark plan step. Internal streaming
+  // compaction overrides that suffix with the intermediate step.
   bool streamingEnabled_{true};
   const int64_t maxPartialAggregationMemoryUsage_;
   int64_t numInputRows_ = 0;

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -1910,9 +1910,9 @@ CudfHashJoinProbe::rightSemiFilterJoin(
       extendedLeftView =
           createExtendedTableView(leftTableView, leftPrecomputed);
     }
-    cudf::table_view extendedRightView =
-        (!rightPrecomputeInstructions_.empty()) ? cachedExtendedRightViews_[0]
-                                                : rightTableView;
+    cudf::table_view extendedRightView = (!rightPrecomputeInstructions_.empty())
+        ? cachedExtendedRightViews_[0]
+        : rightTableView;
     rightJoinIndices = cudf::mixed_left_semi_join(
         rightTableView.select(rightKeyIndices_),
         leftTableView.select(leftKeyIndices_),

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -171,8 +171,11 @@ void CudfLocalPartition::enqueuePartition(
   }
 
   ContinueFuture future;
-  auto blockingReason =
-      queues_[partitionIndex]->enqueue(cudfVector, cudfVector->size(), &future);
+  // LocalExchangeMemoryManager accounts bytes, not rows.  Passing size()
+  // under-counts a GPU batch by orders of magnitude and effectively disables
+  // the existing local-exchange backpressure.
+  auto blockingReason = queues_[partitionIndex]->enqueue(
+      cudfVector, cudfVector->estimateFlatSize(), &future);
   if (blockingReason != exec::BlockingReason::kNotBlocked) {
     blockingReasons_.push_back(blockingReason);
     futures_.push_back(std::move(future));
@@ -256,8 +259,11 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
   } else {
     // Single partition case.
     ContinueFuture future;
+    // CudfVector's retainedSize() does not represent the device table payload.
+    // Use the same flat-byte estimate reported by operator statistics so the
+    // LocalExchangeMemoryManager's byte high-water mark can engage.
     auto blockingReason =
-        queues_[0]->enqueue(input, input->retainedSize(), &future);
+        queues_[0]->enqueue(input, input->estimateFlatSize(), &future);
     if (blockingReason != exec::BlockingReason::kNotBlocked) {
       blockingReasons_.push_back(blockingReason);
       futures_.push_back(std::move(future));

--- a/velox/experimental/cudf/exec/CudfOperator.h
+++ b/velox/experimental/cudf/exec/CudfOperator.h
@@ -164,10 +164,7 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
       checkCudaErrorInDebug();
       if (sample) {
         logDeviceMemory(
-            "getOutput",
-            "after",
-            -1,
-            result == nullptr ? 0 : result->size());
+            "getOutput", "after", -1, result == nullptr ? 0 : result->size());
       }
       return result;
     } catch (...) {
@@ -245,17 +242,18 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
     if (!deviceMemoryDiagnosticsEnabled()) {
       return;
     }
-    logDeviceMemorySnapshot(fmt::format(
-        "operator={} node={} operatorId={} method={} phase={} inputRows={} "
-        "outputRows={} call={}",
-        className_,
-        planNodeId_,
-        operatorId_,
-        method,
-        phase,
-        inputRows,
-        outputRows,
-        deviceMemoryCallCount_));
+    logDeviceMemorySnapshot(
+        fmt::format(
+            "operator={} node={} operatorId={} method={} phase={} inputRows={} "
+            "outputRows={} call={}",
+            className_,
+            planNodeId_,
+            operatorId_,
+            method,
+            phase,
+            inputRows,
+            outputRows,
+            deviceMemoryCallCount_));
   }
 
   const std::string className_;

--- a/velox/experimental/cudf/exec/CudfOperator.h
+++ b/velox/experimental/cudf/exec/CudfOperator.h
@@ -17,6 +17,7 @@
 
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/DebugUtil.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 
 #include "velox/common/base/SpillConfig.h"
@@ -123,35 +124,94 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
             spillConfig),
         NvtxHelper(color, operatorId, fmt::format("[{}]", planNodeId)),
         className_(operatorName),
+        planNodeId_(planNodeId),
+        operatorId_(operatorId),
         nvtxMethods_(nvtxMethods) {}
 
   void addInput(RowVectorPtr input) final {
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kAddInput, className_);
-    doAddInput(std::move(input));
-    checkCudaErrorInDebug();
+    CudaAllocationTraceScope allocationTrace(
+        fmt::format("{} node={} method=addInput", className_, planNodeId_));
+    const auto inputRows = input == nullptr ? 0 : input->size();
+    const auto sample = shouldSampleDeviceMemory(false);
+    if (sample) {
+      logDeviceMemory("addInput", "before", inputRows, -1);
+    }
+    try {
+      doAddInput(std::move(input));
+      checkCudaErrorInDebug();
+      if (sample) {
+        logDeviceMemory("addInput", "after", inputRows, -1);
+      }
+    } catch (...) {
+      logDeviceMemory("addInput", "error", inputRows, -1);
+      throw;
+    }
   }
 
   RowVectorPtr getOutput() final {
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kGetOutput, className_);
-    auto result = doGetOutput();
-    checkCudaErrorInDebug();
-    return result;
+    CudaAllocationTraceScope allocationTrace(
+        fmt::format("{} node={} method=getOutput", className_, planNodeId_));
+    const auto sample = shouldSampleDeviceMemory(false);
+    if (sample) {
+      logDeviceMemory("getOutput", "before", -1, -1);
+    }
+    try {
+      auto result = doGetOutput();
+      checkCudaErrorInDebug();
+      if (sample) {
+        logDeviceMemory(
+            "getOutput",
+            "after",
+            -1,
+            result == nullptr ? 0 : result->size());
+      }
+      return result;
+    } catch (...) {
+      logDeviceMemory("getOutput", "error", -1, -1);
+      throw;
+    }
   }
 
   void noMoreInput() final {
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kNoMoreInput, className_);
-    doNoMoreInput();
-    checkCudaErrorInDebug();
+    const auto sample = shouldSampleDeviceMemory(true);
+    if (sample) {
+      logDeviceMemory("noMoreInput", "before", -1, -1);
+    }
+    try {
+      doNoMoreInput();
+      checkCudaErrorInDebug();
+      if (sample) {
+        logDeviceMemory("noMoreInput", "after", -1, -1);
+      }
+    } catch (...) {
+      logDeviceMemory("noMoreInput", "error", -1, -1);
+      throw;
+    }
   }
 
   void close() final {
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kClose, className_);
-    doClose();
-    checkCudaErrorInDebug();
+    const auto sample = shouldSampleDeviceMemory(true);
+    if (sample) {
+      logDeviceMemory("close", "before", -1, -1);
+    }
+    try {
+      doClose();
+      checkCudaErrorInDebug();
+      if (sample) {
+        logDeviceMemory("close", "after", -1, -1);
+      }
+    } catch (...) {
+      logDeviceMemory("close", "error", -1, -1);
+      throw;
+    }
   }
 
  protected:
@@ -168,8 +228,41 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
   }
 
  private:
+  bool shouldSampleDeviceMemory(bool force) {
+    if (!deviceMemoryDiagnosticsEnabled()) {
+      return false;
+    }
+    ++deviceMemoryCallCount_;
+    return force || deviceMemoryCallCount_ == 1 ||
+        deviceMemoryCallCount_ % 64 == 0;
+  }
+
+  void logDeviceMemory(
+      const char* method,
+      const char* phase,
+      int64_t inputRows,
+      int64_t outputRows) const {
+    if (!deviceMemoryDiagnosticsEnabled()) {
+      return;
+    }
+    logDeviceMemorySnapshot(fmt::format(
+        "operator={} node={} operatorId={} method={} phase={} inputRows={} "
+        "outputRows={} call={}",
+        className_,
+        planNodeId_,
+        operatorId_,
+        method,
+        phase,
+        inputRows,
+        outputRows,
+        deviceMemoryCallCount_));
+  }
+
   const std::string className_;
+  const core::PlanNodeId planNodeId_;
+  const int32_t operatorId_;
   const NvtxMethodFlag nvtxMethods_;
+  uint64_t deviceMemoryCallCount_{0};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -20,17 +20,18 @@
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
-#include <cudf/sorting.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/merge.hpp>
 #include <cudf/search.hpp>
+#include <cudf/sorting.hpp>
+
+#include <malloc.h>
+#include <unistd.h>
 
 #include <atomic>
 #include <filesystem>
-#include <malloc.h>
-#include <unistd.h>
 
 namespace facebook::velox::cudf_velox {
 namespace {
@@ -163,8 +164,7 @@ RowVectorPtr CudfOrderBy::doGetOutput() {
       return nullptr;
     }
     return std::make_shared<CudfVector>(
-        pool(), outputType_, result->num_rows(), std::move(result),
-        stream);
+        pool(), outputType_, result->num_rows(), std::move(result), stream);
   }
   finished_ = true;
   return std::exchange(outputTable_, nullptr);
@@ -177,12 +177,11 @@ void CudfOrderBy::spillSortedRun() {
   namespace fs = std::filesystem;
   if (!spilled_) {
     const auto sequence = orderBySpillDirectorySequence.fetch_add(1);
-    spillDirectory_ = (
-        fs::temp_directory_path() /
-        fmt::format(
-            "velox-cudf-orderby-spill-{}-{}",
-            static_cast<int64_t>(::getpid()),
-            sequence))
+    spillDirectory_ = (fs::temp_directory_path() /
+                       fmt::format(
+                           "velox-cudf-orderby-spill-{}-{}",
+                           static_cast<int64_t>(::getpid()),
+                           sequence))
                           .string();
     fs::create_directories(spillDirectory_);
     spilled_ = true;
@@ -194,8 +193,12 @@ void CudfOrderBy::spillSortedRun() {
       getConcatenatedTable(std::exchange(inputs_, {}), outputType_, stream, mr);
   bufferedBytes_ = 0;
   auto sorted = cudf::sort_by_key(
-      input->view(), input->view().select(sortKeys_), columnOrder_, nullOrder_,
-      stream, mr);
+      input->view(),
+      input->view().select(sortKeys_),
+      columnOrder_,
+      nullOrder_,
+      stream,
+      mr);
   auto path = fmt::format(
       "{}/run-{:06}.parquet", spillDirectory_, spillFileSequence_++);
   auto options = cudf::io::parquet_writer_options::builder(
@@ -269,14 +272,21 @@ std::unique_ptr<cudf::table> CudfOrderBy::mergeNextSortedBatch(
     auto sortedBoundaries = cudf::sort_by_key(
         boundaryCandidates->view(),
         boundaryCandidates->view().select(sortKeys_),
-        columnOrder_, nullOrder_, stream, mr);
+        columnOrder_,
+        nullOrder_,
+        stream,
+        mr);
     auto boundary = cudf::slice(sortedBoundaries->view(), {0, 1}, stream);
     auto positions = cudf::upper_bound(
-        merged->view().select(sortKeys_), boundary.front().select(sortKeys_),
-        columnOrder_, nullOrder_, stream, mr);
+        merged->view().select(sortKeys_),
+        boundary.front().select(sortKeys_),
+        columnOrder_,
+        nullOrder_,
+        stream,
+        mr);
     const auto safeEnd = firstSearchPosition(positions->view(), stream);
-    mergeCarry_ = copyTableSlice(
-        merged->view(), safeEnd, merged->num_rows(), stream, mr);
+    mergeCarry_ =
+        copyTableSlice(merged->view(), safeEnd, merged->num_rows(), stream, mr);
     if (safeEnd > 0) {
       return copyTableSlice(merged->view(), 0, safeEnd, stream, mr);
     }

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -37,7 +37,7 @@ namespace facebook::velox::cudf_velox {
 namespace {
 
 constexpr uint64_t kSortedRunBytes = 3ULL << 30;
-constexpr uint64_t kMergeChunkBytes = 256ULL << 20;
+constexpr uint64_t kMergeChunkBytes = 32ULL << 20;
 std::atomic<uint64_t> orderBySpillDirectorySequence{0};
 
 std::unique_ptr<cudf::table> copyTableSlice(

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -21,8 +21,52 @@
 #include "velox/experimental/cudf/exec/Utilities.h"
 
 #include <cudf/sorting.hpp>
+#include <cudf/concatenate.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/io/parquet.hpp>
+#include <cudf/merge.hpp>
+#include <cudf/search.hpp>
+
+#include <atomic>
+#include <filesystem>
+#include <malloc.h>
+#include <unistd.h>
 
 namespace facebook::velox::cudf_velox {
+namespace {
+
+constexpr uint64_t kSortedRunBytes = 3ULL << 30;
+constexpr uint64_t kMergeChunkBytes = 256ULL << 20;
+std::atomic<uint64_t> orderBySpillDirectorySequence{0};
+
+std::unique_ptr<cudf::table> copyTableSlice(
+    cudf::table_view input,
+    cudf::size_type begin,
+    cudf::size_type end,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_LE(begin, end);
+  auto slices = cudf::slice(input, {begin, end}, stream);
+  VELOX_CHECK_EQ(slices.size(), 1);
+  return std::make_unique<cudf::table>(slices.front(), stream, mr);
+}
+
+cudf::size_type firstSearchPosition(
+    cudf::column_view positions,
+    rmm::cuda_stream_view stream) {
+  VELOX_CHECK_EQ(positions.size(), 1);
+  cudf::size_type result{0};
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      &result,
+      positions.data<cudf::size_type>(),
+      sizeof(result),
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+  stream.synchronize();
+  return result;
+}
+
+} // namespace
 
 CudfOrderBy::CudfOrderBy(
     int32_t operatorId,
@@ -65,14 +109,27 @@ void CudfOrderBy::doAddInput(RowVectorPtr input) {
   if (input->size() > 0) {
     auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
     VELOX_CHECK_NOT_NULL(cudfInput);
+    bufferedBytes_ += cudfInput->estimateFlatSize();
     inputs_.push_back(std::move(cudfInput));
+    if (bufferedBytes_ >= kSortedRunBytes) {
+      spillSortedRun();
+    }
   }
 }
 
 void CudfOrderBy::doNoMoreInput() {
   Operator::noMoreInput();
 
+  if (spilled_ && !inputs_.empty()) {
+    spillSortedRun();
+  }
+  if (spilled_) {
+    initializeSortedRunReaders();
+    return;
+  }
+
   if (inputs_.empty()) {
+    finished_ = true;
     return;
   }
 
@@ -80,6 +137,7 @@ void CudfOrderBy::doNoMoreInput() {
   // Using the output memory resource to allow spilling to CPU memory.
   auto tbl = getConcatenatedTable(
       std::exchange(inputs_, {}), outputType_, stream, get_output_mr());
+  bufferedBytes_ = 0;
 
   VELOX_CHECK_NOT_NULL(tbl);
 
@@ -96,8 +154,146 @@ RowVectorPtr CudfOrderBy::doGetOutput() {
   if (finished_ || !noMoreInput_) {
     return nullptr;
   }
+  if (spilled_) {
+    auto stream = cudfGlobalStreamPool().get_stream();
+    auto result = mergeNextSortedBatch(stream, get_output_mr());
+    if (!result || result->num_rows() == 0) {
+      finished_ = true;
+      cleanupSpillFiles();
+      return nullptr;
+    }
+    return std::make_shared<CudfVector>(
+        pool(), outputType_, result->num_rows(), std::move(result),
+        stream);
+  }
   finished_ = true;
-  return outputTable_;
+  return std::exchange(outputTable_, nullptr);
+}
+
+void CudfOrderBy::spillSortedRun() {
+  if (inputs_.empty()) {
+    return;
+  }
+  namespace fs = std::filesystem;
+  if (!spilled_) {
+    const auto sequence = orderBySpillDirectorySequence.fetch_add(1);
+    spillDirectory_ = (
+        fs::temp_directory_path() /
+        fmt::format(
+            "velox-cudf-orderby-spill-{}-{}",
+            static_cast<int64_t>(::getpid()),
+            sequence))
+                          .string();
+    fs::create_directories(spillDirectory_);
+    spilled_ = true;
+  }
+
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+  auto input =
+      getConcatenatedTable(std::exchange(inputs_, {}), outputType_, stream, mr);
+  bufferedBytes_ = 0;
+  auto sorted = cudf::sort_by_key(
+      input->view(), input->view().select(sortKeys_), columnOrder_, nullOrder_,
+      stream, mr);
+  auto path = fmt::format(
+      "{}/run-{:06}.parquet", spillDirectory_, spillFileSequence_++);
+  auto options = cudf::io::parquet_writer_options::builder(
+                     cudf::io::sink_info{path}, sorted->view())
+                     .build();
+  cudf::io::write_parquet(options, stream);
+  sortedRuns_.push_back({std::move(path), nullptr});
+  ::malloc_trim(0);
+}
+
+void CudfOrderBy::initializeSortedRunReaders() {
+  if (readersInitialized_) {
+    return;
+  }
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+  for (auto& run : sortedRuns_) {
+    auto options = cudf::io::parquet_reader_options::builder(
+                       cudf::io::source_info{run.path})
+                       .build();
+    run.reader = std::make_unique<cudf::io::chunked_parquet_reader>(
+        kMergeChunkBytes, 0, options, stream, mr);
+  }
+  readersInitialized_ = true;
+}
+
+std::unique_ptr<cudf::table> CudfOrderBy::mergeNextSortedBatch(
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  while (!mergeFinished_) {
+    std::vector<std::unique_ptr<cudf::table>> chunks;
+    std::vector<cudf::table_view> mergeViews;
+    std::vector<cudf::table_view> boundaryRows;
+    if (mergeCarry_ && mergeCarry_->num_rows() > 0) {
+      mergeViews.push_back(mergeCarry_->view());
+    }
+    for (auto& run : sortedRuns_) {
+      if (!run.reader || !run.reader->has_next()) {
+        continue;
+      }
+      auto chunk = run.reader->read_chunk();
+      if (chunk.tbl->num_rows() == 0) {
+        continue;
+      }
+      chunks.push_back(std::move(chunk.tbl));
+      mergeViews.push_back(chunks.back()->view());
+      if (run.reader->has_next()) {
+        auto last = cudf::slice(
+            chunks.back()->view(),
+            {chunks.back()->num_rows() - 1, chunks.back()->num_rows()},
+            stream);
+        boundaryRows.push_back(last.front());
+      }
+    }
+    if (mergeViews.empty()) {
+      mergeFinished_ = true;
+      return std::exchange(mergeCarry_, nullptr);
+    }
+
+    std::unique_ptr<cudf::table> merged = mergeViews.size() == 1
+        ? std::make_unique<cudf::table>(mergeViews.front(), stream, mr)
+        : cudf::merge(
+              mergeViews, sortKeys_, columnOrder_, nullOrder_, stream, mr);
+    mergeCarry_.reset();
+    if (boundaryRows.empty()) {
+      mergeFinished_ = true;
+      return merged;
+    }
+
+    auto boundaryCandidates = cudf::concatenate(boundaryRows, stream, mr);
+    auto sortedBoundaries = cudf::sort_by_key(
+        boundaryCandidates->view(),
+        boundaryCandidates->view().select(sortKeys_),
+        columnOrder_, nullOrder_, stream, mr);
+    auto boundary = cudf::slice(sortedBoundaries->view(), {0, 1}, stream);
+    auto positions = cudf::upper_bound(
+        merged->view().select(sortKeys_), boundary.front().select(sortKeys_),
+        columnOrder_, nullOrder_, stream, mr);
+    const auto safeEnd = firstSearchPosition(positions->view(), stream);
+    mergeCarry_ = copyTableSlice(
+        merged->view(), safeEnd, merged->num_rows(), stream, mr);
+    if (safeEnd > 0) {
+      return copyTableSlice(merged->view(), 0, safeEnd, stream, mr);
+    }
+  }
+  return nullptr;
+}
+
+void CudfOrderBy::cleanupSpillFiles() {
+  sortedRuns_.clear();
+  mergeCarry_.reset();
+  if (spillDirectory_.empty()) {
+    return;
+  }
+  std::error_code error;
+  std::filesystem::remove_all(spillDirectory_, error);
+  spillDirectory_.clear();
+  ::malloc_trim(0);
 }
 
 void CudfOrderBy::doClose() {
@@ -106,5 +302,6 @@ void CudfOrderBy::doClose() {
   // Release cudf memory resources
   inputs_.clear();
   outputTable_.reset();
+  cleanupSpillFiles();
 }
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -23,6 +23,9 @@
 #include "velox/vector/ComplexVector.h"
 
 #include <cudf/types.hpp>
+#include <cudf/io/parquet.hpp>
+
+#include <string>
 
 namespace facebook::velox::cudf_velox {
 
@@ -34,7 +37,7 @@ class CudfOrderBy : public CudfOperatorBase {
       const std::shared_ptr<const core::OrderByNode>& orderByNode);
 
   bool needsInput() const override {
-    return !finished_;
+    return !noMoreInput_;
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -52,12 +55,31 @@ class CudfOrderBy : public CudfOperatorBase {
   void doClose() override;
 
  private:
+  void spillSortedRun();
+  void initializeSortedRunReaders();
+  std::unique_ptr<cudf::table> mergeNextSortedBatch(
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+  void cleanupSpillFiles();
+
   CudfVectorPtr outputTable_;
   std::shared_ptr<const core::OrderByNode> orderByNode_;
   std::vector<CudfVectorPtr> inputs_;
   std::vector<cudf::size_type> sortKeys_;
   std::vector<cudf::order> columnOrder_;
   std::vector<cudf::null_order> nullOrder_;
+  uint64_t bufferedBytes_{0};
+  struct SortedRun {
+    std::string path;
+    std::unique_ptr<cudf::io::chunked_parquet_reader> reader;
+  };
+  std::vector<SortedRun> sortedRuns_;
+  std::string spillDirectory_;
+  uint64_t spillFileSequence_{0};
+  std::unique_ptr<cudf::table> mergeCarry_;
+  bool readersInitialized_{false};
+  bool mergeFinished_{false};
+  bool spilled_{false};
   bool finished_{false};
 };
 

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -22,8 +22,8 @@
 #include "velox/exec/Operator.h"
 #include "velox/vector/ComplexVector.h"
 
-#include <cudf/types.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/types.hpp>
 
 #include <string>
 

--- a/velox/experimental/cudf/exec/CudfReduce.cpp
+++ b/velox/experimental/cudf/exec/CudfReduce.cpp
@@ -88,8 +88,8 @@ std::unique_ptr<cudf::column> reduceMinMaxWithInputType(
     TypePtr const& outputType,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
-  auto const resultScalar =
-      cudf::reduce(inputCol, aggRequest, inputCol.type(), stream, get_temp_mr());
+  auto const resultScalar = cudf::reduce(
+      inputCol, aggRequest, inputCol.type(), stream, get_temp_mr());
   auto resultCol = cudf::make_column_from_scalar(*resultScalar, 1, stream, mr);
   auto const cudfOutputType = cudf_velox::veloxToCudfDataType(outputType);
   if (resultCol->type() != cudfOutputType) {
@@ -98,26 +98,26 @@ std::unique_ptr<cudf::column> reduceMinMaxWithInputType(
   return resultCol;
 }
 
-#define DEFINE_MIN_MAX_REDUCE_AGGREGATOR(Name, name)                         \
-  struct Reduce##Name##Aggregator : ReduceAggregator {                       \
-    Reduce##Name##Aggregator(                                                \
-        core::AggregationNode::Step step,                                    \
-        uint32_t inputIndex,                                                 \
-        VectorPtr constant,                                                  \
-        const TypePtr& resultType)                                           \
-        : ReduceAggregator(step, inputIndex, constant, resultType) {}        \
-                                                                             \
-    std::unique_ptr<cudf::column> doReduce(                                  \
-        cudf::table_view const& input,                                       \
-        TypePtr const& outputType,                                           \
-        vector_size_t /* inputRowCount */,                                   \
-        rmm::cuda_stream_view stream,                                        \
-        rmm::device_async_resource_ref mr) override {                        \
-      auto const aggRequest =                                                \
-          cudf::make_##name##_aggregation<cudf::reduce_aggregation>();       \
-      return reduceMinMaxWithInputType(                                      \
-          input.column(inputIndex), *aggRequest, outputType, stream, mr);    \
-    }                                                                        \
+#define DEFINE_MIN_MAX_REDUCE_AGGREGATOR(Name, name)                      \
+  struct Reduce##Name##Aggregator : ReduceAggregator {                    \
+    Reduce##Name##Aggregator(                                             \
+        core::AggregationNode::Step step,                                 \
+        uint32_t inputIndex,                                              \
+        VectorPtr constant,                                               \
+        const TypePtr& resultType)                                        \
+        : ReduceAggregator(step, inputIndex, constant, resultType) {}     \
+                                                                          \
+    std::unique_ptr<cudf::column> doReduce(                               \
+        cudf::table_view const& input,                                    \
+        TypePtr const& outputType,                                        \
+        vector_size_t /* inputRowCount */,                                \
+        rmm::cuda_stream_view stream,                                     \
+        rmm::device_async_resource_ref mr) override {                     \
+      auto const aggRequest =                                             \
+          cudf::make_##name##_aggregation<cudf::reduce_aggregation>();    \
+      return reduceMinMaxWithInputType(                                   \
+          input.column(inputIndex), *aggRequest, outputType, stream, mr); \
+    }                                                                     \
   };
 
 DEFINE_MIN_MAX_REDUCE_AGGREGATOR(Min, min)

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -22,14 +22,36 @@
 #include "velox/exec/OperatorUtils.h"
 
 #include <cudf/column/column_factories.hpp>
+#include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
+#include <cudf/groupby.hpp>
+#include <cudf/io/experimental/cudftable.hpp>
+#include <cudf/io/parquet.hpp>
 #include <cudf/join/hash_join.hpp>
+#include <cudf/merge.hpp>
+#include <cudf/search.hpp>
+#include <cudf/partitioning.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/stream_compaction.hpp>
+#include <cudf/unary.hpp>
+
+#include <atomic>
+#include <filesystem>
+#include <malloc.h>
+#include <unistd.h>
 
 namespace facebook::velox::cudf_velox {
 namespace {
+
+constexpr uint64_t kSortedRunBytes = 3ULL << 30;
+constexpr uint64_t kCandidateRunBytes = 128ULL << 20;
+constexpr uint64_t kMergeChunkBytes = 32ULL << 20;
+constexpr size_t kMergeFanIn = 4;
+constexpr cudf::size_type kMaxCompleteOutputRows = 262144;
+constexpr std::string_view kConditionalTopNMarker =
+    "__gluten_mpp_topn_active";
+std::atomic<uint64_t> spillDirectorySequence{0};
 
 bool isSupportedKeyType(const TypePtr& type) {
   switch (type->kind()) {
@@ -41,6 +63,33 @@ bool isSupportedKeyType(const TypePtr& type) {
     default:
       return true;
   }
+}
+
+std::unique_ptr<cudf::table> copyTableSlice(
+    cudf::table_view input,
+    cudf::size_type begin,
+    cudf::size_type end,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_LE(begin, end);
+  auto slices = cudf::slice(input, {begin, end}, stream);
+  VELOX_CHECK_EQ(slices.size(), 1);
+  return std::make_unique<cudf::table>(slices.front(), stream, mr);
+}
+
+cudf::size_type firstSearchPosition(
+    cudf::column_view positions,
+    rmm::cuda_stream_view stream) {
+  VELOX_CHECK_EQ(positions.size(), 1);
+  cudf::size_type result{0};
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      &result,
+      positions.data<cudf::size_type>(),
+      sizeof(result),
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+  stream.synchronize();
+  return result;
 }
 
 } // namespace
@@ -93,7 +142,8 @@ CudfTopNRowNumber::CudfTopNRowNumber(
       limit_(node->limit()),
       rankFunction_(node->rankFunction()),
       generateRowNumber_(node->generateRowNumber()),
-      inputType_(node->inputType()) {
+      inputType_(node->inputType()),
+      diagnosticNodeId_(node->id()) {
   VELOX_CHECK_EQ(limit_, 1, "CudfTopNRowNumber only supports limit=1");
   VELOX_CHECK(
       rankFunction_ == core::TopNRowNumberNode::RankFunction::kRowNumber ||
@@ -107,6 +157,17 @@ CudfTopNRowNumber::CudfTopNRowNumber(
         channel != kConstantChannel,
         "TopNRowNumber doesn't allow constant partition keys");
     partitionKeys_.push_back(channel);
+    const auto& keyName = inputType_->nameOf(channel);
+    if (keyName.compare(0, kConditionalTopNMarker.size(), kConditionalTopNMarker) ==
+        0) {
+      VELOX_CHECK(
+          !passthroughKey_.has_value(),
+          "TopNRowNumber allows only one conditional pass-through key");
+      VELOX_CHECK(
+          inputType_->childAt(channel)->kind() == TypeKind::BOOLEAN,
+          "Conditional TopNRowNumber marker must be boolean");
+      passthroughKey_ = channel;
+    }
   }
 
   const auto& sortingKeys = node->sortingKeys();
@@ -147,37 +208,540 @@ void CudfTopNRowNumber::doAddInput(RowVectorPtr input) {
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput, "Expected CudfVector input");
-  inputs_.push_back(std::move(cudfInput));
+
+  if (passthroughKey_.has_value()) {
+    auto stream = cudfInput->stream();
+    auto inputView = cudfInput->getTableView();
+    auto activeMask = inputView.column(*passthroughKey_);
+    VELOX_CHECK(
+        activeMask.type().id() == cudf::type_id::BOOL8,
+        "Conditional TopNRowNumber marker must be BOOL8");
+
+    auto inactiveMask = cudf::unary_operation(
+        activeMask,
+        cudf::unary_operator::NOT,
+        stream,
+        get_temp_mr());
+    auto inactive = cudf::apply_boolean_mask(
+        inputView, inactiveMask->view(), stream, get_output_mr());
+    if (inactive->num_rows() > 0) {
+      passthroughOutputs_.push_back(std::make_shared<CudfVector>(
+          pool(),
+          inputType_,
+          inactive->num_rows(),
+          std::move(inactive),
+          stream));
+    }
+
+    auto active = cudf::apply_boolean_mask(
+        inputView, activeMask, stream, get_output_mr());
+    if (active->num_rows() == 0) {
+      return;
+    }
+    cudfInput = std::make_shared<CudfVector>(
+        pool(), inputType_, active->num_rows(), std::move(active), stream);
+  }
+
+  auto stream = cudfInput->stream();
+  auto mr = get_output_mr();
+  auto batchCandidates =
+      reduceToCandidates(cudfInput->getTableView(), stream, mr);
+  if (candidates_ && candidates_->num_rows() > 0) {
+    std::vector<cudf::table_view> pieces{
+        candidates_->view(), batchCandidates->view()};
+    auto merged = cudf::concatenate(pieces, stream, mr);
+    candidates_ = reduceToCandidates(merged->view(), stream, mr);
+  } else {
+    candidates_ = std::move(batchCandidates);
+  }
+
+  auto candidateVector = std::make_shared<CudfVector>(
+      pool(),
+      inputType_,
+      candidates_->num_rows(),
+      std::move(candidates_),
+      stream);
+  const auto candidateBytes = candidateVector->estimateFlatSize();
+  if (candidateBytes >= kCandidateRunBytes) {
+    inputs_.push_back(std::move(candidateVector));
+    bufferedBytes_ = candidateBytes;
+    spillSortedRun();
+  } else {
+    candidates_ = candidateVector->release();
+  }
 }
 
 void CudfTopNRowNumber::doNoMoreInput() {
   Operator::noMoreInput();
-  if (inputs_.empty()) {
-    finished_ = true;
+  if (spilled_ && candidates_) {
+    auto stream = cudfGlobalStreamPool().get_stream();
+    auto candidateVector = std::make_shared<CudfVector>(
+        pool(),
+        inputType_,
+        candidates_->num_rows(),
+        std::move(candidates_),
+        stream);
+    bufferedBytes_ = candidateVector->estimateFlatSize();
+    inputs_.push_back(std::move(candidateVector));
+    spillSortedRun();
+  }
+  if (spilled_) {
+    compactSortedRunsForMerge();
+    initializeSortedRunReaders();
+  }
+  if (!candidates_ && passthroughOutputs_.empty()) {
+    finished_ = !spilled_;
   }
 }
 
 RowVectorPtr CudfTopNRowNumber::doGetOutput() {
+  if (!passthroughOutputs_.empty()) {
+    auto output = std::move(passthroughOutputs_.front());
+    passthroughOutputs_.pop_front();
+    return output;
+  }
+
   if (finished_ || !noMoreInput_) {
     return nullptr;
   }
 
-  if (inputs_.empty()) {
+  if (spilled_) {
+    auto result = computeNextSortedOutput();
+    if (result != nullptr) {
+      return result;
+    }
+    finished_ = true;
+    cleanupSpillFiles();
+    return nullptr;
+  }
+
+  if (!candidates_) {
     finished_ = true;
     return nullptr;
   }
 
   auto stream = cudfGlobalStreamPool().get_stream();
   auto mr = get_output_mr();
-  auto input = getConcatenatedTable(std::move(inputs_), inputType_, stream, mr);
-  inputs_.clear();
-
+  auto input = std::exchange(candidates_, nullptr);
   auto result =
       rankFunction_ == core::TopNRowNumberNode::RankFunction::kRowNumber
       ? computeLimitOneRowNumber(input->view(), stream, mr)
       : computeLimitOneRankLike(input->view(), stream, mr);
   finished_ = true;
   return result;
+}
+
+std::unique_ptr<cudf::table> CudfTopNRowNumber::reduceToCandidates(
+    cudf::table_view input,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto reduced =
+      rankFunction_ == core::TopNRowNumberNode::RankFunction::kRowNumber
+      ? computeLimitOneRowNumber(input, stream, mr)
+      : computeLimitOneRankLike(input, stream, mr);
+  auto table = reduced->release();
+  if (generateRowNumber_) {
+    auto columns = table->release();
+    VELOX_CHECK_EQ(
+        columns.size(),
+        inputType_->size() + 1,
+        "Incremental TopN candidate has unexpected generated rank column");
+    columns.pop_back();
+    table = std::make_unique<cudf::table>(std::move(columns));
+  }
+  return table;
+}
+
+void CudfTopNRowNumber::spillSortedRun() {
+  if (inputs_.empty()) {
+    return;
+  }
+
+  namespace fs = std::filesystem;
+  if (!spilled_) {
+    const auto sequence = spillDirectorySequence.fetch_add(1);
+    spillDirectory_ = (
+        fs::temp_directory_path() /
+        fmt::format(
+            "velox-cudf-topn-spill-{}-{}",
+            static_cast<int64_t>(::getpid()),
+            sequence))
+                          .string();
+    fs::create_directories(spillDirectory_);
+    spilled_ = true;
+  }
+
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfTopNRowNumber node={} state=sortRun.concatenate.begin "
+      "bufferedBytes={} bufferedInputs={}",
+      diagnosticNodeId_,
+      bufferedBytes_,
+      inputs_.size()));
+  auto input =
+      getConcatenatedTable(std::exchange(inputs_, {}), inputType_, stream, mr);
+  bufferedBytes_ = 0;
+
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfTopNRowNumber node={} state=sortRun.sort.begin rows={}",
+      diagnosticNodeId_,
+      input->num_rows()));
+  auto sorted = cudf::sort_by_key(
+      input->view(),
+      input->view().select(allKeyIndices_),
+      columnOrders_,
+      nullOrders_,
+      stream,
+      mr);
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfTopNRowNumber node={} state=sortRun.sort.end rows={}",
+      diagnosticNodeId_,
+      input->num_rows()));
+
+  auto path = fmt::format(
+      "{}/run-{:06}.parquet", spillDirectory_, spillFileSequence_++);
+  auto options = cudf::io::parquet_writer_options::builder(
+                     cudf::io::sink_info{path}, sorted->view())
+                     .build();
+  cudf::io::write_parquet(options, stream);
+  sortedRuns_.push_back({std::move(path), nullptr});
+  ::malloc_trim(0);
+}
+
+void CudfTopNRowNumber::initializeSortedRunReaders() {
+  if (readersInitialized_) {
+    return;
+  }
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+  for (auto& run : sortedRuns_) {
+    auto options = cudf::io::parquet_reader_options::builder(
+                       cudf::io::source_info{run.path})
+                       .build();
+    run.reader = std::make_unique<cudf::io::chunked_parquet_reader>(
+        kMergeChunkBytes, 0, options, stream, mr);
+  }
+  readersInitialized_ = true;
+}
+
+void CudfTopNRowNumber::compactSortedRunsForMerge() {
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+
+  while (sortedRuns_.size() > kMergeFanIn) {
+    std::vector<SortedRun> nextLevel;
+    nextLevel.reserve(
+        (sortedRuns_.size() + kMergeFanIn - 1) / kMergeFanIn);
+
+    for (size_t begin = 0; begin < sortedRuns_.size(); begin += kMergeFanIn) {
+      const auto end = std::min(sortedRuns_.size(), begin + kMergeFanIn);
+      if (end - begin == 1) {
+        nextLevel.push_back(std::move(sortedRuns_[begin]));
+        continue;
+      }
+
+      std::vector<std::unique_ptr<cudf::io::chunked_parquet_reader>> readers;
+      readers.reserve(end - begin);
+      for (size_t index = begin; index < end; ++index) {
+        auto options = cudf::io::parquet_reader_options::builder(
+                           cudf::io::source_info{sortedRuns_[index].path})
+                           .build();
+        readers.push_back(
+            std::make_unique<cudf::io::chunked_parquet_reader>(
+                kMergeChunkBytes, 0, options, stream, mr));
+      }
+
+      const auto outputPath = fmt::format(
+          "{}/merge-{:06}.parquet", spillDirectory_, spillFileSequence_++);
+      auto writerOptions =
+          cudf::io::chunked_parquet_writer_options::builder(
+              cudf::io::sink_info{outputPath})
+              .build();
+      cudf::io::chunked_parquet_writer writer(writerOptions, stream);
+      std::unique_ptr<cudf::table> carry;
+
+      while (true) {
+        std::vector<std::unique_ptr<cudf::table>> chunks;
+        std::vector<cudf::table_view> mergeViews;
+        std::vector<cudf::table_view> boundaryRows;
+        if (carry && carry->num_rows() > 0) {
+          mergeViews.push_back(carry->view());
+        }
+        for (auto& reader : readers) {
+          if (!reader->has_next()) {
+            continue;
+          }
+          auto chunk = reader->read_chunk();
+          if (chunk.tbl->num_rows() == 0) {
+            continue;
+          }
+          chunks.push_back(std::move(chunk.tbl));
+          mergeViews.push_back(chunks.back()->view());
+          if (reader->has_next()) {
+            auto last = cudf::slice(
+                chunks.back()->view(),
+                {chunks.back()->num_rows() - 1, chunks.back()->num_rows()},
+                stream);
+            boundaryRows.push_back(last.front());
+          }
+        }
+
+        if (mergeViews.empty()) {
+          break;
+        }
+        std::unique_ptr<cudf::table> merged = mergeViews.size() == 1
+            ? std::make_unique<cudf::table>(mergeViews.front(), stream, mr)
+            : cudf::merge(
+                  mergeViews,
+                  allKeyIndices_,
+                  columnOrders_,
+                  nullOrders_,
+                  stream,
+                  mr);
+        carry.reset();
+        if (boundaryRows.empty()) {
+          writer.write(merged->view());
+          break;
+        }
+
+        auto boundaryCandidates =
+            cudf::concatenate(boundaryRows, stream, mr);
+        auto sortedBoundaries = cudf::sort_by_key(
+            boundaryCandidates->view(),
+            boundaryCandidates->view().select(allKeyIndices_),
+            columnOrders_,
+            nullOrders_,
+            stream,
+            mr);
+        auto boundary =
+            cudf::slice(sortedBoundaries->view(), {0, 1}, stream);
+        auto positions = cudf::upper_bound(
+            merged->view().select(allKeyIndices_),
+            boundary.front().select(allKeyIndices_),
+            columnOrders_,
+            nullOrders_,
+            stream,
+            mr);
+        const auto safeEnd = firstSearchPosition(positions->view(), stream);
+        carry = copyTableSlice(
+            merged->view(), safeEnd, merged->num_rows(), stream, mr);
+        if (safeEnd > 0) {
+          auto safe = cudf::slice(merged->view(), {0, safeEnd}, stream);
+          writer.write(safe.front());
+        }
+      }
+      writer.close();
+
+      for (size_t index = begin; index < end; ++index) {
+        std::error_code error;
+        std::filesystem::remove(sortedRuns_[index].path, error);
+      }
+      nextLevel.push_back({outputPath, nullptr});
+    }
+    sortedRuns_ = std::move(nextLevel);
+  }
+}
+
+std::unique_ptr<cudf::table> CudfTopNRowNumber::mergeNextSortedBatch(
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    bool& finalBatch) {
+  // Once all readers are exhausted, a subsequent call may exist solely to
+  // drain partitionCarry_. Mark it final so the last partition is emitted
+  // instead of being retained forever as a possibly-incomplete peer group.
+  finalBatch = mergeFinished_;
+  while (!mergeFinished_) {
+    std::vector<std::unique_ptr<cudf::table>> chunks;
+    std::vector<cudf::table_view> mergeViews;
+    std::vector<cudf::table_view> boundaryRows;
+    if (mergeCarry_ && mergeCarry_->num_rows() > 0) {
+      mergeViews.push_back(mergeCarry_->view());
+    }
+    for (auto& run : sortedRuns_) {
+      if (!run.reader || !run.reader->has_next()) {
+        continue;
+      }
+      auto chunk = run.reader->read_chunk();
+      if (chunk.tbl->num_rows() == 0) {
+        continue;
+      }
+      chunks.push_back(std::move(chunk.tbl));
+      mergeViews.push_back(chunks.back()->view());
+      if (run.reader->has_next()) {
+        auto last = cudf::slice(
+            chunks.back()->view(),
+            {chunks.back()->num_rows() - 1, chunks.back()->num_rows()},
+            stream);
+        boundaryRows.push_back(last.front());
+      }
+    }
+    if (mergeViews.empty()) {
+      mergeFinished_ = true;
+      finalBatch = true;
+      return std::exchange(mergeCarry_, nullptr);
+    }
+
+    std::unique_ptr<cudf::table> merged;
+    if (mergeViews.size() == 1) {
+      merged = std::make_unique<cudf::table>(mergeViews.front(), stream, mr);
+    } else {
+      merged = cudf::merge(
+          mergeViews,
+          allKeyIndices_,
+          columnOrders_,
+          nullOrders_,
+          stream,
+          mr);
+    }
+    mergeCarry_.reset();
+    if (boundaryRows.empty()) {
+      mergeFinished_ = true;
+      finalBatch = true;
+      return merged;
+    }
+
+    auto boundaryCandidates = cudf::concatenate(boundaryRows, stream, mr);
+    auto sortedBoundaries = cudf::sort_by_key(
+        boundaryCandidates->view(),
+        boundaryCandidates->view().select(allKeyIndices_),
+        columnOrders_,
+        nullOrders_,
+        stream,
+        mr);
+    auto boundary = cudf::slice(sortedBoundaries->view(), {0, 1}, stream);
+    // Future rows are >= each run's current tail. Rows equal to the minimum
+    // tail are therefore safe to emit as well (the sort is not required to be
+    // stable across runs). Keeping them in carry makes low-cardinality keys
+    // grow without bound.
+    auto positions = cudf::upper_bound(
+        merged->view().select(allKeyIndices_),
+        boundary.front().select(allKeyIndices_),
+        columnOrders_,
+        nullOrders_,
+        stream,
+        mr);
+    const auto safeEnd = firstSearchPosition(positions->view(), stream);
+    mergeCarry_ = copyTableSlice(
+        merged->view(), safeEnd, merged->num_rows(), stream, mr);
+    if (safeEnd > 0) {
+      return copyTableSlice(merged->view(), 0, safeEnd, stream, mr);
+    }
+  }
+  return nullptr;
+}
+
+std::unique_ptr<cudf::table> CudfTopNRowNumber::takeCompletePartitions(
+    std::unique_ptr<cudf::table> sorted,
+    bool finalBatch,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  if (partitionCarry_ && partitionCarry_->num_rows() > 0) {
+    if (sorted && sorted->num_rows() > 0) {
+      std::vector<cudf::table_view> pieces{
+          partitionCarry_->view(), sorted->view()};
+      sorted = cudf::concatenate(pieces, stream, mr);
+      partitionCarry_.reset();
+    } else {
+      sorted = std::exchange(partitionCarry_, nullptr);
+    }
+  }
+  if (!sorted || sorted->num_rows() == 0) {
+    return nullptr;
+  }
+
+  auto partitionColumns = sorted->view().select(partitionKeys_);
+  std::vector<cudf::order> orders(
+      partitionKeys_.size(), cudf::order::ASCENDING);
+  std::vector<cudf::null_order> nullOrders(
+      partitionKeys_.size(), cudf::null_order::BEFORE);
+  cudf::size_type completeEnd = sorted->num_rows();
+  if (!finalBatch) {
+    auto lastPartition = cudf::slice(
+        partitionColumns,
+        {sorted->num_rows() - 1, sorted->num_rows()},
+        stream);
+    auto positions = cudf::lower_bound(
+        partitionColumns,
+        lastPartition.front(),
+        orders,
+        nullOrders,
+        stream,
+        mr);
+    completeEnd = firstSearchPosition(positions->view(), stream);
+  }
+
+  // Keep each downstream Top-N reduction/gather bounded. Select a partition
+  // boundary at or before the row target so a rank peer group is never split.
+  cudf::size_type emitEnd = completeEnd;
+  if (completeEnd > kMaxCompleteOutputRows) {
+    auto boundaryPartition = cudf::slice(
+        partitionColumns,
+        {kMaxCompleteOutputRows, kMaxCompleteOutputRows + 1},
+        stream);
+    auto positions = cudf::lower_bound(
+        partitionColumns,
+        boundaryPartition.front(),
+        orders,
+        nullOrders,
+        stream,
+        mr);
+    const auto boundary = firstSearchPosition(positions->view(), stream);
+    // A single giant peer group must remain intact for rank semantics.
+    emitEnd = boundary > 0 ? boundary : completeEnd;
+  }
+
+  partitionCarry_ = copyTableSlice(
+      sorted->view(), emitEnd, sorted->num_rows(), stream, mr);
+  if (emitEnd == 0) {
+    return nullptr;
+  }
+  return copyTableSlice(sorted->view(), 0, emitEnd, stream, mr);
+}
+
+CudfVectorPtr CudfTopNRowNumber::computeNextSortedOutput() {
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+  while (!mergeFinished_ || mergeCarry_ || partitionCarry_) {
+    bool finalBatch = false;
+    auto sorted = mergeNextSortedBatch(stream, mr, finalBatch);
+    sorted = takeCompletePartitions(
+        std::move(sorted), finalBatch, stream, mr);
+    if (!sorted || sorted->num_rows() == 0) {
+      if (finalBatch) {
+        return nullptr;
+      }
+      continue;
+    }
+    // The merge output is already globally ordered. The existing limit-one
+    // helpers are reused initially for exact rank/tie semantics; they operate
+    // on a bounded complete-partition batch.
+    return rankFunction_ == core::TopNRowNumberNode::RankFunction::kRowNumber
+        ? computeLimitOneRowNumber(sorted->view(), stream, mr)
+        : computeLimitOneRankLike(sorted->view(), stream, mr);
+  }
+  return nullptr;
+}
+
+void CudfTopNRowNumber::cleanupSpillFiles() {
+  sortedRuns_.clear();
+  mergeCarry_.reset();
+  partitionCarry_.reset();
+  if (spillDirectory_.empty()) {
+    return;
+  }
+  std::error_code error;
+  std::filesystem::remove_all(spillDirectory_, error);
+  spillDirectory_.clear();
+  ::malloc_trim(0);
+}
+
+void CudfTopNRowNumber::doClose() {
+  inputs_.clear();
+  candidates_.reset();
+  passthroughOutputs_.clear();
+  cleanupSpillFiles();
+  Operator::close();
 }
 
 CudfVectorPtr CudfTopNRowNumber::computeLimitOneRowNumber(
@@ -203,6 +767,54 @@ CudfVectorPtr CudfTopNRowNumber::computeLimitOneRowNumber(
         firstIndex,
         cudf::out_of_bounds_policy::DONT_CHECK,
         cudf::negative_index_policy::NOT_ALLOWED,
+        stream,
+        mr);
+  } else if (
+      sortKeys_.size() == 1 &&
+      nullOrders_[partitionKeys_.size()] == cudf::null_order::AFTER) {
+    auto partitionView = input.select(partitionKeys_);
+    cudf::groupby::groupby grouper(
+        partitionView, cudf::null_policy::INCLUDE);
+    std::vector<cudf::groupby::aggregation_request> requests(1);
+    requests[0].values = input.column(sortKeys_.front());
+    if (columnOrders_[partitionKeys_.size()] == cudf::order::ASCENDING) {
+      requests[0].aggregations.push_back(
+          cudf::make_min_aggregation<cudf::groupby_aggregation>());
+    } else {
+      requests[0].aggregations.push_back(
+          cudf::make_max_aggregation<cudf::groupby_aggregation>());
+    }
+    auto [groupKeys, aggregateResults] =
+        grouper.aggregate(requests, stream, mr);
+    VELOX_CHECK_EQ(aggregateResults.size(), 1);
+    VELOX_CHECK_EQ(aggregateResults[0].results.size(), 1);
+    auto topKeyColumns = groupKeys->release();
+    topKeyColumns.push_back(std::move(aggregateResults[0].results[0]));
+    auto topKeys =
+        std::make_unique<cudf::table>(std::move(topKeyColumns));
+    auto probeKeys = input.select(allKeyIndices_);
+    cudf::hash_join lookup(
+        topKeys->view(),
+        cudf::nullable_join::YES,
+        cudf::null_equality::EQUAL,
+        0.5,
+        stream);
+    auto joinIndices =
+        lookup.inner_join(probeKeys, std::nullopt, stream, mr);
+    auto probeIndices = cudf::column_view{
+        cudf::device_span<cudf::size_type const>{*joinIndices.first}};
+    auto bestPeers = cudf::gather(
+        input,
+        probeIndices,
+        cudf::out_of_bounds_policy::DONT_CHECK,
+        cudf::negative_index_policy::NOT_ALLOWED,
+        stream,
+        mr);
+    result = cudf::unique(
+        bestPeers->view(),
+        partitionKeys_,
+        cudf::duplicate_keep_option::KEEP_FIRST,
+        cudf::null_equality::EQUAL,
         stream,
         mr);
   } else {
@@ -248,6 +860,51 @@ CudfVectorPtr CudfTopNRowNumber::computeLimitOneRankLike(
   std::unique_ptr<cudf::table> result;
   if (input.num_rows() == 0) {
     result = std::make_unique<cudf::table>(input, stream, mr);
+  } else if (
+      !partitionKeys_.empty() && sortKeys_.size() == 1 &&
+      nullOrders_[partitionKeys_.size()] == cudf::null_order::AFTER) {
+    // Fast grouped Top-1 for the common single scalar order key. A full sort
+    // is unnecessary: compute each partition's best key, then join that key
+    // back to the input. The inner join intentionally preserves every peer of
+    // the best key, which is exactly rank/dense_rank limit=1 semantics.
+    auto partitionView = input.select(partitionKeys_);
+    cudf::groupby::groupby grouper(
+        partitionView, cudf::null_policy::INCLUDE);
+    std::vector<cudf::groupby::aggregation_request> requests(1);
+    requests[0].values = input.column(sortKeys_.front());
+    if (columnOrders_[partitionKeys_.size()] == cudf::order::ASCENDING) {
+      requests[0].aggregations.push_back(
+          cudf::make_min_aggregation<cudf::groupby_aggregation>());
+    } else {
+      requests[0].aggregations.push_back(
+          cudf::make_max_aggregation<cudf::groupby_aggregation>());
+    }
+    auto [groupKeys, aggregateResults] =
+        grouper.aggregate(requests, stream, mr);
+    VELOX_CHECK_EQ(aggregateResults.size(), 1);
+    VELOX_CHECK_EQ(aggregateResults[0].results.size(), 1);
+    auto topKeyColumns = groupKeys->release();
+    topKeyColumns.push_back(std::move(aggregateResults[0].results[0]));
+    auto topKeys =
+        std::make_unique<cudf::table>(std::move(topKeyColumns));
+    auto probeKeys = input.select(allKeyIndices_);
+    cudf::hash_join lookup(
+        topKeys->view(),
+        cudf::nullable_join::YES,
+        cudf::null_equality::EQUAL,
+        0.5,
+        stream);
+    auto joinIndices =
+        lookup.inner_join(probeKeys, std::nullopt, stream, mr);
+    auto probeIndices = cudf::column_view{
+        cudf::device_span<cudf::size_type const>{*joinIndices.first}};
+    result = cudf::gather(
+        input,
+        probeIndices,
+        cudf::out_of_bounds_policy::DONT_CHECK,
+        cudf::negative_index_policy::NOT_ALLOWED,
+        stream,
+        mr);
   } else {
     auto allKeysView = input.select(allKeyIndices_);
     auto sortedIndices = cudf::stable_sorted_order(

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "velox/experimental/cudf/exec/CudfTopNRowNumber.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/exec/CudfTopNRowNumber.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
@@ -30,16 +30,17 @@
 #include <cudf/io/parquet.hpp>
 #include <cudf/join/hash_join.hpp>
 #include <cudf/merge.hpp>
-#include <cudf/search.hpp>
 #include <cudf/partitioning.hpp>
+#include <cudf/search.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/unary.hpp>
 
-#include <atomic>
-#include <filesystem>
 #include <malloc.h>
 #include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
 
 namespace facebook::velox::cudf_velox {
 namespace {
@@ -49,8 +50,7 @@ constexpr uint64_t kCandidateRunBytes = 128ULL << 20;
 constexpr uint64_t kMergeChunkBytes = 32ULL << 20;
 constexpr size_t kMergeFanIn = 4;
 constexpr cudf::size_type kMaxCompleteOutputRows = 262144;
-constexpr std::string_view kConditionalTopNMarker =
-    "__gluten_mpp_topn_active";
+constexpr std::string_view kConditionalTopNMarker = "__gluten_mpp_topn_active";
 std::atomic<uint64_t> spillDirectorySequence{0};
 
 bool isSupportedKeyType(const TypePtr& type) {
@@ -158,8 +158,8 @@ CudfTopNRowNumber::CudfTopNRowNumber(
         "TopNRowNumber doesn't allow constant partition keys");
     partitionKeys_.push_back(channel);
     const auto& keyName = inputType_->nameOf(channel);
-    if (keyName.compare(0, kConditionalTopNMarker.size(), kConditionalTopNMarker) ==
-        0) {
+    if (keyName.compare(
+            0, kConditionalTopNMarker.size(), kConditionalTopNMarker) == 0) {
       VELOX_CHECK(
           !passthroughKey_.has_value(),
           "TopNRowNumber allows only one conditional pass-through key");
@@ -192,8 +192,7 @@ CudfTopNRowNumber::CudfTopNRowNumber(
 
   for (const auto& order : sortingOrders) {
     columnOrders_.push_back(
-        order.isAscending() ? cudf::order::ASCENDING
-                            : cudf::order::DESCENDING);
+        order.isAscending() ? cudf::order::ASCENDING : cudf::order::DESCENDING);
     nullOrders_.push_back(
         (order.isNullsFirst() ^ !order.isAscending())
             ? cudf::null_order::BEFORE
@@ -218,19 +217,17 @@ void CudfTopNRowNumber::doAddInput(RowVectorPtr input) {
         "Conditional TopNRowNumber marker must be BOOL8");
 
     auto inactiveMask = cudf::unary_operation(
-        activeMask,
-        cudf::unary_operator::NOT,
-        stream,
-        get_temp_mr());
+        activeMask, cudf::unary_operator::NOT, stream, get_temp_mr());
     auto inactive = cudf::apply_boolean_mask(
         inputView, inactiveMask->view(), stream, get_output_mr());
     if (inactive->num_rows() > 0) {
-      passthroughOutputs_.push_back(std::make_shared<CudfVector>(
-          pool(),
-          inputType_,
-          inactive->num_rows(),
-          std::move(inactive),
-          stream));
+      passthroughOutputs_.push_back(
+          std::make_shared<CudfVector>(
+              pool(),
+              inputType_,
+              inactive->num_rows(),
+              std::move(inactive),
+              stream));
     }
 
     auto active = cudf::apply_boolean_mask(
@@ -360,12 +357,11 @@ void CudfTopNRowNumber::spillSortedRun() {
   namespace fs = std::filesystem;
   if (!spilled_) {
     const auto sequence = spillDirectorySequence.fetch_add(1);
-    spillDirectory_ = (
-        fs::temp_directory_path() /
-        fmt::format(
-            "velox-cudf-topn-spill-{}-{}",
-            static_cast<int64_t>(::getpid()),
-            sequence))
+    spillDirectory_ = (fs::temp_directory_path() /
+                       fmt::format(
+                           "velox-cudf-topn-spill-{}-{}",
+                           static_cast<int64_t>(::getpid()),
+                           sequence))
                           .string();
     fs::create_directories(spillDirectory_);
     spilled_ = true;
@@ -373,20 +369,22 @@ void CudfTopNRowNumber::spillSortedRun() {
 
   auto stream = cudfGlobalStreamPool().get_stream();
   auto mr = get_output_mr();
-  logDeviceMemorySnapshot(fmt::format(
-      "operator=CudfTopNRowNumber node={} state=sortRun.concatenate.begin "
-      "bufferedBytes={} bufferedInputs={}",
-      diagnosticNodeId_,
-      bufferedBytes_,
-      inputs_.size()));
+  logDeviceMemorySnapshot(
+      fmt::format(
+          "operator=CudfTopNRowNumber node={} state=sortRun.concatenate.begin "
+          "bufferedBytes={} bufferedInputs={}",
+          diagnosticNodeId_,
+          bufferedBytes_,
+          inputs_.size()));
   auto input =
       getConcatenatedTable(std::exchange(inputs_, {}), inputType_, stream, mr);
   bufferedBytes_ = 0;
 
-  logDeviceMemorySnapshot(fmt::format(
-      "operator=CudfTopNRowNumber node={} state=sortRun.sort.begin rows={}",
-      diagnosticNodeId_,
-      input->num_rows()));
+  logDeviceMemorySnapshot(
+      fmt::format(
+          "operator=CudfTopNRowNumber node={} state=sortRun.sort.begin rows={}",
+          diagnosticNodeId_,
+          input->num_rows()));
   auto sorted = cudf::sort_by_key(
       input->view(),
       input->view().select(allKeyIndices_),
@@ -394,10 +392,11 @@ void CudfTopNRowNumber::spillSortedRun() {
       nullOrders_,
       stream,
       mr);
-  logDeviceMemorySnapshot(fmt::format(
-      "operator=CudfTopNRowNumber node={} state=sortRun.sort.end rows={}",
-      diagnosticNodeId_,
-      input->num_rows()));
+  logDeviceMemorySnapshot(
+      fmt::format(
+          "operator=CudfTopNRowNumber node={} state=sortRun.sort.end rows={}",
+          diagnosticNodeId_,
+          input->num_rows()));
 
   auto path = fmt::format(
       "{}/run-{:06}.parquet", spillDirectory_, spillFileSequence_++);
@@ -431,8 +430,7 @@ void CudfTopNRowNumber::compactSortedRunsForMerge() {
 
   while (sortedRuns_.size() > kMergeFanIn) {
     std::vector<SortedRun> nextLevel;
-    nextLevel.reserve(
-        (sortedRuns_.size() + kMergeFanIn - 1) / kMergeFanIn);
+    nextLevel.reserve((sortedRuns_.size() + kMergeFanIn - 1) / kMergeFanIn);
 
     for (size_t begin = 0; begin < sortedRuns_.size(); begin += kMergeFanIn) {
       const auto end = std::min(sortedRuns_.size(), begin + kMergeFanIn);
@@ -454,10 +452,9 @@ void CudfTopNRowNumber::compactSortedRunsForMerge() {
 
       const auto outputPath = fmt::format(
           "{}/merge-{:06}.parquet", spillDirectory_, spillFileSequence_++);
-      auto writerOptions =
-          cudf::io::chunked_parquet_writer_options::builder(
-              cudf::io::sink_info{outputPath})
-              .build();
+      auto writerOptions = cudf::io::chunked_parquet_writer_options::builder(
+                               cudf::io::sink_info{outputPath})
+                               .build();
       cudf::io::chunked_parquet_writer writer(writerOptions, stream);
       std::unique_ptr<cudf::table> carry;
 
@@ -505,8 +502,7 @@ void CudfTopNRowNumber::compactSortedRunsForMerge() {
           break;
         }
 
-        auto boundaryCandidates =
-            cudf::concatenate(boundaryRows, stream, mr);
+        auto boundaryCandidates = cudf::concatenate(boundaryRows, stream, mr);
         auto sortedBoundaries = cudf::sort_by_key(
             boundaryCandidates->view(),
             boundaryCandidates->view().select(allKeyIndices_),
@@ -514,8 +510,7 @@ void CudfTopNRowNumber::compactSortedRunsForMerge() {
             nullOrders_,
             stream,
             mr);
-        auto boundary =
-            cudf::slice(sortedBoundaries->view(), {0, 1}, stream);
+        auto boundary = cudf::slice(sortedBoundaries->view(), {0, 1}, stream);
         auto positions = cudf::upper_bound(
             merged->view().select(allKeyIndices_),
             boundary.front().select(allKeyIndices_),
@@ -587,12 +582,7 @@ std::unique_ptr<cudf::table> CudfTopNRowNumber::mergeNextSortedBatch(
       merged = std::make_unique<cudf::table>(mergeViews.front(), stream, mr);
     } else {
       merged = cudf::merge(
-          mergeViews,
-          allKeyIndices_,
-          columnOrders_,
-          nullOrders_,
-          stream,
-          mr);
+          mergeViews, allKeyIndices_, columnOrders_, nullOrders_, stream, mr);
     }
     mergeCarry_.reset();
     if (boundaryRows.empty()) {
@@ -622,8 +612,8 @@ std::unique_ptr<cudf::table> CudfTopNRowNumber::mergeNextSortedBatch(
         stream,
         mr);
     const auto safeEnd = firstSearchPosition(positions->view(), stream);
-    mergeCarry_ = copyTableSlice(
-        merged->view(), safeEnd, merged->num_rows(), stream, mr);
+    mergeCarry_ =
+        copyTableSlice(merged->view(), safeEnd, merged->num_rows(), stream, mr);
     if (safeEnd > 0) {
       return copyTableSlice(merged->view(), 0, safeEnd, stream, mr);
     }
@@ -658,9 +648,7 @@ std::unique_ptr<cudf::table> CudfTopNRowNumber::takeCompletePartitions(
   cudf::size_type completeEnd = sorted->num_rows();
   if (!finalBatch) {
     auto lastPartition = cudf::slice(
-        partitionColumns,
-        {sorted->num_rows() - 1, sorted->num_rows()},
-        stream);
+        partitionColumns, {sorted->num_rows() - 1, sorted->num_rows()}, stream);
     auto positions = cudf::lower_bound(
         partitionColumns,
         lastPartition.front(),
@@ -691,8 +679,8 @@ std::unique_ptr<cudf::table> CudfTopNRowNumber::takeCompletePartitions(
     emitEnd = boundary > 0 ? boundary : completeEnd;
   }
 
-  partitionCarry_ = copyTableSlice(
-      sorted->view(), emitEnd, sorted->num_rows(), stream, mr);
+  partitionCarry_ =
+      copyTableSlice(sorted->view(), emitEnd, sorted->num_rows(), stream, mr);
   if (emitEnd == 0) {
     return nullptr;
   }
@@ -705,8 +693,7 @@ CudfVectorPtr CudfTopNRowNumber::computeNextSortedOutput() {
   while (!mergeFinished_ || mergeCarry_ || partitionCarry_) {
     bool finalBatch = false;
     auto sorted = mergeNextSortedBatch(stream, mr, finalBatch);
-    sorted = takeCompletePartitions(
-        std::move(sorted), finalBatch, stream, mr);
+    sorted = takeCompletePartitions(std::move(sorted), finalBatch, stream, mr);
     if (!sorted || sorted->num_rows() == 0) {
       if (finalBatch) {
         return nullptr;
@@ -773,8 +760,7 @@ CudfVectorPtr CudfTopNRowNumber::computeLimitOneRowNumber(
       sortKeys_.size() == 1 &&
       nullOrders_[partitionKeys_.size()] == cudf::null_order::AFTER) {
     auto partitionView = input.select(partitionKeys_);
-    cudf::groupby::groupby grouper(
-        partitionView, cudf::null_policy::INCLUDE);
+    cudf::groupby::groupby grouper(partitionView, cudf::null_policy::INCLUDE);
     std::vector<cudf::groupby::aggregation_request> requests(1);
     requests[0].values = input.column(sortKeys_.front());
     if (columnOrders_[partitionKeys_.size()] == cudf::order::ASCENDING) {
@@ -790,8 +776,7 @@ CudfVectorPtr CudfTopNRowNumber::computeLimitOneRowNumber(
     VELOX_CHECK_EQ(aggregateResults[0].results.size(), 1);
     auto topKeyColumns = groupKeys->release();
     topKeyColumns.push_back(std::move(aggregateResults[0].results[0]));
-    auto topKeys =
-        std::make_unique<cudf::table>(std::move(topKeyColumns));
+    auto topKeys = std::make_unique<cudf::table>(std::move(topKeyColumns));
     auto probeKeys = input.select(allKeyIndices_);
     cudf::hash_join lookup(
         topKeys->view(),
@@ -799,8 +784,7 @@ CudfVectorPtr CudfTopNRowNumber::computeLimitOneRowNumber(
         cudf::null_equality::EQUAL,
         0.5,
         stream);
-    auto joinIndices =
-        lookup.inner_join(probeKeys, std::nullopt, stream, mr);
+    auto joinIndices = lookup.inner_join(probeKeys, std::nullopt, stream, mr);
     auto probeIndices = cudf::column_view{
         cudf::device_span<cudf::size_type const>{*joinIndices.first}};
     auto bestPeers = cudf::gather(
@@ -868,8 +852,7 @@ CudfVectorPtr CudfTopNRowNumber::computeLimitOneRankLike(
     // back to the input. The inner join intentionally preserves every peer of
     // the best key, which is exactly rank/dense_rank limit=1 semantics.
     auto partitionView = input.select(partitionKeys_);
-    cudf::groupby::groupby grouper(
-        partitionView, cudf::null_policy::INCLUDE);
+    cudf::groupby::groupby grouper(partitionView, cudf::null_policy::INCLUDE);
     std::vector<cudf::groupby::aggregation_request> requests(1);
     requests[0].values = input.column(sortKeys_.front());
     if (columnOrders_[partitionKeys_.size()] == cudf::order::ASCENDING) {
@@ -885,8 +868,7 @@ CudfVectorPtr CudfTopNRowNumber::computeLimitOneRankLike(
     VELOX_CHECK_EQ(aggregateResults[0].results.size(), 1);
     auto topKeyColumns = groupKeys->release();
     topKeyColumns.push_back(std::move(aggregateResults[0].results[0]));
-    auto topKeys =
-        std::make_unique<cudf::table>(std::move(topKeyColumns));
+    auto topKeys = std::make_unique<cudf::table>(std::move(topKeyColumns));
     auto probeKeys = input.select(allKeyIndices_);
     cudf::hash_join lookup(
         topKeys->view(),
@@ -894,8 +876,7 @@ CudfVectorPtr CudfTopNRowNumber::computeLimitOneRankLike(
         cudf::null_equality::EQUAL,
         0.5,
         stream);
-    auto joinIndices =
-        lookup.inner_join(probeKeys, std::nullopt, stream, mr);
+    auto joinIndices = lookup.inner_join(probeKeys, std::nullopt, stream, mr);
     auto probeIndices = cudf::column_view{
         cudf::device_span<cudf::size_type const>{*joinIndices.first}};
     result = cudf::gather(

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.h
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.h
@@ -20,8 +20,8 @@
 
 #include "velox/core/PlanNode.h"
 
-#include <cudf/types.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/types.hpp>
 
 #include <cstdint>
 #include <deque>

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.h
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.h
@@ -21,6 +21,13 @@
 #include "velox/core/PlanNode.h"
 
 #include <cudf/types.hpp>
+#include <cudf/io/parquet.hpp>
+
+#include <cstdint>
+#include <deque>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace facebook::velox::cudf_velox {
 
@@ -36,7 +43,7 @@ class CudfTopNRowNumber : public CudfOperatorBase {
       const std::shared_ptr<const core::TopNRowNumberNode>& node);
 
   bool needsInput() const override {
-    return !noMoreInput_;
+    return !noMoreInput_ && passthroughOutputs_.empty();
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -44,7 +51,7 @@ class CudfTopNRowNumber : public CudfOperatorBase {
   }
 
   bool isFinished() override {
-    return finished_;
+    return finished_ && passthroughOutputs_.empty();
   }
 
   static bool shouldReplace(
@@ -54,8 +61,24 @@ class CudfTopNRowNumber : public CudfOperatorBase {
   void doAddInput(RowVectorPtr input) override;
   RowVectorPtr doGetOutput() override;
   void doNoMoreInput() override;
+  void doClose() override;
 
  private:
+  void spillSortedRun();
+  void compactSortedRunsForMerge();
+  void initializeSortedRunReaders();
+  std::unique_ptr<cudf::table> mergeNextSortedBatch(
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr,
+      bool& finalBatch);
+  std::unique_ptr<cudf::table> takeCompletePartitions(
+      std::unique_ptr<cudf::table> sorted,
+      bool finalBatch,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+  CudfVectorPtr computeNextSortedOutput();
+  void cleanupSpillFiles();
+
   CudfVectorPtr computeLimitOneRowNumber(
       cudf::table_view input,
       rmm::cuda_stream_view stream,
@@ -64,11 +87,16 @@ class CudfTopNRowNumber : public CudfOperatorBase {
       cudf::table_view input,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr);
+  std::unique_ptr<cudf::table> reduceToCandidates(
+      cudf::table_view input,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
 
   const int32_t limit_;
   const core::TopNRowNumberNode::RankFunction rankFunction_;
   const bool generateRowNumber_;
   const RowTypePtr inputType_;
+  const core::PlanNodeId diagnosticNodeId_;
 
   std::vector<cudf::size_type> partitionKeys_;
   std::vector<cudf::size_type> sortKeys_;
@@ -76,7 +104,34 @@ class CudfTopNRowNumber : public CudfOperatorBase {
   std::vector<cudf::order> columnOrders_;
   std::vector<cudf::null_order> nullOrders_;
 
+  // A boolean partition key whose name starts with this marker makes Top-N
+  // conditional: false rows are known singleton/pass-through partitions and
+  // can be emitted immediately; only true rows enter rank state.  This keeps
+  // one input scan while avoiding state for high-volume unaffected rows.
+  std::optional<cudf::size_type> passthroughKey_;
+  std::deque<CudfVectorPtr> passthroughOutputs_;
+
   std::vector<CudfVectorPtr> inputs_;
+  // Incremental per-partition Top-1 state. Every input batch is reduced first,
+  // then merged with this already-reduced state and reduced again. For
+  // row_number this is at most one row per partition; rank/dense_rank retain
+  // only ties for the current best sort key. Device residency therefore
+  // depends on candidate cardinality, not total input rows.
+  std::unique_ptr<cudf::table> candidates_;
+  uint64_t bufferedBytes_{0};
+  uint64_t nextDiagnosticBufferedBytes_{512ULL << 20};
+  struct SortedRun {
+    std::string path;
+    std::unique_ptr<cudf::io::chunked_parquet_reader> reader;
+  };
+  std::vector<SortedRun> sortedRuns_;
+  std::string spillDirectory_;
+  uint64_t spillFileSequence_{0};
+  std::unique_ptr<cudf::table> mergeCarry_;
+  std::unique_ptr<cudf::table> partitionCarry_;
+  bool readersInitialized_{false};
+  bool mergeFinished_{false};
+  bool spilled_{false};
   bool finished_{false};
 };
 

--- a/velox/experimental/cudf/exec/CudfUnnest.cpp
+++ b/velox/experimental/cudf/exec/CudfUnnest.cpp
@@ -21,6 +21,7 @@
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include <cudf/binaryop.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/lists/explode.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/unary.hpp>
@@ -28,6 +29,12 @@
 namespace facebook::velox::cudf_velox {
 
 namespace {
+
+// Bound expanding-operator output before it reaches blocking consumers such
+// as OrderBy. This is input rows (not bytes); at a 10x expansion factor it
+// yields batches around a few hundred MiB.
+// Parquet reader chunk/pass limits remain independent and unbounded.
+constexpr cudf::size_type kMaxUnnestInputRowsPerOutput = 262144;
 
 column_index_t fieldChannel(
     const RowTypePtr& inputType,
@@ -110,83 +117,89 @@ CudfUnnest::CudfUnnest(
 void CudfUnnest::doAddInput(RowVectorPtr input) {
   VELOX_CHECK_NULL(input_);
   input_ = std::move(input);
+  inputRowOffset_ = 0;
 }
 
 RowVectorPtr CudfUnnest::doGetOutput() {
-  if (!input_) {
-    return nullptr;
-  }
+  while (input_) {
+    if (input_->size() == 0) {
+      input_.reset();
+      return nullptr;
+    }
 
-  if (input_->size() == 0) {
-    input_.reset();
-    return nullptr;
-  }
+    auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
+    VELOX_CHECK_NOT_NULL(cudfInput);
+    auto stream = cudfInput->stream();
+    auto* inputPool = input_->pool();
+    const auto inputSize = static_cast<cudf::size_type>(input_->size());
+    const auto end = std::min(
+        inputSize, inputRowOffset_ + kMaxUnnestInputRowsPerOutput);
 
-  auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
-  VELOX_CHECK_NOT_NULL(cudfInput);
-  auto stream = cudfInput->stream();
-  auto inputColumns = cudfInput->release()->release();
+    const auto inputView = cudfInput->getTableView();
+    std::vector<cudf::column_view> explodeInputColumns;
+    explodeInputColumns.reserve(replicateChannels_.size() + 1);
+    for (const auto channel : replicateChannels_) {
+      explodeInputColumns.push_back(inputView.column(channel));
+    }
+    explodeInputColumns.push_back(inputView.column(unnestChannel_));
+    auto slices = cudf::slice(
+        cudf::table_view{explodeInputColumns},
+        {inputRowOffset_, end},
+        stream);
+    VELOX_CHECK_EQ(slices.size(), 1);
+    inputRowOffset_ = end;
 
-  std::vector<std::unique_ptr<cudf::column>> explodeInputColumns;
-  explodeInputColumns.reserve(replicateChannels_.size() + 1);
-  for (const auto channel : replicateChannels_) {
-    VELOX_CHECK_NOT_NULL(inputColumns[channel]);
-    explodeInputColumns.push_back(std::move(inputColumns[channel]));
-  }
-  VELOX_CHECK_NOT_NULL(inputColumns[unnestChannel_]);
-  explodeInputColumns.push_back(std::move(inputColumns[unnestChannel_]));
+    const auto explodeColumnIdx =
+        static_cast<cudf::size_type>(replicateChannels_.size());
+    auto exploded = hasOrdinality_
+        ? cudf::explode_position(
+              slices.front(), explodeColumnIdx, stream, get_output_mr())
+        : cudf::explode(
+              slices.front(), explodeColumnIdx, stream, get_output_mr());
 
-  auto explodeInput =
-      std::make_unique<cudf::table>(std::move(explodeInputColumns));
-  const auto explodeColumnIdx =
-      static_cast<cudf::size_type>(replicateChannels_.size());
-  auto exploded = hasOrdinality_
-      ? cudf::explode_position(
-            explodeInput->view(), explodeColumnIdx, stream, get_output_mr())
-      : cudf::explode(
-            explodeInput->view(), explodeColumnIdx, stream, get_output_mr());
+    if (inputRowOffset_ >= inputSize) {
+      input_.reset();
+      inputRowOffset_ = 0;
+    }
 
-  const auto outputSize = exploded->num_rows();
-  if (outputSize == 0) {
-    input_.reset();
-    return nullptr;
-  }
+    const auto outputSize = exploded->num_rows();
+    if (outputSize == 0) {
+      continue;
+    }
 
-  auto explodedColumns = exploded->release();
-  if (!hasOrdinality_) {
-    auto output = std::make_shared<CudfVector>(
-        input_->pool(),
+    auto explodedColumns = exploded->release();
+    if (!hasOrdinality_) {
+      return std::make_shared<CudfVector>(
+          inputPool,
+          outputType_,
+          outputSize,
+          std::make_unique<cudf::table>(std::move(explodedColumns)),
+          stream);
+    }
+
+    const auto replicatedColumnCount = replicateChannels_.size();
+    VELOX_CHECK_EQ(explodedColumns.size(), replicatedColumnCount + 2);
+
+    std::vector<std::unique_ptr<cudf::column>> outputColumns;
+    outputColumns.reserve(outputType_->size());
+    for (column_index_t i = 0; i < replicatedColumnCount; ++i) {
+      outputColumns.push_back(std::move(explodedColumns[i]));
+    }
+
+    const auto positionColumn = replicatedColumnCount;
+    const auto valueColumn = replicatedColumnCount + 1;
+    outputColumns.push_back(std::move(explodedColumns[valueColumn]));
+    outputColumns.push_back(makeVeloxOrdinality(
+        explodedColumns[positionColumn]->view(), stream, get_output_mr()));
+
+    return std::make_shared<CudfVector>(
+        inputPool,
         outputType_,
         outputSize,
-        std::make_unique<cudf::table>(std::move(explodedColumns)),
+        std::make_unique<cudf::table>(std::move(outputColumns)),
         stream);
-    input_.reset();
-    return output;
   }
-
-  const auto replicatedColumnCount = replicateChannels_.size();
-  VELOX_CHECK_EQ(explodedColumns.size(), replicatedColumnCount + 2);
-
-  std::vector<std::unique_ptr<cudf::column>> outputColumns;
-  outputColumns.reserve(outputType_->size());
-  for (column_index_t i = 0; i < replicatedColumnCount; ++i) {
-    outputColumns.push_back(std::move(explodedColumns[i]));
-  }
-
-  const auto positionColumn = replicatedColumnCount;
-  const auto valueColumn = replicatedColumnCount + 1;
-  outputColumns.push_back(std::move(explodedColumns[valueColumn]));
-  outputColumns.push_back(makeVeloxOrdinality(
-      explodedColumns[positionColumn]->view(), stream, get_output_mr()));
-
-  auto output = std::make_shared<CudfVector>(
-      input_->pool(),
-      outputType_,
-      outputSize,
-      std::make_unique<cudf::table>(std::move(outputColumns)),
-      stream);
-  input_.reset();
-  return output;
+  return nullptr;
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfUnnest.cpp
+++ b/velox/experimental/cudf/exec/CudfUnnest.cpp
@@ -132,8 +132,8 @@ RowVectorPtr CudfUnnest::doGetOutput() {
     auto stream = cudfInput->stream();
     auto* inputPool = input_->pool();
     const auto inputSize = static_cast<cudf::size_type>(input_->size());
-    const auto end = std::min(
-        inputSize, inputRowOffset_ + kMaxUnnestInputRowsPerOutput);
+    const auto end =
+        std::min(inputSize, inputRowOffset_ + kMaxUnnestInputRowsPerOutput);
 
     const auto inputView = cudfInput->getTableView();
     std::vector<cudf::column_view> explodeInputColumns;
@@ -143,9 +143,7 @@ RowVectorPtr CudfUnnest::doGetOutput() {
     }
     explodeInputColumns.push_back(inputView.column(unnestChannel_));
     auto slices = cudf::slice(
-        cudf::table_view{explodeInputColumns},
-        {inputRowOffset_, end},
-        stream);
+        cudf::table_view{explodeInputColumns}, {inputRowOffset_, end}, stream);
     VELOX_CHECK_EQ(slices.size(), 1);
     inputRowOffset_ = end;
 

--- a/velox/experimental/cudf/exec/CudfUnnest.h
+++ b/velox/experimental/cudf/exec/CudfUnnest.h
@@ -52,6 +52,7 @@ class CudfUnnest : public CudfOperatorBase {
   std::vector<column_index_t> replicateChannels_;
   column_index_t unnestChannel_;
   bool hasOrdinality_;
+  cudf::size_type inputRowOffset_{0};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfValues.cpp
+++ b/velox/experimental/cudf/exec/CudfValues.cpp
@@ -52,8 +52,9 @@ void CudfValues::initialize() {
   for (auto& vector : valueNodes_->values()) {
     if (vector->size() > 0) {
       if (valueNodes_->testingIsParallelizable()) {
-        values_.emplace_back(std::static_pointer_cast<RowVector>(
-            vector->testingCopyPreserveEncodings()));
+        values_.emplace_back(
+            std::static_pointer_cast<RowVector>(
+                vector->testingCopyPreserveEncodings()));
       } else {
         values_.emplace_back(vector);
       }

--- a/velox/experimental/cudf/exec/CudfValues.h
+++ b/velox/experimental/cudf/exec/CudfValues.h
@@ -16,9 +16,10 @@
 
 #pragma once
 
+#include "velox/experimental/cudf/exec/CudfOperator.h"
+
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Operator.h"
-#include "velox/experimental/cudf/exec/CudfOperator.h"
 
 namespace facebook::velox::cudf_velox {
 

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "velox/experimental/cudf/exec/CudfWindow.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/exec/CudfWindow.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
@@ -35,11 +35,12 @@
 #include <cudf/sorting.hpp>
 #include <cudf/unary.hpp>
 
+#include <malloc.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <atomic>
 #include <filesystem>
-#include <malloc.h>
-#include <unistd.h>
 
 namespace facebook::velox::cudf_velox {
 namespace {
@@ -77,8 +78,7 @@ bool isFieldAccessExpr(const core::TypedExprPtr& expr) {
 
 bool isUnboundedPrecedingToCurrentRowFrame(
     const core::WindowNode::Frame& frame) {
-  return frame.startType ==
-      core::WindowNode::BoundType::kUnboundedPreceding &&
+  return frame.startType == core::WindowNode::BoundType::kUnboundedPreceding &&
       frame.endType == core::WindowNode::BoundType::kCurrentRow &&
       frame.startValue == nullptr && frame.endValue == nullptr;
 }
@@ -127,8 +127,7 @@ bool isSupportedFullPartitionSumFunction(
   return isFieldAccessExpr(input) && isSupportedSumInputType(input->type());
 }
 
-bool isSupportedRunningSumFunction(
-    const core::WindowNode::Function& function) {
+bool isSupportedRunningSumFunction(const core::WindowNode::Function& function) {
   if (function.functionCall->name() != "sum" || function.ignoreNulls ||
       function.functionCall->inputs().size() != 1 ||
       function.frame.type != core::WindowNode::WindowType::kRows ||
@@ -139,8 +138,7 @@ bool isSupportedRunningSumFunction(
   return isFieldAccessExpr(input) && isSupportedSumInputType(input->type());
 }
 
-bool isSupportedFirstValueFunction(
-    const core::WindowNode::Function& function) {
+bool isSupportedFirstValueFunction(const core::WindowNode::Function& function) {
   const auto& name = function.functionCall->name();
   if ((name != "first" && name != "first_value") || function.ignoreNulls ||
       function.functionCall->inputs().size() != 1 ||
@@ -225,8 +223,7 @@ bool isSupportedCudfWindowNode(
     return false;
   }
 
-  if ((hasRowNumber || hasFirstValue || hasRunningSum) &&
-      hasFullPartitionSum) {
+  if ((hasRowNumber || hasFirstValue || hasRunningSum) && hasFullPartitionSum) {
     return false;
   }
 
@@ -278,8 +275,7 @@ CudfWindow::CudfWindow(
 
     const auto& order = sortingOrders[i];
     sortOrders_.push_back(
-        order.isAscending() ? cudf::order::ASCENDING
-                            : cudf::order::DESCENDING);
+        order.isAscending() ? cudf::order::ASCENDING : cudf::order::DESCENDING);
     sortNullOrders_.push_back(
         (order.isNullsFirst() ^ !order.isAscending())
             ? cudf::null_order::BEFORE
@@ -299,13 +295,14 @@ void CudfWindow::doAddInput(RowVectorPtr input) {
 
   if (deviceMemoryDiagnosticsEnabled() &&
       bufferedBytes_ >= nextDiagnosticBufferedBytes_) {
-    logDeviceMemorySnapshot(fmt::format(
-        "operator=CudfWindow node={} state=buffering bufferedBytes={} "
-        "bufferedInputs={} spilled={}",
-        windowNode_->id(),
-        bufferedBytes_,
-        inputs_.size(),
-        spilled_));
+    logDeviceMemorySnapshot(
+        fmt::format(
+            "operator=CudfWindow node={} state=buffering bufferedBytes={} "
+            "bufferedInputs={} spilled={}",
+            windowNode_->id(),
+            bufferedBytes_,
+            inputs_.size(),
+            spilled_));
     while (nextDiagnosticBufferedBytes_ <= bufferedBytes_) {
       nextDiagnosticBufferedBytes_ += 512ULL << 20;
     }
@@ -380,12 +377,11 @@ void CudfWindow::spillSortedRun() {
   namespace fs = std::filesystem;
   if (!spilled_) {
     const auto sequence = windowSpillDirectorySequence.fetch_add(1);
-    spillDirectory_ = (
-        fs::temp_directory_path() /
-        fmt::format(
-            "velox-cudf-window-spill-{}-{}",
-            static_cast<int64_t>(::getpid()),
-            sequence))
+    spillDirectory_ = (fs::temp_directory_path() /
+                       fmt::format(
+                           "velox-cudf-window-spill-{}-{}",
+                           static_cast<int64_t>(::getpid()),
+                           sequence))
                           .string();
     fs::create_directories(spillDirectory_);
     spilled_ = true;
@@ -393,12 +389,13 @@ void CudfWindow::spillSortedRun() {
 
   auto stream = cudfGlobalStreamPool().get_stream();
   auto mr = get_output_mr();
-  logDeviceMemorySnapshot(fmt::format(
-      "operator=CudfWindow node={} state=sortRun.concatenate.begin "
-      "bufferedBytes={} bufferedInputs={}",
-      windowNode_->id(),
-      bufferedBytes_,
-      inputs_.size()));
+  logDeviceMemorySnapshot(
+      fmt::format(
+          "operator=CudfWindow node={} state=sortRun.concatenate.begin "
+          "bufferedBytes={} bufferedInputs={}",
+          windowNode_->id(),
+          bufferedBytes_,
+          inputs_.size()));
   auto input =
       getConcatenatedTable(std::exchange(inputs_, {}), inputType_, stream, mr);
   bufferedBytes_ = 0;
@@ -414,10 +411,11 @@ void CudfWindow::spillSortedRun() {
   nullOrders.insert(
       nullOrders.end(), sortNullOrders_.begin(), sortNullOrders_.end());
 
-  logDeviceMemorySnapshot(fmt::format(
-      "operator=CudfWindow node={} state=sortRun.sort.begin rows={}",
-      windowNode_->id(),
-      input->num_rows()));
+  logDeviceMemorySnapshot(
+      fmt::format(
+          "operator=CudfWindow node={} state=sortRun.sort.begin rows={}",
+          windowNode_->id(),
+          input->num_rows()));
   auto sorted = cudf::sort_by_key(
       input->view(),
       input->view().select(sortChannels),
@@ -425,10 +423,11 @@ void CudfWindow::spillSortedRun() {
       nullOrders,
       stream,
       mr);
-  logDeviceMemorySnapshot(fmt::format(
-      "operator=CudfWindow node={} state=sortRun.sort.end rows={}",
-      windowNode_->id(),
-      input->num_rows()));
+  logDeviceMemorySnapshot(
+      fmt::format(
+          "operator=CudfWindow node={} state=sortRun.sort.end rows={}",
+          windowNode_->id(),
+          input->num_rows()));
 
   auto path = fmt::format(
       "{}/run-{:06}.parquet", spillDirectory_, spillFileSequence_++);
@@ -515,8 +514,8 @@ std::unique_ptr<cudf::table> CudfWindow::mergeNextSortedBatch(
     if (mergeViews.size() == 1) {
       merged = std::make_unique<cudf::table>(mergeViews.front(), stream, mr);
     } else {
-      merged = cudf::merge(
-          mergeViews, sortChannels, orders, nullOrders, stream, mr);
+      merged =
+          cudf::merge(mergeViews, sortChannels, orders, nullOrders, stream, mr);
     }
     mergeCarry_.reset();
 
@@ -545,8 +544,8 @@ std::unique_ptr<cudf::table> CudfWindow::mergeNextSortedBatch(
         stream,
         mr);
     const auto safeEnd = firstSearchPosition(positions->view(), stream);
-    mergeCarry_ = copyTableSlice(
-        merged->view(), safeEnd, merged->num_rows(), stream, mr);
+    mergeCarry_ =
+        copyTableSlice(merged->view(), safeEnd, merged->num_rows(), stream, mr);
     if (safeEnd > 0) {
       return copyTableSlice(merged->view(), 0, safeEnd, stream, mr);
     }
@@ -574,20 +573,13 @@ std::unique_ptr<cudf::table> CudfWindow::takeCompletePartitions(
 
   auto partitionColumns = sorted->view().select(partitionKeyChannels_);
   auto lastPartition = cudf::slice(
-      partitionColumns,
-      {sorted->num_rows() - 1, sorted->num_rows()},
-      stream);
+      partitionColumns, {sorted->num_rows() - 1, sorted->num_rows()}, stream);
   std::vector<cudf::order> orders(
       partitionKeyChannels_.size(), cudf::order::ASCENDING);
   std::vector<cudf::null_order> nullOrders(
       partitionKeyChannels_.size(), cudf::null_order::BEFORE);
   auto positions = cudf::lower_bound(
-      partitionColumns,
-      lastPartition.front(),
-      orders,
-      nullOrders,
-      stream,
-      mr);
+      partitionColumns, lastPartition.front(), orders, nullOrders, stream, mr);
   const auto completeEnd = firstSearchPosition(positions->view(), stream);
   partitionCarry_ = copyTableSlice(
       sorted->view(), completeEnd, sorted->num_rows(), stream, mr);
@@ -613,8 +605,8 @@ CudfVectorPtr CudfWindow::computeNextSortedOutput() {
       }
       partitionCarry_.reset();
     } else {
-      sorted = takeCompletePartitions(
-          std::move(sorted), finalBatch, stream, mr);
+      sorted =
+          takeCompletePartitions(std::move(sorted), finalBatch, stream, mr);
     }
     if (!sorted || sorted->num_rows() == 0) {
       if (finalBatch) {
@@ -622,8 +614,7 @@ CudfVectorPtr CudfWindow::computeNextSortedOutput() {
       }
       continue;
     }
-    auto output =
-        computeOutputTable(std::move(sorted), stream, mr, true);
+    auto output = computeOutputTable(std::move(sorted), stream, mr, true);
     return std::make_shared<CudfVector>(
         pool(), outputType_, output->num_rows(), std::move(output), stream);
   }
@@ -661,10 +652,7 @@ std::unique_ptr<cudf::column> CudfWindow::computeRowNumberColumn(
   std::unique_ptr<cudf::column> rowNumber;
   if (partitionKeyChannels_.empty()) {
     auto aggregation = cudf::make_rank_aggregation<cudf::scan_aggregation>(
-        cudf::rank_method::FIRST,
-        order,
-        cudf::null_policy::INCLUDE,
-        nullOrder);
+        cudf::rank_method::FIRST, order, cudf::null_policy::INCLUDE, nullOrder);
     rowNumber = cudf::scan(
         valuesColumn,
         *aggregation,
@@ -710,7 +698,8 @@ std::unique_ptr<cudf::column> CudfWindow::computeRankColumn(
     const TypePtr& expectedType,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const {
-  auto rowNumber = computeRowNumberColumn(sortedInput, expectedType, stream, mr);
+  auto rowNumber =
+      computeRowNumberColumn(sortedInput, expectedType, stream, mr);
 
   std::vector<cudf::size_type> rankKeyChannels = partitionKeyChannels_;
   rankKeyChannels.insert(
@@ -784,8 +773,7 @@ std::unique_ptr<cudf::column> CudfWindow::computeFullPartitionSumColumn(
   const auto valueChannel =
       exec::exprToChannel(function.functionCall->inputs()[0].get(), inputType_);
   VELOX_CHECK(
-      valueChannel != kConstantChannel,
-      "Window sum input must be a column");
+      valueChannel != kConstantChannel, "Window sum input must be a column");
 
   auto partitionColumns = selectColumns(input, partitionKeyChannels_);
 
@@ -896,8 +884,7 @@ std::unique_ptr<cudf::column> CudfWindow::computePartitionFirstColumn(
   const auto valueChannel =
       exec::exprToChannel(function.functionCall->inputs()[0].get(), inputType_);
   VELOX_CHECK(
-      valueChannel != kConstantChannel,
-      "Window first input must be a column");
+      valueChannel != kConstantChannel, "Window first input must be a column");
 
   auto partitionColumns = selectColumns(sortedInput, partitionKeyChannels_);
 

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -24,17 +24,32 @@
 
 #include <cudf/aggregation.hpp>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/groupby.hpp>
+#include <cudf/io/parquet.hpp>
 #include <cudf/join/hash_join.hpp>
+#include <cudf/merge.hpp>
 #include <cudf/reduction.hpp>
+#include <cudf/search.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/unary.hpp>
 
 #include <algorithm>
+#include <atomic>
+#include <filesystem>
+#include <malloc.h>
+#include <unistd.h>
 
 namespace facebook::velox::cudf_velox {
 namespace {
+
+// A sorted run is deliberately much larger than an exchange/read batch.  On a
+// 32 GiB device this leaves enough room for concatenate + stable sort while
+// avoiding the thousands of tiny spill files produced by hash bucketing.
+constexpr uint64_t kWindowSortedRunBytes = 3ULL << 30;
+constexpr uint64_t kWindowMergeChunkBytes = 256ULL << 20;
+std::atomic<uint64_t> windowSpillDirectorySequence{0};
 
 bool isSupportedScalarWindowType(const TypePtr& type) {
   switch (type->kind()) {
@@ -112,6 +127,18 @@ bool isSupportedFullPartitionSumFunction(
   return isFieldAccessExpr(input) && isSupportedSumInputType(input->type());
 }
 
+bool isSupportedRunningSumFunction(
+    const core::WindowNode::Function& function) {
+  if (function.functionCall->name() != "sum" || function.ignoreNulls ||
+      function.functionCall->inputs().size() != 1 ||
+      function.frame.type != core::WindowNode::WindowType::kRows ||
+      !isUnboundedPrecedingToCurrentRowFrame(function.frame)) {
+    return false;
+  }
+  const auto& input = function.functionCall->inputs()[0];
+  return isFieldAccessExpr(input) && isSupportedSumInputType(input->type());
+}
+
 bool isSupportedFirstValueFunction(
     const core::WindowNode::Function& function) {
   const auto& name = function.functionCall->name();
@@ -136,6 +163,33 @@ std::vector<cudf::column_view> selectColumns(
   return columns;
 }
 
+std::unique_ptr<cudf::table> copyTableSlice(
+    cudf::table_view input,
+    cudf::size_type begin,
+    cudf::size_type end,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_LE(begin, end);
+  auto slices = cudf::slice(input, {begin, end}, stream);
+  VELOX_CHECK_EQ(slices.size(), 1);
+  return std::make_unique<cudf::table>(slices.front(), stream, mr);
+}
+
+cudf::size_type firstSearchPosition(
+    cudf::column_view positions,
+    rmm::cuda_stream_view stream) {
+  VELOX_CHECK_EQ(positions.size(), 1);
+  cudf::size_type result{0};
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      &result,
+      positions.data<cudf::size_type>(),
+      sizeof(result),
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+  stream.synchronize();
+  return result;
+}
+
 } // namespace
 
 bool isSupportedCudfWindowNode(
@@ -146,12 +200,15 @@ bool isSupportedCudfWindowNode(
 
   bool hasRowNumber = false;
   bool hasFullPartitionSum = false;
+  bool hasRunningSum = false;
   bool hasFirstValue = false;
   for (const auto& function : node->windowFunctions()) {
     if (isSupportedRankLikeFunction(function)) {
       hasRowNumber = true;
     } else if (isSupportedFullPartitionSumFunction(function)) {
       hasFullPartitionSum = true;
+    } else if (isSupportedRunningSumFunction(function)) {
+      hasRunningSum = true;
     } else if (isSupportedFirstValueFunction(function)) {
       hasFirstValue = true;
     } else {
@@ -159,7 +216,8 @@ bool isSupportedCudfWindowNode(
     }
   }
 
-  if ((hasRowNumber || hasFirstValue) && node->sortingKeys().empty()) {
+  if ((hasRowNumber || hasFirstValue || hasRunningSum) &&
+      node->sortingKeys().empty()) {
     return false;
   }
 
@@ -167,7 +225,8 @@ bool isSupportedCudfWindowNode(
     return false;
   }
 
-  if ((hasRowNumber || hasFirstValue) && hasFullPartitionSum) {
+  if ((hasRowNumber || hasFirstValue || hasRunningSum) &&
+      hasFullPartitionSum) {
     return false;
   }
 
@@ -235,18 +294,57 @@ void CudfWindow::doAddInput(RowVectorPtr input) {
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput, "Expected CudfVector input");
+  bufferedBytes_ += cudfInput->estimateFlatSize();
   inputs_.push_back(std::move(cudfInput));
+
+  if (deviceMemoryDiagnosticsEnabled() &&
+      bufferedBytes_ >= nextDiagnosticBufferedBytes_) {
+    logDeviceMemorySnapshot(fmt::format(
+        "operator=CudfWindow node={} state=buffering bufferedBytes={} "
+        "bufferedInputs={} spilled={}",
+        windowNode_->id(),
+        bufferedBytes_,
+        inputs_.size(),
+        spilled_));
+    while (nextDiagnosticBufferedBytes_ <= bufferedBytes_) {
+      nextDiagnosticBufferedBytes_ += 512ULL << 20;
+    }
+  }
+
+  // Build independently sorted runs.  After noMoreInput() these runs are read
+  // in chunks and order-merged, matching Velox CPU SortWindowBuild's external
+  // sort architecture.
+  if (!windowNode_->inputsSorted() && !partitionKeyChannels_.empty() &&
+      bufferedBytes_ >= kWindowSortedRunBytes) {
+    spillSortedRun();
+  }
 }
 
 void CudfWindow::doNoMoreInput() {
   Operator::noMoreInput();
-  if (inputs_.empty()) {
+  if (spilled_ && !inputs_.empty()) {
+    spillSortedRun();
+  }
+  if (spilled_) {
+    initializeSortedRunReaders();
+  }
+  if (!spilled_ && inputs_.empty()) {
     finished_ = true;
   }
 }
 
 RowVectorPtr CudfWindow::doGetOutput() {
   if (finished_ || !noMoreInput_) {
+    return nullptr;
+  }
+
+  if (spilled_) {
+    auto result = computeNextSortedOutput();
+    if (result != nullptr) {
+      return result;
+    }
+    finished_ = true;
+    cleanupSpillFiles();
     return nullptr;
   }
 
@@ -259,6 +357,7 @@ RowVectorPtr CudfWindow::doGetOutput() {
   auto mr = get_output_mr();
   auto input = getConcatenatedTable(std::move(inputs_), inputType_, stream, mr);
   inputs_.clear();
+  bufferedBytes_ = 0;
 
   auto output = computeOutputTable(std::move(input), stream, mr);
   finished_ = true;
@@ -268,6 +367,286 @@ RowVectorPtr CudfWindow::doGetOutput() {
 
   return std::make_shared<CudfVector>(
       pool(), outputType_, output->num_rows(), std::move(output), stream);
+}
+
+void CudfWindow::spillSortedRun() {
+  if (inputs_.empty()) {
+    return;
+  }
+  VELOX_CHECK(
+      !partitionKeyChannels_.empty(),
+      "CudfWindow spill requires partition keys");
+
+  namespace fs = std::filesystem;
+  if (!spilled_) {
+    const auto sequence = windowSpillDirectorySequence.fetch_add(1);
+    spillDirectory_ = (
+        fs::temp_directory_path() /
+        fmt::format(
+            "velox-cudf-window-spill-{}-{}",
+            static_cast<int64_t>(::getpid()),
+            sequence))
+                          .string();
+    fs::create_directories(spillDirectory_);
+    spilled_ = true;
+  }
+
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfWindow node={} state=sortRun.concatenate.begin "
+      "bufferedBytes={} bufferedInputs={}",
+      windowNode_->id(),
+      bufferedBytes_,
+      inputs_.size()));
+  auto input =
+      getConcatenatedTable(std::exchange(inputs_, {}), inputType_, stream, mr);
+  bufferedBytes_ = 0;
+
+  std::vector<cudf::size_type> sortChannels = partitionKeyChannels_;
+  sortChannels.insert(
+      sortChannels.end(), sortKeyChannels_.begin(), sortKeyChannels_.end());
+  std::vector<cudf::order> orders(
+      partitionKeyChannels_.size(), cudf::order::ASCENDING);
+  orders.insert(orders.end(), sortOrders_.begin(), sortOrders_.end());
+  std::vector<cudf::null_order> nullOrders(
+      partitionKeyChannels_.size(), cudf::null_order::BEFORE);
+  nullOrders.insert(
+      nullOrders.end(), sortNullOrders_.begin(), sortNullOrders_.end());
+
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfWindow node={} state=sortRun.sort.begin rows={}",
+      windowNode_->id(),
+      input->num_rows()));
+  auto sorted = cudf::sort_by_key(
+      input->view(),
+      input->view().select(sortChannels),
+      orders,
+      nullOrders,
+      stream,
+      mr);
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfWindow node={} state=sortRun.sort.end rows={}",
+      windowNode_->id(),
+      input->num_rows()));
+
+  auto path = fmt::format(
+      "{}/run-{:06}.parquet", spillDirectory_, spillFileSequence_++);
+  auto options = cudf::io::parquet_writer_options::builder(
+                     cudf::io::sink_info{path}, sorted->view())
+                     .build();
+  cudf::io::write_parquet(options, stream);
+  sortedRuns_.push_back({std::move(path), nullptr});
+  ::malloc_trim(0);
+}
+
+void CudfWindow::initializeSortedRunReaders() {
+  if (readersInitialized_) {
+    return;
+  }
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+  for (auto& run : sortedRuns_) {
+    auto options = cudf::io::parquet_reader_options::builder(
+                       cudf::io::source_info{run.path})
+                       .build();
+    run.reader = std::make_unique<cudf::io::chunked_parquet_reader>(
+        kWindowMergeChunkBytes, 0, options, stream, mr);
+  }
+  readersInitialized_ = true;
+}
+
+std::unique_ptr<cudf::table> CudfWindow::mergeNextSortedBatch(
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    bool& finalBatch) {
+  finalBatch = false;
+  while (!mergeFinished_) {
+    std::vector<std::unique_ptr<cudf::table>> chunks;
+    std::vector<cudf::table_view> mergeViews;
+    std::vector<cudf::table_view> boundaryRows;
+    chunks.reserve(sortedRuns_.size());
+    mergeViews.reserve(sortedRuns_.size() + (mergeCarry_ ? 1 : 0));
+    boundaryRows.reserve(sortedRuns_.size());
+
+    if (mergeCarry_ && mergeCarry_->num_rows() > 0) {
+      mergeViews.push_back(mergeCarry_->view());
+    }
+
+    for (auto& run : sortedRuns_) {
+      if (!run.reader || !run.reader->has_next()) {
+        continue;
+      }
+      auto chunk = run.reader->read_chunk();
+      if (chunk.tbl->num_rows() == 0) {
+        continue;
+      }
+      chunks.push_back(std::move(chunk.tbl));
+      mergeViews.push_back(chunks.back()->view());
+      // Only a run with unread rows can constrain the globally safe prefix.
+      // Rows in its next chunk are >= the final row of this chunk.
+      if (run.reader->has_next()) {
+        auto last = cudf::slice(
+            chunks.back()->view(),
+            {chunks.back()->num_rows() - 1, chunks.back()->num_rows()},
+            stream);
+        boundaryRows.push_back(last.front());
+      }
+    }
+
+    if (mergeViews.empty()) {
+      mergeFinished_ = true;
+      finalBatch = true;
+      return std::exchange(mergeCarry_, nullptr);
+    }
+
+    std::vector<cudf::size_type> sortChannels = partitionKeyChannels_;
+    sortChannels.insert(
+        sortChannels.end(), sortKeyChannels_.begin(), sortKeyChannels_.end());
+    std::vector<cudf::order> orders(
+        partitionKeyChannels_.size(), cudf::order::ASCENDING);
+    orders.insert(orders.end(), sortOrders_.begin(), sortOrders_.end());
+    std::vector<cudf::null_order> nullOrders(
+        partitionKeyChannels_.size(), cudf::null_order::BEFORE);
+    nullOrders.insert(
+        nullOrders.end(), sortNullOrders_.begin(), sortNullOrders_.end());
+
+    std::unique_ptr<cudf::table> merged;
+    if (mergeViews.size() == 1) {
+      merged = std::make_unique<cudf::table>(mergeViews.front(), stream, mr);
+    } else {
+      merged = cudf::merge(
+          mergeViews, sortChannels, orders, nullOrders, stream, mr);
+    }
+    mergeCarry_.reset();
+
+    if (boundaryRows.empty()) {
+      mergeFinished_ = true;
+      finalBatch = true;
+      return merged;
+    }
+
+    auto boundaryCandidates = cudf::concatenate(boundaryRows, stream, mr);
+    auto sortedBoundaries = cudf::sort_by_key(
+        boundaryCandidates->view(),
+        boundaryCandidates->view().select(sortChannels),
+        orders,
+        nullOrders,
+        stream,
+        mr);
+    auto boundary = cudf::slice(sortedBoundaries->view(), {0, 1}, stream);
+    // Equal boundary keys are safe to emit: future chunks cannot contain a
+    // smaller key and cross-run ordering of peers is not stable/observable.
+    auto positions = cudf::upper_bound(
+        merged->view().select(sortChannels),
+        boundary.front().select(sortChannels),
+        orders,
+        nullOrders,
+        stream,
+        mr);
+    const auto safeEnd = firstSearchPosition(positions->view(), stream);
+    mergeCarry_ = copyTableSlice(
+        merged->view(), safeEnd, merged->num_rows(), stream, mr);
+    if (safeEnd > 0) {
+      return copyTableSlice(merged->view(), 0, safeEnd, stream, mr);
+    }
+  }
+  return nullptr;
+}
+
+std::unique_ptr<cudf::table> CudfWindow::takeCompletePartitions(
+    std::unique_ptr<cudf::table> sorted,
+    bool finalBatch,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  if (!sorted || sorted->num_rows() == 0) {
+    return nullptr;
+  }
+  if (partitionCarry_ && partitionCarry_->num_rows() > 0) {
+    std::vector<cudf::table_view> pieces{
+        partitionCarry_->view(), sorted->view()};
+    sorted = cudf::concatenate(pieces, stream, mr);
+    partitionCarry_.reset();
+  }
+  if (finalBatch || partitionKeyChannels_.empty()) {
+    return sorted;
+  }
+
+  auto partitionColumns = sorted->view().select(partitionKeyChannels_);
+  auto lastPartition = cudf::slice(
+      partitionColumns,
+      {sorted->num_rows() - 1, sorted->num_rows()},
+      stream);
+  std::vector<cudf::order> orders(
+      partitionKeyChannels_.size(), cudf::order::ASCENDING);
+  std::vector<cudf::null_order> nullOrders(
+      partitionKeyChannels_.size(), cudf::null_order::BEFORE);
+  auto positions = cudf::lower_bound(
+      partitionColumns,
+      lastPartition.front(),
+      orders,
+      nullOrders,
+      stream,
+      mr);
+  const auto completeEnd = firstSearchPosition(positions->view(), stream);
+  partitionCarry_ = copyTableSlice(
+      sorted->view(), completeEnd, sorted->num_rows(), stream, mr);
+  if (completeEnd == 0) {
+    return nullptr;
+  }
+  return copyTableSlice(sorted->view(), 0, completeEnd, stream, mr);
+}
+
+CudfVectorPtr CudfWindow::computeNextSortedOutput() {
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+  while (!mergeFinished_ || mergeCarry_ || partitionCarry_) {
+    bool finalBatch = false;
+    auto sorted = mergeNextSortedBatch(stream, mr, finalBatch);
+    if (finalBatch && partitionCarry_) {
+      if (sorted && sorted->num_rows() > 0) {
+        std::vector<cudf::table_view> pieces{
+            partitionCarry_->view(), sorted->view()};
+        sorted = cudf::concatenate(pieces, stream, mr);
+      } else {
+        sorted = std::exchange(partitionCarry_, nullptr);
+      }
+      partitionCarry_.reset();
+    } else {
+      sorted = takeCompletePartitions(
+          std::move(sorted), finalBatch, stream, mr);
+    }
+    if (!sorted || sorted->num_rows() == 0) {
+      if (finalBatch) {
+        return nullptr;
+      }
+      continue;
+    }
+    auto output =
+        computeOutputTable(std::move(sorted), stream, mr, true);
+    return std::make_shared<CudfVector>(
+        pool(), outputType_, output->num_rows(), std::move(output), stream);
+  }
+  return nullptr;
+}
+
+void CudfWindow::cleanupSpillFiles() {
+  sortedRuns_.clear();
+  mergeCarry_.reset();
+  partitionCarry_.reset();
+  if (spillDirectory_.empty()) {
+    return;
+  }
+  std::error_code error;
+  std::filesystem::remove_all(spillDirectory_, error);
+  spillDirectory_.clear();
+  ::malloc_trim(0);
+}
+
+void CudfWindow::doClose() {
+  inputs_.clear();
+  cleanupSpillFiles();
+  Operator::close();
 }
 
 std::unique_ptr<cudf::column> CudfWindow::computeRowNumberColumn(
@@ -470,6 +849,42 @@ std::unique_ptr<cudf::column> CudfWindow::computeFullPartitionSumColumn(
   return std::move(scattered->release()[0]);
 }
 
+std::unique_ptr<cudf::column> CudfWindow::computeRunningPartitionSumColumn(
+    cudf::table_view const& sortedInput,
+    const core::WindowNode::Function& function,
+    const TypePtr& expectedType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  VELOX_CHECK(!partitionKeyChannels_.empty());
+  const auto valueChannel =
+      exec::exprToChannel(function.functionCall->inputs()[0].get(), inputType_);
+  VELOX_CHECK_NE(valueChannel, kConstantChannel);
+
+  auto partitionColumns = selectColumns(sortedInput, partitionKeyChannels_);
+  std::vector<cudf::groupby::scan_request> requests(1);
+  requests[0].values = sortedInput.column(valueChannel);
+  requests[0].aggregations.push_back(
+      cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>());
+
+  cudf::groupby::groupby grouper(
+      cudf::table_view(partitionColumns),
+      cudf::null_policy::INCLUDE,
+      cudf::sorted::YES,
+      std::vector<cudf::order>(
+          partitionKeyChannels_.size(), cudf::order::ASCENDING),
+      std::vector<cudf::null_order>(
+          partitionKeyChannels_.size(), cudf::null_order::BEFORE));
+  auto scanResult = grouper.scan(requests, stream, mr);
+  VELOX_CHECK_EQ(scanResult.second.size(), 1);
+  VELOX_CHECK_EQ(scanResult.second[0].results.size(), 1);
+  auto result = std::move(scanResult.second[0].results[0]);
+  const auto expectedCudfType = veloxToCudfDataType(expectedType);
+  if (result->type() != expectedCudfType) {
+    result = cudf::cast(result->view(), expectedCudfType, stream, mr);
+  }
+  return result;
+}
+
 std::unique_ptr<cudf::column> CudfWindow::computePartitionFirstColumn(
     cudf::table_view const& sortedInput,
     const core::WindowNode::Function& function,
@@ -557,7 +972,8 @@ std::unique_ptr<cudf::column> CudfWindow::computePartitionFirstColumn(
 std::unique_ptr<cudf::table> CudfWindow::computeOutputTable(
     std::unique_ptr<cudf::table> input,
     rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) const {
+    rmm::device_async_resource_ref mr,
+    bool inputAlreadySorted) const {
   const auto inputSize = inputType_->size();
   const auto numFunctions = windowNode_->windowFunctions().size();
 
@@ -614,7 +1030,7 @@ std::unique_ptr<cudf::table> CudfWindow::computeOutputTable(
   std::unique_ptr<cudf::table> sortedTable;
   cudf::table_view sortedView;
 
-  if (windowNode_->inputsSorted()) {
+  if (inputAlreadySorted || windowNode_->inputsSorted()) {
     sortedView = inputView;
   } else {
     sortedOrder = cudf::stable_sorted_order(
@@ -639,6 +1055,13 @@ std::unique_ptr<cudf::table> CudfWindow::computeOutputTable(
           sortedView, outputType_->childAt(inputSize + i), stream, mr));
     } else if (functionName == "first" || functionName == "first_value") {
       resultColumns.push_back(computePartitionFirstColumn(
+          sortedView,
+          function,
+          outputType_->childAt(inputSize + i),
+          stream,
+          mr));
+    } else if (functionName == "sum") {
+      resultColumns.push_back(computeRunningPartitionSumColumn(
           sortedView,
           function,
           outputType_->childAt(inputSize + i),

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -21,6 +21,10 @@
 #include "velox/core/PlanNode.h"
 
 #include <cudf/types.hpp>
+#include <cudf/io/parquet.hpp>
+
+#include <string>
+#include <vector>
 
 namespace facebook::velox::cudf_velox {
 
@@ -31,6 +35,8 @@ bool isSupportedCudfWindowNode(
 /// - row_number() / rank() with the default UNBOUNDED PRECEDING to CURRENT ROW
 ///   frame.
 /// - sum(field) over a full partition ROWS frame.
+/// - sum(field) over a partitioned ordered ROWS UNBOUNDED PRECEDING to
+///   CURRENT ROW frame.
 /// - first(field) / first_value(field) over a partitioned ordered UNBOUNDED
 ///   PRECEDING to CURRENT ROW frame.
 class CudfWindow : public CudfOperatorBase {
@@ -56,6 +62,7 @@ class CudfWindow : public CudfOperatorBase {
   void doAddInput(RowVectorPtr input) override;
   RowVectorPtr doGetOutput() override;
   void doNoMoreInput() override;
+  void doClose() override;
 
  private:
   std::unique_ptr<cudf::column> computeRowNumberColumn(
@@ -77,6 +84,13 @@ class CudfWindow : public CudfOperatorBase {
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const;
 
+  std::unique_ptr<cudf::column> computeRunningPartitionSumColumn(
+      cudf::table_view const& sortedInput,
+      const core::WindowNode::Function& function,
+      const TypePtr& expectedType,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
   std::unique_ptr<cudf::column> computePartitionFirstColumn(
       cudf::table_view const& sortedInput,
       const core::WindowNode::Function& function,
@@ -87,11 +101,41 @@ class CudfWindow : public CudfOperatorBase {
   std::unique_ptr<cudf::table> computeOutputTable(
       std::unique_ptr<cudf::table> input,
       rmm::cuda_stream_view stream,
-      rmm::device_async_resource_ref mr) const;
+      rmm::device_async_resource_ref mr,
+      bool inputAlreadySorted = false) const;
+
+  void spillSortedRun();
+  void initializeSortedRunReaders();
+  std::unique_ptr<cudf::table> mergeNextSortedBatch(
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr,
+      bool& finalBatch);
+  std::unique_ptr<cudf::table> takeCompletePartitions(
+      std::unique_ptr<cudf::table> sorted,
+      bool finalBatch,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+  CudfVectorPtr computeNextSortedOutput();
+  void cleanupSpillFiles();
+
+  struct SortedRun {
+    std::string path;
+    std::unique_ptr<cudf::io::chunked_parquet_reader> reader;
+  };
 
   const std::shared_ptr<const core::WindowNode> windowNode_;
   const RowTypePtr inputType_;
   std::vector<CudfVectorPtr> inputs_;
+  uint64_t bufferedBytes_{0};
+  uint64_t nextDiagnosticBufferedBytes_{512ULL << 20};
+  std::vector<SortedRun> sortedRuns_;
+  std::string spillDirectory_;
+  uint64_t spillFileSequence_{0};
+  std::unique_ptr<cudf::table> mergeCarry_;
+  std::unique_ptr<cudf::table> partitionCarry_;
+  bool readersInitialized_{false};
+  bool mergeFinished_{false};
+  bool spilled_{false};
   bool finished_{false};
 
   std::vector<cudf::size_type> partitionKeyChannels_;

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -20,8 +20,8 @@
 
 #include "velox/core/PlanNode.h"
 
-#include <cudf/types.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/types.hpp>
 
 #include <string>
 #include <vector>

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -29,11 +29,21 @@
 #include <rmm/mr/managed_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/prefetch_resource_adaptor.hpp>
+#include <rmm/mr/statistics_resource_adaptor.hpp>
 
 #include <common/base/Exceptions.h>
 
+#include <cuda_runtime_api.h>
+#include <dlfcn.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
+#include <string>
 #include <string_view>
+#include <thread>
+#include <unistd.h>
 
 namespace facebook::velox::cudf_velox {
 
@@ -87,9 +97,115 @@ cudf::detail::cuda_stream_pool& cudfGlobalStreamPool() {
 
 std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> output_mr_;
+std::optional<rmm::mr::statistics_resource_adaptor> statistics_mr_;
+std::optional<rmm::mr::statistics_resource_adaptor> output_statistics_mr_;
 
 rmm::device_async_resource_ref get_output_mr() {
   return output_mr_.value();
+}
+
+bool deviceMemoryDiagnosticsEnabled() {
+  static const bool enabled = [] {
+    const auto* value = std::getenv("GLUTEN_CUDF_DEVICE_MEMORY_DIAGNOSTICS");
+    if (value == nullptr) {
+      return false;
+    }
+    std::string normalized{value};
+    std::transform(
+        normalized.begin(),
+        normalized.end(),
+        normalized.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return !normalized.empty() && normalized != "0" &&
+        normalized != "false" && normalized != "off" &&
+        normalized != "no";
+  }();
+  return enabled;
+}
+
+DeviceMemorySnapshot captureDeviceMemorySnapshot() {
+  DeviceMemorySnapshot snapshot;
+  snapshot.enabled = deviceMemoryDiagnosticsEnabled();
+  if (!snapshot.enabled) {
+    return snapshot;
+  }
+
+  if (cudaGetDevice(&snapshot.device) == cudaSuccess) {
+    snapshot.cudaValid =
+        cudaMemGetInfo(&snapshot.freeBytes, &snapshot.totalBytes) ==
+        cudaSuccess;
+    if (snapshot.cudaValid) {
+      snapshot.usedBytes = snapshot.totalBytes - snapshot.freeBytes;
+    }
+  }
+
+  const auto addStatistics = [&](const auto& statistics) {
+    if (!statistics.has_value()) {
+      return;
+    }
+    const auto bytes = statistics->get_bytes_counter();
+    const auto allocations = statistics->get_allocations_counter();
+    snapshot.rmmCurrentBytes += bytes.value;
+    snapshot.rmmPeakBytes += bytes.peak;
+    snapshot.rmmTotalBytes += bytes.total;
+    snapshot.rmmCurrentAllocations += allocations.value;
+    snapshot.rmmPeakAllocations += allocations.peak;
+    snapshot.rmmTotalAllocations += allocations.total;
+  };
+  addStatistics(statistics_mr_);
+  addStatistics(output_statistics_mr_);
+  return snapshot;
+}
+
+void logDeviceMemorySnapshot(
+    const std::string& label,
+    const DeviceMemorySnapshot& snapshot) {
+  if (!snapshot.enabled) {
+    return;
+  }
+  const auto* visibleDevices = std::getenv("CUDA_VISIBLE_DEVICES");
+  const auto* executorId = std::getenv("SPARK_EXECUTOR_ID");
+  LOG(WARNING) << "CUDF_DEVICE_MEMORY"
+               << " label={" << label << "}"
+               << " pid=" << static_cast<int64_t>(::getpid())
+               << " thread=" << std::this_thread::get_id()
+               << " executorId=" << (executorId == nullptr ? "" : executorId)
+               << " cudaVisibleDevices="
+               << (visibleDevices == nullptr ? "" : visibleDevices)
+               << " device=" << snapshot.device
+               << " cudaValid=" << snapshot.cudaValid
+               << " freeBytes=" << snapshot.freeBytes
+               << " totalBytes=" << snapshot.totalBytes
+               << " usedBytes=" << snapshot.usedBytes
+               << " rmmCurrentBytes=" << snapshot.rmmCurrentBytes
+               << " rmmPeakBytes=" << snapshot.rmmPeakBytes
+               << " rmmTotalBytes=" << snapshot.rmmTotalBytes
+               << " rmmCurrentAllocations="
+               << snapshot.rmmCurrentAllocations
+               << " rmmPeakAllocations=" << snapshot.rmmPeakAllocations
+               << " rmmTotalAllocations=" << snapshot.rmmTotalAllocations;
+}
+
+CudaAllocationTraceScope::CudaAllocationTraceScope(const std::string& label) {
+  using Push = void (*)(const char*);
+  static auto push = reinterpret_cast<Push>(
+      dlsym(RTLD_DEFAULT, "cuda_alloc_trace_push_context"));
+  if (push != nullptr) {
+    push(label.c_str());
+    active_ = true;
+  }
+}
+
+CudaAllocationTraceScope::~CudaAllocationTraceScope() {
+  if (!active_) {
+    return;
+  }
+  using Pop = void (*)();
+  static auto pop = reinterpret_cast<Pop>(
+      dlsym(RTLD_DEFAULT, "cuda_alloc_trace_pop_context"));
+  if (pop != nullptr) {
+    pop();
+  }
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -31,11 +31,12 @@
 #include <rmm/mr/prefetch_resource_adaptor.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
-#include <common/base/Exceptions.h>
-
 #include <cuda_runtime_api.h>
+
+#include <common/base/Exceptions.h>
 #include <dlfcn.h>
 #include <glog/logging.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cctype>
@@ -43,7 +44,6 @@
 #include <string>
 #include <string_view>
 #include <thread>
-#include <unistd.h>
 
 namespace facebook::velox::cudf_velox {
 
@@ -116,9 +116,8 @@ bool deviceMemoryDiagnosticsEnabled() {
         normalized.end(),
         normalized.begin(),
         [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-    return !normalized.empty() && normalized != "0" &&
-        normalized != "false" && normalized != "off" &&
-        normalized != "no";
+    return !normalized.empty() && normalized != "0" && normalized != "false" &&
+        normalized != "off" && normalized != "no";
   }();
   return enabled;
 }
@@ -180,8 +179,7 @@ void logDeviceMemorySnapshot(
                << " rmmCurrentBytes=" << snapshot.rmmCurrentBytes
                << " rmmPeakBytes=" << snapshot.rmmPeakBytes
                << " rmmTotalBytes=" << snapshot.rmmTotalBytes
-               << " rmmCurrentAllocations="
-               << snapshot.rmmCurrentAllocations
+               << " rmmCurrentAllocations=" << snapshot.rmmCurrentAllocations
                << " rmmPeakAllocations=" << snapshot.rmmPeakAllocations
                << " rmmTotalAllocations=" << snapshot.rmmTotalAllocations;
 }

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -18,16 +18,16 @@
 
 #include <cudf/detail/utilities/stream_pool.hpp>
 
-#include <rmm/resource_ref.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
 
-#include <optional>
-#include <cstdint>
 #include <cstddef>
-#include <string_view>
+#include <cstdint>
+#include <optional>
 #include <string>
+#include <string_view>
 
 namespace facebook::velox::cudf_velox {
 

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -19,17 +19,39 @@
 #include <cudf/detail/utilities/stream_pool.hpp>
 
 #include <rmm/resource_ref.hpp>
+#include <rmm/mr/statistics_resource_adaptor.hpp>
 
 #include <cuda/memory_resource>
 
 #include <optional>
+#include <cstdint>
+#include <cstddef>
 #include <string_view>
+#include <string>
 
 namespace facebook::velox::cudf_velox {
+
+struct DeviceMemorySnapshot {
+  bool enabled{false};
+  bool cudaValid{false};
+  int device{-1};
+  std::size_t freeBytes{0};
+  std::size_t totalBytes{0};
+  std::size_t usedBytes{0};
+  int64_t rmmCurrentBytes{0};
+  int64_t rmmPeakBytes{0};
+  int64_t rmmTotalBytes{0};
+  int64_t rmmCurrentAllocations{0};
+  int64_t rmmPeakAllocations{0};
+  int64_t rmmTotalAllocations{0};
+};
 
 extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
     output_mr_;
+extern std::optional<rmm::mr::statistics_resource_adaptor> statistics_mr_;
+extern std::optional<rmm::mr::statistics_resource_adaptor>
+    output_statistics_mr_;
 
 /// Returns the memory resource designated for output vector allocations.
 rmm::device_async_resource_ref get_output_mr();
@@ -48,5 +70,41 @@ createMemoryResource(std::string_view mode, int percent);
  * @brief Returns the global CUDA stream pool used by cudf.
  */
 [[nodiscard]] cudf::detail::cuda_stream_pool& cudfGlobalStreamPool();
+
+/// Enables low-overhead RMM statistics and operator-level CUDA memory
+/// diagnostics when GLUTEN_CUDF_DEVICE_MEMORY_DIAGNOSTICS is set to a true
+/// value in the executor environment.
+[[nodiscard]] bool deviceMemoryDiagnosticsEnabled();
+
+/// Captures both CUDA device-wide usage and allocations made through the
+/// cuDF RMM resource. Unlike cudaMemGetInfo-only diagnostics, the snapshot
+/// always includes the current CUDA device id.
+[[nodiscard]] DeviceMemorySnapshot captureDeviceMemorySnapshot();
+
+/// Emits a structured CUDF_DEVICE_MEMORY log record for later correlation
+/// with the operator node and method that triggered the sample.
+void logDeviceMemorySnapshot(
+    const std::string& label,
+    const DeviceMemorySnapshot& snapshot);
+
+inline void logDeviceMemorySnapshot(const std::string& label) {
+  if (deviceMemoryDiagnosticsEnabled()) {
+    logDeviceMemorySnapshot(label, captureDeviceMemorySnapshot());
+  }
+}
+
+/// Associates CUDA allocations on the current thread with a native operator
+/// when the optional LD_PRELOAD diagnostic tracer is present.
+class CudaAllocationTraceScope {
+ public:
+  explicit CudaAllocationTraceScope(const std::string& label);
+  ~CudaAllocationTraceScope();
+
+  CudaAllocationTraceScope(const CudaAllocationTraceScope&) = delete;
+  CudaAllocationTraceScope& operator=(const CudaAllocationTraceScope&) = delete;
+
+ private:
+  bool active_{false};
+};
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -437,8 +437,7 @@ class UnnestAdapter : public OperatorAdapter {
     auto unnestNode =
         std::dynamic_pointer_cast<const core::UnnestNode>(planNode);
     std::vector<std::unique_ptr<exec::Operator>> result;
-    result.push_back(
-        std::make_unique<CudfUnnest>(operatorId, ctx, unnestNode));
+    result.push_back(std::make_unique<CudfUnnest>(operatorId, ctx, unnestNode));
     return result;
   }
 };
@@ -818,12 +817,11 @@ class WindowAdapter : public OperatorAdapter {
       exec::DriverCtx* /*ctx*/) const override {
     auto windowNode =
         std::dynamic_pointer_cast<const core::WindowNode>(planNode);
-    const bool canRun =
-        canHandle(op) && isSupportedCudfWindowNode(windowNode);
+    const bool canRun = canHandle(op) && isSupportedCudfWindowNode(windowNode);
     if (!canRun) {
       LOG_FALLBACK(
           "WindowAdapter {}, PlanNode id: {}",
-          !canHandle(op) ? "operator is not Window"
+          !canHandle(op)    ? "operator is not Window"
               : !windowNode ? "planNode is not WindowNode"
                             : "isSupportedCudfWindowNode returned false",
           planNode->id());
@@ -1033,7 +1031,7 @@ class AssignUniqueIdAdapter : public OperatorAdapter {
   }
 };
 
-  /// ValuesAdapter - Replaces with CudfValues
+/// ValuesAdapter - Replaces with CudfValues
 class ValuesAdapter : public OperatorAdapter {
  public:
   ValuesAdapter() : OperatorAdapter("Values") {}
@@ -1260,7 +1258,7 @@ class ExchangeAdapter : public OperatorAdapter {
         std::dynamic_pointer_cast<const core::ExchangeNode>(planNode);
     const bool isUcx = exchangeNode &&
         exchangeNode->transportType() ==
-        core::ExchangeNode::TransportType::kUcx;
+            core::ExchangeNode::TransportType::kUcx;
     LOG(WARNING) << "CudfExchangeAdapter: canRunOnGPU node="
                  << (exchangeNode ? exchangeNode->id() : "<null>")
                  << " isUcx=" << isUcx
@@ -1285,10 +1283,8 @@ class ExchangeAdapter : public OperatorAdapter {
         const_cast<exec::Exchange*>(dynamic_cast<const exec::Exchange*>(op));
     VELOX_CHECK_NOT_NULL(exchangeOp);
     LOG(WARNING) << "CudfExchangeAdapter: replacing Exchange with UcxExchange"
-                 << " task=" << op->taskId()
-                 << " pipeline=" << ctx->pipelineId
-                 << " operatorId=" << operatorId
-                 << " node=" << planNode->id();
+                 << " task=" << op->taskId() << " pipeline=" << ctx->pipelineId
+                 << " operatorId=" << operatorId << " node=" << planNode->id();
 
     std::shared_ptr<ucx_exchange::UcxExchangeClient> client;
     auto key = TaskPipelineKey{op->taskId(), ctx->pipelineId};
@@ -1348,7 +1344,7 @@ class MergeExchangeAdapter : public OperatorAdapter {
         std::dynamic_pointer_cast<const core::MergeExchangeNode>(planNode);
     const bool isUcx = mergeExchangeNode &&
         mergeExchangeNode->transportType() ==
-        core::ExchangeNode::TransportType::kUcx;
+            core::ExchangeNode::TransportType::kUcx;
     LOG(WARNING) << "CudfMergeExchangeAdapter: canRunOnGPU node="
                  << (mergeExchangeNode ? mergeExchangeNode->id() : "<null>")
                  << " isUcx=" << isUcx

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -262,7 +262,20 @@ class FilterProjectAdapter : public OperatorAdapter {
 
     // Check projects separately
     if (projectPlanNode) {
-      if (!canBeEvaluatedByCudf(
+      // A projection made entirely of direct field references is a positional
+      // select/rename.  It does not evaluate an expression on the CPU and can
+      // be executed by CudfFilterProject as a zero-copy column selection.  In
+      // particular, MPP exchange boundaries often need this form only to
+      // restore the consumer-side Velox field names.
+      const bool isDirectFieldProjection = std::all_of(
+          projectPlanNode->projections().begin(),
+          projectPlanNode->projections().end(),
+          [](const core::TypedExprPtr& expression) {
+            return std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+                       expression) != nullptr;
+          });
+      if (!isDirectFieldProjection &&
+          !canBeEvaluatedByCudf(
               projectPlanNode->projections(), ctx->task->queryCtx().get())) {
         LOG_FALLBACK(
             "FilterProject projections cannot be evaluated by cuDF, PlanNode id: {}",

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -407,13 +407,27 @@ void registerCudf() {
   const std::string mrMode = CudfConfig::getInstance().memoryResource;
   auto mr = cudf_velox::createMemoryResource(
       mrMode, CudfConfig::getInstance().memoryPercent);
-  cudf::set_current_device_resource(mr);
-  mr_ = std::move(mr);
+  if (deviceMemoryDiagnosticsEnabled()) {
+    statistics_mr_.emplace(std::move(mr));
+    mr_ = cuda::mr::any_resource<cuda::mr::device_accessible>{
+        statistics_mr_.value()};
+    LOG(INFO) << "Enabled cuDF RMM statistics for device-memory diagnostics";
+  } else {
+    mr_ = std::move(mr);
+  }
+  cudf::set_current_device_resource(mr_.value());
 
   const auto& outputMrMode = CudfConfig::getInstance().outputMemoryResource;
   if (!outputMrMode.empty() && outputMrMode != mrMode) {
-    output_mr_ = cudf_velox::createMemoryResource(
+    auto outputMr = cudf_velox::createMemoryResource(
         outputMrMode, CudfConfig::getInstance().memoryPercent);
+    if (deviceMemoryDiagnosticsEnabled()) {
+      output_statistics_mr_.emplace(std::move(outputMr));
+      output_mr_ = cuda::mr::any_resource<cuda::mr::device_accessible>{
+          output_statistics_mr_.value()};
+    } else {
+      output_mr_ = std::move(outputMr);
+    }
   } else {
     output_mr_ = mr_;
   }
@@ -440,6 +454,8 @@ void registerCudf() {
 void unregisterCudf() {
   output_mr_.reset();
   mr_.reset();
+  output_statistics_mr_.reset();
+  statistics_mr_.reset();
   exec::DriverFactory::adapters.erase(
       std::remove_if(
           exec::DriverFactory::adapters.begin(),

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -86,7 +86,9 @@ RowTypePtr gpuInputBoundaryType(
     const core::PlanNodePtr& planNode) {
   if (dynamic_cast<const exec::HashBuild*>(op) != nullptr) {
     VELOX_CHECK_GT(
-        planNode->sources().size(), 1, "HashBuild requires a build-side source");
+        planNode->sources().size(),
+        1,
+        "HashBuild requires a build-side source");
     return planNode->sources()[1]->outputType();
   }
 
@@ -109,7 +111,8 @@ RowTypePtr gpuInputBoundaryType(
     return topNRowNumber->inputType();
   }
 
-  if (auto window = std::dynamic_pointer_cast<const core::WindowNode>(planNode)) {
+  if (auto window =
+          std::dynamic_pointer_cast<const core::WindowNode>(planNode)) {
     return window->inputType();
   }
 

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -277,9 +277,17 @@ bool CompileState::compile(bool allowCpuFallback) {
 
     if (thisOpProps.producesGpuOutput and
         (nextOperatorIsNotGpu or isLastOperatorOfTask) and planNode) {
-      replaceOp.push_back(
-          std::make_unique<CudfToVelox>(
-              id, planNode->outputType(), ctx, planNode->id() + "-to-velox"));
+      const bool keepDeviceOutput = isLastOperatorOfTask &&
+          ctx->queryConfig().get<bool>(
+              CudfConfig::kCudfSkipOutputToVelox, false);
+      if (!keepDeviceOutput) {
+        replaceOp.push_back(
+            std::make_unique<CudfToVelox>(
+                id,
+                planNode->outputType(),
+                ctx,
+                planNode->id() + "-to-velox"));
+      }
     }
 
     if (isPureCpuOperator && isMppFinalOutputBoundary(oper, planNode)) {

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -134,11 +134,7 @@ std::unique_ptr<cudf::column> makeEmptyColumnForType(
       auto entryStruct = cudf::make_structs_column(
           0, std::move(entries), 0, rmm::device_buffer{}, stream, mr);
       return cudf::make_lists_column(
-          0,
-          zeroOffsets(),
-          std::move(entryStruct),
-          0,
-          rmm::device_buffer{});
+          0, zeroOffsets(), std::move(entryStruct), 0, rmm::device_buffer{});
     }
     case TypeKind::ROW: {
       std::vector<std::unique_ptr<cudf::column>> children;
@@ -151,8 +147,7 @@ std::unique_ptr<cudf::column> makeEmptyColumnForType(
           0, std::move(children), 0, rmm::device_buffer{}, stream, mr);
     }
     default:
-      return cudf::make_empty_column(
-          cudf_velox::veloxToCudfDataType(type));
+      return cudf::make_empty_column(cudf_velox::veloxToCudfDataType(type));
   }
 }
 
@@ -192,15 +187,22 @@ std::unique_ptr<cudf::table> getConcatenatedTable(
 
   cudf::detail::join_streams(inputStreams, stream);
 
-  // Even for a single input table we must concatenate (copy) rather than
-  // release in-place: the output is owned by `stream` but the input buffer was
-  // allocated on a different stream, so releasing it would bind deallocation to
-  // the wrong stream.
-  auto output = cudf::concatenate(tableViews, stream, mr);
+  try {
+    // Even for a single input table we must concatenate (copy) rather than
+    // release in-place: the output is owned by `stream` but the input buffer
+    // was allocated on a different stream, so releasing it would bind
+    // deallocation to the wrong stream.
+    auto output = cudf::concatenate(tableViews, stream, mr);
 
-  orderCudfVectorDeallocationsAfterStream(tables, inputStreams, stream);
-  // Input tables are deallocated here when 'tables' goes out of scope.
-  return output;
+    orderCudfVectorDeallocationsAfterStream(tables, inputStreams, stream);
+    // Input tables are deallocated here when 'tables' goes out of scope.
+    return output;
+  } catch (...) {
+    // concatenate can enqueue work for early columns before a later allocation
+    // fails. Finish that work before owners unwind on their original streams.
+    stream.synchronize();
+    throw;
+  }
 }
 
 std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
@@ -229,39 +231,45 @@ std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
 
   cudf::detail::join_streams(inputStreams, stream);
 
-  std::vector<std::unique_ptr<cudf::table>> outputTables;
-  auto const maxRows = maxBatchRows();
-  size_t startpos = 0;
-  size_t runningRows = 0;
-  for (size_t i = 0; i < tableViews.size(); ++i) {
-    auto const numRows = static_cast<size_t>(tableViews[i].num_rows());
-    // If adding this table would exceed the limit, flush current batch
-    // [startpos, i).
-    if (runningRows > 0 && runningRows + numRows > maxRows) {
+  try {
+    std::vector<std::unique_ptr<cudf::table>> outputTables;
+    auto const maxRows = maxBatchRows();
+    size_t startpos = 0;
+    size_t runningRows = 0;
+    for (size_t i = 0; i < tableViews.size(); ++i) {
+      auto const numRows = static_cast<size_t>(tableViews[i].num_rows());
+      // If adding this table would exceed the limit, flush current batch
+      // [startpos, i).
+      if (runningRows > 0 && runningRows + numRows > maxRows) {
+        outputTables.push_back(
+            cudf::concatenate(
+                std::vector<cudf::table_view>(
+                    tableViews.begin() + startpos, tableViews.begin() + i),
+                stream,
+                mr));
+        startpos = i;
+        runningRows = 0;
+      }
+      runningRows += numRows;
+    }
+    // Flush the final batch [startpos, end).
+    if (startpos < tableViews.size()) {
       outputTables.push_back(
           cudf::concatenate(
               std::vector<cudf::table_view>(
-                  tableViews.begin() + startpos, tableViews.begin() + i),
+                  tableViews.begin() + startpos, tableViews.end()),
               stream,
               mr));
-      startpos = i;
-      runningRows = 0;
     }
-    runningRows += numRows;
-  }
-  // Flush the final batch [startpos, end).
-  if (startpos < tableViews.size()) {
-    outputTables.push_back(
-        cudf::concatenate(
-            std::vector<cudf::table_view>(
-                tableViews.begin() + startpos, tableViews.end()),
-            stream,
-            mr));
-  }
-  orderCudfVectorDeallocationsAfterStream(tables, inputStreams, stream);
+    orderCudfVectorDeallocationsAfterStream(tables, inputStreams, stream);
 
-  // Input tables are deallocated here when 'tables' goes out of scope.
-  return outputTables;
+    // Input tables are deallocated here when 'tables' goes out of scope.
+    return outputTables;
+  } catch (...) {
+    // A failed later batch may leave earlier concatenate kernels in flight.
+    stream.synchronize();
+    throw;
+  }
 }
 
 std::vector<CudfVectorPtr> getConcatenatedCudfVectorsBatched(

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -101,25 +101,69 @@ std::unique_ptr<cudf::table> concatenateTables(
   return cudf::concatenate(tableViews, stream, mr);
 }
 
-std::unique_ptr<cudf::table> makeEmptyTable(TypePtr const& inputType) {
+std::unique_ptr<cudf::column> makeEmptyColumnForType(
+    const TypePtr& type,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto zeroOffsets = [&]() {
+    cudf::size_type zero = 0;
+    rmm::device_buffer offsets(&zero, sizeof(zero), stream, mr);
+    return std::make_unique<cudf::column>(
+        cudf::data_type{cudf::type_id::INT32},
+        1,
+        std::move(offsets),
+        rmm::device_buffer{},
+        0);
+  };
+  switch (type->kind()) {
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+      return cudf::make_strings_column(
+          0, zeroOffsets(), rmm::device_buffer{}, 0, rmm::device_buffer{});
+    case TypeKind::ARRAY:
+      return cudf::make_lists_column(
+          0,
+          zeroOffsets(),
+          makeEmptyColumnForType(type->childAt(0), stream, mr),
+          0,
+          rmm::device_buffer{});
+    case TypeKind::MAP: {
+      std::vector<std::unique_ptr<cudf::column>> entries;
+      entries.push_back(makeEmptyColumnForType(type->childAt(0), stream, mr));
+      entries.push_back(makeEmptyColumnForType(type->childAt(1), stream, mr));
+      auto entryStruct = cudf::make_structs_column(
+          0, std::move(entries), 0, rmm::device_buffer{}, stream, mr);
+      return cudf::make_lists_column(
+          0,
+          zeroOffsets(),
+          std::move(entryStruct),
+          0,
+          rmm::device_buffer{});
+    }
+    case TypeKind::ROW: {
+      std::vector<std::unique_ptr<cudf::column>> children;
+      children.reserve(type->size());
+      for (size_t i = 0; i < type->size(); ++i) {
+        children.push_back(
+            makeEmptyColumnForType(type->childAt(i), stream, mr));
+      }
+      return cudf::make_structs_column(
+          0, std::move(children), 0, rmm::device_buffer{}, stream, mr);
+    }
+    default:
+      return cudf::make_empty_column(
+          cudf_velox::veloxToCudfDataType(type));
+  }
+}
+
+std::unique_ptr<cudf::table> makeEmptyTable(
+    TypePtr const& inputType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
   std::vector<std::unique_ptr<cudf::column>> emptyColumns;
   for (size_t i = 0; i < inputType->size(); ++i) {
-    if (auto const& childType = inputType->childAt(i);
-        childType->kind() == TypeKind::ROW) {
-      auto tbl = makeEmptyTable(childType);
-      auto structColumn = std::make_unique<cudf::column>(
-          cudf::data_type(cudf::type_id::STRUCT),
-          0,
-          rmm::device_buffer(),
-          rmm::device_buffer(),
-          0,
-          tbl->release());
-      emptyColumns.push_back(std::move(structColumn));
-    } else {
-      auto emptyColumn = cudf::make_empty_column(
-          cudf_velox::veloxToCudfDataType(inputType->childAt(i)));
-      emptyColumns.push_back(std::move(emptyColumn));
-    }
+    emptyColumns.push_back(
+        makeEmptyColumnForType(inputType->childAt(i), stream, mr));
   }
   return std::make_unique<cudf::table>(std::move(emptyColumns));
 }
@@ -131,7 +175,7 @@ std::unique_ptr<cudf::table> getConcatenatedTable(
     rmm::device_async_resource_ref mr) {
   // Check for empty vector
   if (tables.size() == 0) {
-    return makeEmptyTable(tableType);
+    return makeEmptyTable(tableType, stream, mr);
   }
 
   auto inputStreams = std::vector<rmm::cuda_stream_view>();
@@ -167,7 +211,7 @@ std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
   std::vector<std::unique_ptr<cudf::table>> concatTables;
   // Check for empty vector
   if (tables.size() == 0) {
-    concatTables.push_back(makeEmptyTable(tableType));
+    concatTables.push_back(makeEmptyTable(tableType, stream, mr));
     return concatTables;
   }
 
@@ -264,7 +308,7 @@ std::vector<CudfVectorPtr> getConcatenatedCudfVectorsBatched(
             pool,
             tableType,
             checkedVectorSize(chunkRows),
-            makeEmptyTable(tableType),
+            makeEmptyTable(tableType, stream, mr),
             stream));
     remainingRows -= chunkRows;
   } while (remainingRows > 0);

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -202,8 +202,8 @@ std::unique_ptr<cudf::table> toCudfTable(
       .timestampTimeZone = timestampTimeZone,
       .exportVarbinaryAsString = true,
       .useDecimalTypeWidth = true};
-  auto exportVector = std::static_pointer_cast<BaseVector>(
-      std::make_shared<RowVector>(
+  auto exportVector =
+      std::static_pointer_cast<BaseVector>(std::make_shared<RowVector>(
           veloxTable->pool(),
           veloxTable->type(),
           veloxTable->nulls(),

--- a/velox/experimental/cudf/expression/ArrayAccessFunctions.cpp
+++ b/velox/experimental/cudf/expression/ArrayAccessFunctions.cpp
@@ -702,7 +702,8 @@ class MapElementAtFunction : public CudfFunction {
       cudf::column_view child,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) {
-    auto offsets = std::make_unique<cudf::column>(mapView.offsets(), stream, mr);
+    auto offsets =
+        std::make_unique<cudf::column>(mapView.offsets(), stream, mr);
     auto values = std::make_unique<cudf::column>(child, stream, mr);
     auto nullMask = cudf::copy_bitmask(mapView.parent(), stream, mr);
     return cudf::make_lists_column(
@@ -717,8 +718,7 @@ class MapElementAtFunction : public CudfFunction {
       cudf::column_view positions,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) {
-    auto missing =
-        cudf::numeric_scalar<cudf::size_type>(-1, true, stream, mr);
+    auto missing = cudf::numeric_scalar<cudf::size_type>(-1, true, stream, mr);
     auto missingMask = sanitizeBoolMask(
         cudf::binary_operation(
             positions,

--- a/velox/experimental/cudf/expression/AstExpression.cpp
+++ b/velox/experimental/cudf/expression/AstExpression.cpp
@@ -109,8 +109,21 @@ ColumnOrView ASTExpression::eval(
         LOG(INFO) << cudf::ast::expression_to_string(cudfTree_.back());
         LOG(INFO) << cudf::table_schema_to_string(astInputTableView);
       }
-      return cudf::compute_column(
-          astInputTableView, cudfTree_.back(), stream, mr);
+      try {
+        return cudf::compute_column(
+            astInputTableView, cudfTree_.back(), stream, mr);
+      } catch (...) {
+        // cuDF's AST parser reports only a generic operand-type mismatch.
+        // Preserve the concrete AST and physical input schema at the point of
+        // failure so implicit Spark coercion bugs can be diagnosed without a
+        // second debug build.
+        LOG(ERROR) << "cuDF AST evaluation failed; Velox expression="
+                   << expr_->toString() << "; AST="
+                   << cudf::ast::expression_to_string(cudfTree_.back())
+                   << "; input schema="
+                   << cudf::table_schema_to_string(astInputTableView);
+        throw;
+      }
     }
   }();
   if (finalize) {
@@ -131,6 +144,9 @@ bool ASTExpression::canEvaluate(std::shared_ptr<velox::exec::Expr> expr) {
     }
     return false;
   }
+  // Non-AST children are precomputed by a cuDF expression evaluator and fed
+  // to the AST as temporary columns.  This is still a fully GPU path and is
+  // required for mixed trees such as DOUBLE * coalesce(DOUBLE, DOUBLE).
   return detail::isAstExprSupported(expr);
 }
 

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -511,7 +511,8 @@ struct AstContext {
       size_t columnIndex,
       std::string const& instruction,
       std::string const& fieldName,
-      const std::shared_ptr<CudfExpression>& node = nullptr);
+      const std::shared_ptr<CudfExpression>& node = nullptr,
+      std::optional<cudf::data_type> expectedType = std::nullopt);
   cudf::ast::expression const& addPrecomputeInstruction(
       std::string const& name,
       std::string const& instruction,
@@ -576,13 +577,14 @@ cudf::ast::expression const& AstContext::addPrecomputeInstructionOnSide(
     size_t columnIndex,
     std::string const& instruction,
     std::string const& fieldName,
-    const std::shared_ptr<CudfExpression>& node) {
+    const std::shared_ptr<CudfExpression>& node,
+    std::optional<cudf::data_type> expectedType) {
   auto newColumnIndex = inputRowSchema[sideIdx].get()->size() +
       precomputeInstructions[sideIdx].get().size();
   if (fieldName.empty()) {
     // This custom op should be added to input columns.
     precomputeInstructions[sideIdx].get().emplace_back(
-        columnIndex, instruction, newColumnIndex, node);
+        columnIndex, instruction, newColumnIndex, node, expectedType);
   } else {
     auto nestedIndices = getNestedColumnIndices(
         inputRowSchema[sideIdx].get()->childAt(columnIndex), fieldName);
@@ -714,7 +716,13 @@ cudf::ast::expression const& AstContext::pushExprToTree(
         sideIdx = 0; // Default to left side if no fields found
       }
       auto node = createCudfExpression(expr, inputRowSchema[sideIdx]);
-      return addPrecomputeInstructionOnSide(sideIdx, 0, name, "", node);
+      return addPrecomputeInstructionOnSide(
+          sideIdx,
+          0,
+          name,
+          "",
+          node,
+          veloxToCudfDataType(expr->type()));
     }
     VELOX_FAIL("Unsupported expression: {}", name);
   }
@@ -766,8 +774,72 @@ cudf::ast::expression const& AstContext::pushExprToTree(
       auto const& op2 = pushTimestampFieldReferenceToTree(rightField);
       return tree.push(Operation{binaryOps.at(name), op1, op2});
     }
-    auto const& op1 = pushExprToTree(expr->inputs()[0]);
-    auto const& op2 = pushExprToTree(expr->inputs()[1]);
+    // libcudf's AST parser cannot currently type a NULL_EQUAL operand that is
+    // itself an AST operation (e.g. (string_col = 'x') <=> true), even though
+    // that child resolves to BOOL8. Materialize such children as temporary
+    // cuDF columns. This preserves Spark null-safe semantics and remains an
+    // entirely GPU execution path.
+    auto pushNullEqualOperand = [&](const std::shared_ptr<velox::exec::Expr>& input)
+        -> const cudf::ast::expression& {
+      if (binaryOps.at(name) != Op::NULL_EQUAL ||
+          std::dynamic_pointer_cast<FieldReference>(input) ||
+          std::dynamic_pointer_cast<ConstantExpr>(input)) {
+        return pushExprToTree(input);
+      }
+      int sideIdx = findExpressionSide(input);
+      VELOX_CHECK_NE(
+          sideIdx,
+          -2,
+          "NULL_EQUAL child spanning both join sides cannot be precomputed");
+      if (sideIdx < 0) {
+        sideIdx = 0;
+      }
+      auto node = createCudfExpression(input, inputRowSchema[sideIdx]);
+      return addPrecomputeInstructionOnSide(
+          sideIdx,
+          0,
+          "null_equal_child",
+          "",
+          node,
+          veloxToCudfDataType(input->type()));
+    };
+    auto const& op1 = pushNullEqualOperand(expr->inputs()[0]);
+    auto const& op2 = pushNullEqualOperand(expr->inputs()[1]);
+    // libcudf's type inference accepts some mixed numeric signatures, but the
+    // AST parser requires the two operands of arithmetic operations to have
+    // identical physical types. Spark/Velox performs numeric coercion while
+    // resolving the expression (for example DOUBLE / INTEGER -> DOUBLE) and
+    // does not always leave an explicit CastExpr in the converted plan. Mirror
+    // that resolved type in the AST rather than presenting libcudf with the
+    // original mixed operands.
+    const bool isArithmetic =
+        name == "add" || name == "plus" || name == "subtract" ||
+        name == "minus" || name == "multiply" || name == "divide" ||
+        name == "mod";
+    if (isArithmetic) {
+      auto const targetKind = expr->type()->kind();
+      auto castOperand = [&](const cudf::ast::expression& operand,
+                             TypeKind inputKind)
+          -> const cudf::ast::expression& {
+        if (inputKind == targetKind) {
+          return operand;
+        }
+        if (targetKind == TypeKind::DOUBLE) {
+          return tree.push(Operation{Op::CAST_TO_FLOAT64, operand});
+        }
+        if (targetKind == TypeKind::BIGINT) {
+          return tree.push(Operation{Op::CAST_TO_INT64, operand});
+        }
+        // INTEGER arithmetic should already have matching INT32 operands;
+        // cuDF AST has no CAST_TO_INT32 operator.
+        return operand;
+      };
+      auto const& coerced1 =
+          castOperand(op1, expr->inputs()[0]->type()->kind());
+      auto const& coerced2 =
+          castOperand(op2, expr->inputs()[1]->type()->kind());
+      return tree.push(Operation{binaryOps.at(name), coerced1, coerced2});
+    }
     return tree.push(Operation{binaryOps.at(name), op1, op2});
   } else if (unaryOps.find(name) != unaryOps.end()) {
     VELOX_CHECK_EQ(len, 1);
@@ -886,7 +958,8 @@ std::vector<ColumnOrView> precomputeSubexpressions(
          ins_name,
          new_column_index,
          nested_dependent_column_indices,
-         cudf_expression] = instruction;
+         cudf_expression,
+         expected_type] = instruction;
 
     // If a compiled cudf node is available, evaluate it directly.
     if (cudf_expression) {
@@ -895,6 +968,9 @@ std::vector<ColumnOrView> precomputeSubexpressions(
           stream,
           get_output_mr(),
           /*finalize=*/true);
+      if (expected_type && asView(result).type() != *expected_type) {
+        result = cudf::cast(asView(result), *expected_type, stream, get_output_mr());
+      }
       precomputedColumns.push_back(std::move(result));
       continue;
     }

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -592,7 +592,8 @@ cudf::ast::expression const& AstContext::addPrecomputeInstructionOnSide(
         instruction,
         newColumnIndex,
         std::move(nestedIndices),
-        node);
+        node,
+        expectedType);
   }
   auto side = static_cast<cudf::ast::table_reference>(sideIdx);
   return tree.push(cudf::ast::column_reference(newColumnIndex, side));
@@ -946,6 +947,16 @@ std::vector<ColumnOrView> precomputeSubexpressions(
   std::vector<ColumnOrView> precomputedColumns;
   precomputedColumns.reserve(precomputeInstructions.size());
 
+  auto appendPrecomputed = [&](ColumnOrView result,
+                                   const std::optional<cudf::data_type>&
+                                       expectedType) {
+    if (expectedType && asView(result).type() != *expectedType) {
+      result =
+          cudf::cast(asView(result), *expectedType, stream, get_output_mr());
+    }
+    precomputedColumns.push_back(std::move(result));
+  };
+
   for (const auto& instruction : precomputeInstructions) {
     auto
         [dependent_column_index,
@@ -962,11 +973,7 @@ std::vector<ColumnOrView> precomputeSubexpressions(
           stream,
           get_output_mr(),
           /*finalize=*/true);
-      if (expected_type && asView(result).type() != *expected_type) {
-        result =
-            cudf::cast(asView(result), *expected_type, stream, get_output_mr());
-      }
-      precomputedColumns.push_back(std::move(result));
+      appendPrecomputed(std::move(result), expected_type);
       continue;
     }
     if (ins_name.rfind("fill", 0) == 0) {
@@ -977,21 +984,22 @@ std::vector<ColumnOrView> precomputeSubexpressions(
           inputColumnViews[dependent_column_index].size(),
           stream,
           get_output_mr());
-      precomputedColumns.push_back(std::move(newColumn));
+      appendPrecomputed(std::move(newColumn), expected_type);
     } else if (ins_name == "nested_column") {
       // Nested column already exists in input. Don't materialize.
       auto view = inputColumnViews[dependent_column_index].child(
           nested_dependent_column_indices[0]);
-      precomputedColumns.push_back(view);
+      appendPrecomputed(view, expected_type);
     } else if (ins_name == kTimestampCastInstruction) {
       auto targetType =
           cudf::data_type{CudfConfig::getInstance().timestampUnit};
       auto view = inputColumnViews[dependent_column_index];
       if (view.type() == targetType) {
-        precomputedColumns.push_back(view);
+        appendPrecomputed(view, expected_type);
       } else {
-        precomputedColumns.push_back(
-            cudf::cast(view, targetType, stream, get_output_mr()));
+        appendPrecomputed(
+            cudf::cast(view, targetType, stream, get_output_mr()),
+            expected_type);
       }
     } else {
       VELOX_FAIL("Unsupported precompute operation {}", ins_name);

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -298,8 +298,7 @@ bool isComparisonOp(const cudf::ast::ast_operator op) {
   }
 }
 
-bool isTopLevelFieldReference(
-    const std::shared_ptr<velox::exec::Expr>& expr) {
+bool isTopLevelFieldReference(const std::shared_ptr<velox::exec::Expr>& expr) {
   using velox::exec::FieldReference;
   auto fieldExpr = std::dynamic_pointer_cast<FieldReference>(expr);
   if (!fieldExpr || !fieldExpr->inputs().empty()) {
@@ -717,12 +716,7 @@ cudf::ast::expression const& AstContext::pushExprToTree(
       }
       auto node = createCudfExpression(expr, inputRowSchema[sideIdx]);
       return addPrecomputeInstructionOnSide(
-          sideIdx,
-          0,
-          name,
-          "",
-          node,
-          veloxToCudfDataType(expr->type()));
+          sideIdx, 0, name, "", node, veloxToCudfDataType(expr->type()));
     }
     VELOX_FAIL("Unsupported expression: {}", name);
   }
@@ -779,7 +773,8 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     // that child resolves to BOOL8. Materialize such children as temporary
     // cuDF columns. This preserves Spark null-safe semantics and remains an
     // entirely GPU execution path.
-    auto pushNullEqualOperand = [&](const std::shared_ptr<velox::exec::Expr>& input)
+    auto pushNullEqualOperand =
+        [&](const std::shared_ptr<velox::exec::Expr>& input)
         -> const cudf::ast::expression& {
       if (binaryOps.at(name) != Op::NULL_EQUAL ||
           std::dynamic_pointer_cast<FieldReference>(input) ||
@@ -812,15 +807,14 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     // does not always leave an explicit CastExpr in the converted plan. Mirror
     // that resolved type in the AST rather than presenting libcudf with the
     // original mixed operands.
-    const bool isArithmetic =
-        name == "add" || name == "plus" || name == "subtract" ||
-        name == "minus" || name == "multiply" || name == "divide" ||
-        name == "mod";
+    const bool isArithmetic = name == "add" || name == "plus" ||
+        name == "subtract" || name == "minus" || name == "multiply" ||
+        name == "divide" || name == "mod";
     if (isArithmetic) {
       auto const targetKind = expr->type()->kind();
-      auto castOperand = [&](const cudf::ast::expression& operand,
-                             TypeKind inputKind)
-          -> const cudf::ast::expression& {
+      auto castOperand =
+          [&](const cudf::ast::expression& operand,
+              TypeKind inputKind) -> const cudf::ast::expression& {
         if (inputKind == targetKind) {
           return operand;
         }
@@ -969,7 +963,8 @@ std::vector<ColumnOrView> precomputeSubexpressions(
           get_output_mr(),
           /*finalize=*/true);
       if (expected_type && asView(result).type() != *expected_type) {
-        result = cudf::cast(asView(result), *expected_type, stream, get_output_mr());
+        result =
+            cudf::cast(asView(result), *expected_type, stream, get_output_mr());
       }
       precomputedColumns.push_back(std::move(result));
       continue;

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -205,6 +205,13 @@ static std::unique_ptr<cudf::scalar> createCudfScalar(
       vector->type(), vector->value(), vector->isNullAt(0), toType);
 }
 
+inline std::unique_ptr<cudf::scalar> makeScalarFromConstantVector(
+    const velox::VectorPtr& value,
+    std::optional<cudf::type_id> toType = std::nullopt) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      createCudfScalar, value->typeKind(), value, toType);
+}
+
 inline std::unique_ptr<cudf::scalar> makeScalarFromConstantExpr(
     const std::shared_ptr<velox::exec::Expr>& expr,
     std::optional<cudf::type_id> toType = std::nullopt) {

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -404,8 +404,7 @@ bool isSupportedDirectJsonType(const TypePtr& type, bool isRoot) {
   }
 }
 
-bool isSupportedFromJsonExpr(
-    const std::shared_ptr<velox::exec::Expr>& expr) {
+bool isSupportedFromJsonExpr(const std::shared_ptr<velox::exec::Expr>& expr) {
   return isSupportedFromJsonRowOfStringsExpr(expr) ||
       (expr->inputs().size() == 1 &&
        expr->inputs()[0]->type()->kind() == TypeKind::VARCHAR &&
@@ -515,9 +514,8 @@ bool isUtf8DecodeCharset(std::string_view charset) {
     normalized[i] =
         static_cast<char>(std::tolower(static_cast<unsigned char>(charset[i])));
   }
-  return charset.size() == 5
-      ? std::string_view(normalized, 5) == "utf-8"
-      : std::string_view(normalized, 4) == "utf8";
+  return charset.size() == 5 ? std::string_view(normalized, 5) == "utf-8"
+                             : std::string_view(normalized, 4) == "utf8";
 }
 
 bool hasSupportedConstantDecodeCharset(
@@ -1434,8 +1432,7 @@ class CastFunction : public CudfFunction {
       castMode_ = CastMode::kStringToBool;
     } else if (isStringToDateVeloxCast(sourceVeloxType, targetVeloxType)) {
       castMode_ = CastMode::kStringToDate;
-    } else if (isStringToTimestampVeloxCast(
-                   sourceVeloxType, targetVeloxType)) {
+    } else if (isStringToTimestampVeloxCast(sourceVeloxType, targetVeloxType)) {
       castMode_ = CastMode::kStringToTimestamp;
     } else if (isNumericToTimestampVeloxCast(
                    sourceVeloxType, targetVeloxType)) {
@@ -1834,8 +1831,7 @@ class ArrayDistinctFunction : public CudfFunction {
 
 class ArrayExceptFunction : public CudfFunction {
  public:
-  explicit ArrayExceptFunction(
-      const std::shared_ptr<velox::exec::Expr>& expr) {
+  explicit ArrayExceptFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
     VELOX_CHECK_EQ(
         expr->inputs().size(), 2, "array_except expects exactly 2 inputs");
     VELOX_CHECK_EQ(
@@ -2914,8 +2910,8 @@ class CoalesceFunction : public CudfFunction {
         result = cudf::copy_if_else(
             asView(inputColumns[i]), current, nullRows->view(), stream, mr);
       } else {
-        result = cudf::replace_nulls(
-            current, asView(inputColumns[i]), stream, mr);
+        result =
+            cudf::replace_nulls(current, asView(inputColumns[i]), stream, mr);
       }
     }
 

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -110,15 +110,13 @@ class ScopedCudfFunctionQueryConfig {
 cudf::size_type resolveFieldReferenceIndex(
     velox::exec::FieldReference& fieldExpr,
     const RowTypePtr& parentRowType) {
-  auto pool = memory::memoryManager()->addLeafPool();
-  auto queryCtx = core::QueryCtx::create();
-  core::ExecCtx execCtx(pool.get(), queryCtx.get());
-  exec::ExprSet exprSet({}, &execCtx, /*enableConstantFolding=*/false);
-  auto row = RowVector::createEmpty(parentRowType, pool.get());
-  exec::EvalCtx evalCtx(&execCtx, &exprSet, row.get());
-  auto fieldIndex = fieldExpr.index(evalCtx);
-  VELOX_CHECK_GE(fieldIndex, 0);
-  return static_cast<cudf::size_type>(fieldIndex);
+  // FieldReference::index(EvalCtx) may retain the index resolved against the
+  // original, outer input row. Re-evaluating it with a synthetic child row is
+  // therefore unsafe for nested dereferences and selected the wrong struct
+  // child in complex projection plans. Resolve the nested field directly
+  // against its declared parent ROW instead.
+  return static_cast<cudf::size_type>(
+      parentRowType->getChildIdx(fieldExpr.field()));
 }
 
 bool decimalScalarIsZero(
@@ -2906,8 +2904,19 @@ class CoalesceFunction : public CudfFunction {
     ColumnOrView result = asView(inputColumns[0]);
     size_t stop = std::min(numColumnsBeforeLiteral_, inputColumns.size());
     for (size_t i = 1; i < stop && asView(result).has_nulls(); ++i) {
-      result = cudf::replace_nulls(
-          asView(result), asView(inputColumns[i]), stream, mr);
+      const auto current = asView(result);
+      if (current.type().id() == cudf::type_id::LIST ||
+          current.type().id() == cudf::type_id::STRUCT) {
+        // libcudf replace_nulls does not specialize nested columns. Select
+        // whole rows instead, preserving child nulls inside a valid map/list/
+        // struct value while replacing only null parent rows.
+        auto nullRows = cudf::is_null(current, stream, mr);
+        result = cudf::copy_if_else(
+            asView(inputColumns[i]), current, nullRows->view(), stream, mr);
+      } else {
+        result = cudf::replace_nulls(
+            current, asView(inputColumns[i]), stream, mr);
+      }
     }
 
     if ((literalScalar_ || emptyArrayLiteralType_) &&
@@ -2915,8 +2924,20 @@ class CoalesceFunction : public CudfFunction {
       auto scalar = emptyArrayLiteralType_
           ? makeEmptyArrayScalar(emptyArrayLiteralType_, stream, mr)
           : nullptr;
-      result = cudf::replace_nulls(
-          asView(result), scalar ? *scalar : *literalScalar_, stream, mr);
+      const auto current = asView(result);
+      if (current.type().id() == cudf::type_id::LIST ||
+          current.type().id() == cudf::type_id::STRUCT) {
+        auto nullRows = cudf::is_null(current, stream, mr);
+        result = cudf::copy_if_else(
+            scalar ? *scalar : *literalScalar_,
+            current,
+            nullRows->view(),
+            stream,
+            mr);
+      } else {
+        result = cudf::replace_nulls(
+            current, scalar ? *scalar : *literalScalar_, stream, mr);
+      }
     }
 
     return result;

--- a/velox/experimental/cudf/expression/PrecomputeInstruction.h
+++ b/velox/experimental/cudf/expression/PrecomputeInstruction.h
@@ -32,17 +32,22 @@ struct PrecomputeInstruction {
   int new_column_index;
   std::vector<int> nested_dependent_column_indices;
   std::shared_ptr<CudfExpression> cudf_expression;
+  // The AST is compiled from Velox types.  A non-AST child must therefore be
+  // presented to it with exactly the type advertised by that child Expr.
+  std::optional<cudf::data_type> expected_type;
 
   // Constructor to initialize the struct with values
   PrecomputeInstruction(
       int depIndex,
       const std::string& name,
       int newIndex,
-      const std::shared_ptr<CudfExpression>& node = nullptr)
+      const std::shared_ptr<CudfExpression>& node = nullptr,
+      std::optional<cudf::data_type> expectedType = std::nullopt)
       : dependent_column_index(depIndex),
         ins_name(name),
         new_column_index(newIndex),
-        cudf_expression(node) {}
+        cudf_expression(node),
+        expected_type(expectedType) {}
 
   // TODO (dm): This two ctor situation is crazy.
   PrecomputeInstruction(
@@ -50,12 +55,14 @@ struct PrecomputeInstruction {
       const std::string& name,
       int newIndex,
       std::vector<int>&& nestedIndices,
-      const std::shared_ptr<CudfExpression>& node = nullptr)
+      const std::shared_ptr<CudfExpression>& node = nullptr,
+      std::optional<cudf::data_type> expectedType = std::nullopt)
       : dependent_column_index(depIndex),
         ins_name(name),
         new_column_index(newIndex),
         nested_dependent_column_indices(std::move(nestedIndices)),
-        cudf_expression(node) {}
+        cudf_expression(node),
+        expected_type(expectedType) {}
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/expression/SparkFunctions.cpp
+++ b/velox/experimental/cudf/expression/SparkFunctions.cpp
@@ -948,6 +948,45 @@ class UnixTimestampFunction : public CudfFunction {
   }
 };
 
+class TimestampMillisFunction : public CudfFunction {
+ public:
+  explicit TimestampMillisFunction(
+      const std::shared_ptr<velox::exec::Expr>& expr) {
+    VELOX_CHECK_EQ(
+        expr->inputs().size(), 1, "timestamp_millis expects exactly 1 input");
+    VELOX_CHECK(
+        expr->inputs()[0]->type()->kind() == TypeKind::BIGINT,
+        "timestamp_millis input must be BIGINT");
+    VELOX_CHECK(
+        expr->type()->kind() == TypeKind::TIMESTAMP,
+        "timestamp_millis output must be TIMESTAMP");
+  }
+
+  ColumnOrView eval(
+      std::vector<ColumnOrView>& inputColumns,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const override {
+    VELOX_CHECK_EQ(inputColumns.size(), 1);
+    const auto timestampType =
+        cudf::data_type{CudfConfig::getInstance().timestampUnit};
+    const auto ticksPerMillisecond =
+        timestampTicksPerSecond(timestampType) / 1000;
+    VELOX_CHECK_GT(ticksPerMillisecond, 0);
+    const auto int64Type = cudf::data_type{cudf::type_id::INT64};
+    cudf::numeric_scalar<int64_t> multiplier(
+        ticksPerMillisecond, true, stream, mr);
+    auto ticks = cudf::binary_operation(
+        asView(inputColumns[0]),
+        multiplier,
+        cudf::binary_operator::MUL,
+        int64Type,
+        stream,
+        mr);
+    return std::make_unique<cudf::column>(
+        cudf::bit_cast(ticks->view(), timestampType), stream, mr);
+  }
+};
+
 class FromUnixTimeFunction : public CudfFunction {
  public:
   explicit FromUnixTimeFunction(
@@ -1675,6 +1714,16 @@ void registerSparkFunctions(const std::string& prefix) {
       {FunctionSignatureBuilder()
            .returnType("bigint")
            .argumentType("timestamp")
+           .build()});
+
+  registerCudfFunction(
+      prefix + "timestamp_millis",
+      [](const std::string&, const std::shared_ptr<velox::exec::Expr>& expr) {
+        return std::make_shared<TimestampMillisFunction>(expr);
+      },
+      {FunctionSignatureBuilder()
+           .returnType("timestamp")
+           .argumentType("bigint")
            .build()});
 
   registerCudfFunction(

--- a/velox/experimental/cudf/expression/SparkFunctions.cpp
+++ b/velox/experimental/cudf/expression/SparkFunctions.cpp
@@ -31,9 +31,9 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 
-#include <cudf/column/column_factories.hpp>
 #include <cudf/aggregation.hpp>
 #include <cudf/binaryop.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/datetime.hpp>
 #include <cudf/filling.hpp>
@@ -48,8 +48,8 @@
 #include <cudf/reshape.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
-#include <cudf/strings/contains.hpp>
 #include <cudf/strings/combine.hpp>
+#include <cudf/strings/contains.hpp>
 #include <cudf/strings/convert/convert_datetime.hpp>
 #include <cudf/strings/regex/regex_program.hpp>
 #include <cudf/strings/strings_column_view.hpp>
@@ -119,9 +119,8 @@ bool isUtf8DecodeCharset(std::string_view charset) {
     normalized[i] =
         static_cast<char>(std::tolower(static_cast<unsigned char>(charset[i])));
   }
-  return charset.size() == 5
-      ? std::string_view(normalized, 5) == "utf-8"
-      : std::string_view(normalized, 4) == "utf8";
+  return charset.size() == 5 ? std::string_view(normalized, 5) == "utf-8"
+                             : std::string_view(normalized, 4) == "utf8";
 }
 
 std::string readTranslatedSparkDatetimePattern(
@@ -374,8 +373,7 @@ bool isSupportedDirectJsonType(const TypePtr& type, bool isRoot) {
   }
 }
 
-bool isSupportedFromJsonNested(
-    const std::shared_ptr<velox::exec::Expr>& expr) {
+bool isSupportedFromJsonNested(const std::shared_ptr<velox::exec::Expr>& expr) {
   return expr->inputs().size() == 1 &&
       expr->inputs()[0]->type()->kind() == TypeKind::VARCHAR &&
       isSupportedDirectJsonType(expr->type(), true);
@@ -467,7 +465,8 @@ std::unique_ptr<cudf::column> makeEmptyColumnForType(
       std::vector<std::unique_ptr<cudf::column>> children;
       children.reserve(type->size());
       for (size_t i = 0; i < type->size(); ++i) {
-        children.push_back(makeEmptyColumnForType(type->childAt(i), stream, mr));
+        children.push_back(
+            makeEmptyColumnForType(type->childAt(i), stream, mr));
       }
       return cudf::make_structs_column(
           0, std::move(children), 0, rmm::device_buffer{}, stream, mr);
@@ -541,10 +540,7 @@ PreparedJsonInput prepareJsonInput(
       mr);
   auto emptyPattern = cudf::strings::regex_program::create("^$");
   auto emptyRows = cudf::strings::contains_re(
-      cudf::strings_column_view(stripped->view()),
-      *emptyPattern,
-      stream,
-      mr);
+      cudf::strings_column_view(stripped->view()), *emptyPattern, stream, mr);
 
   auto sanitized =
       cudf::copy_if_else(replacement, inputCol, emptyRows->view(), stream, mr);
@@ -1398,7 +1394,8 @@ class SequenceFunction : public CudfFunction {
         stream,
         mr);
     auto withinLimitNoNulls = nullToTrue(withinLimit->view(), stream, mr);
-    auto allAggregation = cudf::make_all_aggregation<cudf::reduce_aggregation>();
+    auto allAggregation =
+        cudf::make_all_aggregation<cudf::reduce_aggregation>();
     auto allScalar = cudf::reduce(
         withinLimitNoNulls->view(),
         *allAggregation,
@@ -1408,8 +1405,7 @@ class SequenceFunction : public CudfFunction {
     auto const& allBool =
         static_cast<cudf::numeric_scalar<bool> const&>(*allScalar);
     VELOX_USER_CHECK(
-        allBool.is_valid(stream) && allBool.value(stream),
-        "Too long sequence");
+        allBool.is_valid(stream) && allBool.value(stream), "Too long sequence");
 
     return cudf::cast(
         size64->view(), cudf::data_type{cudf::type_id::INT32}, stream, mr);
@@ -1563,9 +1559,7 @@ class FromJsonNestedFunction : public CudfFunction {
 class FromJsonFunction : public CudfFunction {
  public:
   explicit FromJsonFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
-    VELOX_CHECK(
-        isSupportedFromJson(expr),
-        "Unsupported cuDF from_json shape");
+    VELOX_CHECK(isSupportedFromJson(expr), "Unsupported cuDF from_json shape");
     if (isSupportedFromJsonRowOfStrings(expr)) {
       impl_ = std::make_shared<FromJsonRowOfStringsFunction>(expr);
     } else {

--- a/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
+++ b/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
@@ -374,11 +374,13 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
       // synthesize `column == column`: that evaluates to null for a null row
       // and is not semantically equivalent to AlwaysTrue.
       const bool value = filter.kind() == common::FilterKind::kAlwaysTrue;
-      scalars.emplace_back(std::make_unique<cudf::numeric_scalar<bool>>(
-          value, true, stream, mr));
+      scalars.emplace_back(
+          std::make_unique<cudf::numeric_scalar<bool>>(
+              value, true, stream, mr));
       stream.synchronize();
-      return tree.push(cudf::ast::literal{
-          *static_cast<cudf::numeric_scalar<bool>*>(scalars.back().get())});
+      return tree.push(
+          cudf::ast::literal{
+              *static_cast<cudf::numeric_scalar<bool>*>(scalars.back().get())});
     }
 
     case common::FilterKind::kBigintRange: {

--- a/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
+++ b/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
@@ -368,6 +368,19 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
   auto mr = get_temp_mr();
 
   switch (filter.kind()) {
+    case common::FilterKind::kAlwaysFalse:
+    case common::FilterKind::kAlwaysTrue: {
+      // These filters are constants, including for null input values.  Do not
+      // synthesize `column == column`: that evaluates to null for a null row
+      // and is not semantically equivalent to AlwaysTrue.
+      const bool value = filter.kind() == common::FilterKind::kAlwaysTrue;
+      scalars.emplace_back(std::make_unique<cudf::numeric_scalar<bool>>(
+          value, true, stream, mr));
+      stream.synchronize();
+      return tree.push(cudf::ast::literal{
+          *static_cast<cudf::numeric_scalar<bool>*>(scalars.back().get())});
+    }
+
     case common::FilterKind::kBigintRange: {
       auto const& columnType = inputRowSchema->childAt(columnIndex);
       auto result = VELOX_DYNAMIC_TYPE_DISPATCH(

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -86,9 +86,8 @@ TEST_F(AdapterOperatorTest, fullPartitionWindowSumUsesCudfWindow) {
 
   auto plan = PlanBuilder()
                   .values({data})
-                  .window(
-                      {"sum(v) over (partition by k0, k1 rows between "
-                       "unbounded preceding and unbounded following) as s"})
+                  .window({"sum(v) over (partition by k0, k1 rows between "
+                           "unbounded preceding and unbounded following) as s"})
                   .planNode();
 
   auto task = AssertQueryBuilder(duckDbQueryRunner_)
@@ -111,12 +110,12 @@ TEST_F(AdapterOperatorTest, orderedFirstValueUsesCudfWindow) {
        makeNullableFlatVector<int64_t>({100, 50, 10, 1, 1, 1})});
   createDuckDbTable({data});
 
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .window(
-                      {"first_value(v) over (partition by k order by o0 desc "
-                       "nulls last, o1 desc nulls last) as first_v"})
-                  .planNode();
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({"first_value(v) over (partition by k order by o0 desc "
+                   "nulls last, o1 desc nulls last) as first_v"})
+          .planNode();
 
   auto task = AssertQueryBuilder(duckDbQueryRunner_)
                   .config("cudf.enabled", true)

--- a/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
+++ b/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
@@ -48,11 +48,8 @@ class CudfFunctionBaseTest : public velox::functions::test::FunctionBaseTest {
     auto stream = cudf::get_default_stream();
     auto cudfTable = velox::cudf_velox::with_arrow::toCudfTable(
         input, pool_.get(), stream, cudf::get_current_device_resource_ref());
-    auto filterEvaluator =
-        createCudfExpression(
-            {exprSet.exprs()[0]},
-            input->rowType(),
-            &queryCtx_->queryConfig());
+    auto filterEvaluator = createCudfExpression(
+        {exprSet.exprs()[0]}, input->rowType(), &queryCtx_->queryConfig());
     auto ownedColumns = cudfTable->release();
     std::vector<cudf::column_view> inputViews;
     inputViews.reserve(ownedColumns.size());

--- a/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
@@ -137,8 +137,7 @@ TEST_F(CudfExpressionSelectionTest, decimalPredicateUsesFunctionEvaluator) {
   CudfConfig::getInstance().astExpressionEnabled = true;
   CudfConfig::getInstance().jitExpressionEnabled = true;
 
-  auto decimalRowType =
-      ROW({{"d0", DECIMAL(17, 2)}, {"d1", DECIMAL(17, 2)}});
+  auto decimalRowType = ROW({{"d0", DECIMAL(17, 2)}, {"d1", DECIMAL(17, 2)}});
   auto expr = compileExecExpr(
       "(d0 > CAST(0.0 AS DECIMAL(17, 2))) AND "
       "(d1 > CAST(0.0 AS DECIMAL(17, 2)))",
@@ -358,8 +357,8 @@ TEST_F(CudfExpressionSelectionTest, regexpLookaroundFallsBack) {
 
   auto supportedLeadingZeroLookahead = compileExecExpr(
       "regexp_replace(name, '^0+(?!$)', '')", rowType_, execCtx_.get());
-  ASSERT_TRUE(canBeEvaluatedByCudf(
-      supportedLeadingZeroLookahead, /*deep=*/true));
+  ASSERT_TRUE(
+      canBeEvaluatedByCudf(supportedLeadingZeroLookahead, /*deep=*/true));
 
   auto badLookahead = compileExecExpr(
       "regexp_replace(name, '(?!x)0+', '')", rowType_, execCtx_.get());

--- a/velox/experimental/cudf/tests/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/FilterProjectTest.cpp
@@ -1872,9 +1872,8 @@ TEST_F(CudfFilterProjectTest, substringWithIntegerBounds) {
   auto data = makeRowVector({input});
   auto substrPlan = PlanBuilder()
                         .values({data})
-                        .project({
-                            "substring(c0, cast(1 as integer), "
-                            "cast(2 as integer)) AS c0"})
+                        .project({"substring(c0, cast(1 as integer), "
+                                  "cast(2 as integer)) AS c0"})
                         .planNode();
   auto substrResults = AssertQueryBuilder(substrPlan).copyResults(pool());
 
@@ -2189,8 +2188,7 @@ TEST_F(CudfSimpleFilterProjectTest, castIntegralToVarchar) {
       evaluateOnce<std::string, int32_t>("cast(c0 as varchar)", 12345),
       "12345");
   EXPECT_EQ(
-      evaluateOnce<std::string, int64_t>(
-          "cast(c0 as varchar)", 9876543210LL),
+      evaluateOnce<std::string, int64_t>("cast(c0 as varchar)", 9876543210LL),
       "9876543210");
   EXPECT_EQ(
       evaluateOnce<std::string, int16_t>(
@@ -2208,8 +2206,7 @@ TEST_F(CudfSimpleFilterProjectTest, castIntegralToVarchar) {
 
 TEST_F(CudfSimpleFilterProjectTest, castFloatingPointToVarchar) {
   EXPECT_EQ(
-      evaluateOnce<std::string, double>("cast(c0 as varchar)", 12.5),
-      "12.5");
+      evaluateOnce<std::string, double>("cast(c0 as varchar)", 12.5), "12.5");
   EXPECT_EQ(
       evaluateOnce<std::string, float>(
           "try_cast(c0 as varchar)", static_cast<float>(-7.25)),

--- a/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
@@ -650,9 +650,9 @@ TEST_F(CudfFilterProjectTest, fromJsonRowOfStringFields) {
   });
   auto data = makeRowVector({input});
 
-  auto outputType = ROW(
-      {"id", "name", "reason", "field-name", "payload"},
-      {VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR()});
+  auto outputType =
+      ROW({"id", "name", "reason", "field-name", "payload"},
+          {VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR()});
   auto expression = std::make_shared<const core::CallTypedExpr>(
       outputType,
       std::vector<core::TypedExprPtr>{
@@ -672,9 +672,9 @@ TEST_F(CudfFilterProjectTest, fromJsonNestedRow) {
   });
   auto data = makeRowVector({input});
 
-  auto outputType = ROW(
-      {"ok", "count", "score", "name", "items"},
-      {BOOLEAN(), BIGINT(), DOUBLE(), VARCHAR(), ARRAY(BIGINT())});
+  auto outputType =
+      ROW({"ok", "count", "score", "name", "items"},
+          {BOOLEAN(), BIGINT(), DOUBLE(), VARCHAR(), ARRAY(BIGINT())});
   auto expression = std::make_shared<const core::CallTypedExpr>(
       outputType,
       std::vector<core::TypedExprPtr>{
@@ -694,9 +694,9 @@ TEST_F(CudfFilterProjectTest, fromJsonArrayOfRows) {
   });
   auto data = makeRowVector({input});
 
-  auto rowType = ROW(
-      {"bgstart", "category", "clienttime", "errorcode", "errormsg"},
-      {BOOLEAN(), VARCHAR(), BIGINT(), VARCHAR(), VARCHAR()});
+  auto rowType =
+      ROW({"bgstart", "category", "clienttime", "errorcode", "errormsg"},
+          {BOOLEAN(), VARCHAR(), BIGINT(), VARCHAR(), VARCHAR()});
   auto expression = std::make_shared<const core::CallTypedExpr>(
       ARRAY(rowType),
       std::vector<core::TypedExprPtr>{

--- a/velox/experimental/cudf/vector/CudfVector.cpp
+++ b/velox/experimental/cudf/vector/CudfVector.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include "velox/buffer/Buffer.h"
@@ -108,6 +109,30 @@ void logDefaultStreamIfNeeded(
                << process::StackTrace().toString();
 }
 
+void validatePhysicalSchema(const TypePtr& type, cudf::table_view table) {
+  const auto rowType = asRowType(type);
+  VELOX_CHECK_EQ(
+      rowType->size(),
+      table.num_columns(),
+      "CudfVector physical column count does not match RowType");
+  for (size_t i = 0; i < rowType->size(); ++i) {
+    const auto kind = rowType->childAt(i)->kind();
+    if (kind == TypeKind::ARRAY || kind == TypeKind::MAP ||
+        kind == TypeKind::ROW || kind == TypeKind::UNKNOWN) {
+      continue;
+    }
+    const auto expected = veloxToCudfDataType(rowType->childAt(i));
+    VELOX_CHECK(
+        expected == table.column(i).type(),
+        "CudfVector schema mismatch at column {} ({}): Velox {} -> cuDF {}, actual cuDF {}. The producing GPU operator emitted columns in the wrong order.",
+        i,
+        rowType->nameOf(i),
+        rowType->childAt(i)->toString(),
+        static_cast<int>(expected.id()),
+        static_cast<int>(table.column(i).type().id()));
+  }
+}
+
 } // namespace
 
 CudfVector::CudfVector(
@@ -131,6 +156,7 @@ CudfVector::CudfVector(
   flatSize_ = bytes;
   tablePtr = std::move(tableOut);
   tabView_ = tablePtr->view();
+  validatePhysicalSchema(type_, tabView_);
 }
 
 CudfVector::CudfVector(
@@ -152,6 +178,7 @@ CudfVector::CudfVector(
   auto& packedPtr =
       std::get<std::unique_ptr<cudf::packed_table>>(tableStorage_);
   tabView_ = packedPtr->table;
+  validatePhysicalSchema(type_, tabView_);
   // For packed table, flatSize is the size of the GPU data buffer
   flatSize_ = packedPtr->data.gpu_data->size();
 }

--- a/velox/experimental/ucx-exchange/Acceptor.cpp
+++ b/velox/experimental/ucx-exchange/Acceptor.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cstring>
+
 #include "velox/experimental/ucx-exchange/Acceptor.h"
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
@@ -41,7 +43,19 @@ void Acceptor::cStyleAMCallback(
       "Possible protocol mismatch or truncated message.",
       buffer->getSize(),
       sizeof(HandshakeMsg));
-  HandshakeMsg* handshakePtr = reinterpret_cast<HandshakeMsg*>(buffer->data());
+  // Copy out of UCXX-owned storage before parsing.  This also avoids relying
+  // on the alignment of the active-message receive buffer.
+  HandshakeMsg handshake{};
+  std::memcpy(&handshake, buffer->data(), sizeof(handshake));
+  const auto taskIdEnd = static_cast<const char*>(
+      std::memchr(handshake.taskId, '\0', sizeof(handshake.taskId)));
+  VELOX_CHECK_NOT_NULL(taskIdEnd, "Handshake task id is not NUL terminated");
+  VELOX_CHECK_GT(taskIdEnd, handshake.taskId, "Handshake task id is empty");
+  VELOX_CHECK_LT(
+      handshake.destination,
+      65536,
+      "Handshake destination is invalid: {}",
+      handshake.destination);
 
   // Create a exchangeServer based on the information received in the initial
   // handshake.
@@ -51,7 +65,7 @@ void Acceptor::cStyleAMCallback(
   VELOX_CHECK_NOT_NULL(epRef, "Could not find endpoint reference");
   const std::string peerAddress = epRef->getPeerAddress();
 
-  const PartitionKey key = {handshakePtr->taskId, handshakePtr->destination};
+  const PartitionKey key = {handshake.taskId, handshake.destination};
 
   // Determine if this is an intra-process transfer by comparing the source's
   // workerId with our Communicator's workerId. A match means both source and
@@ -60,7 +74,7 @@ void Acceptor::cStyleAMCallback(
   //
   // Previous approach used IP comparison (getLocalIpAddresses), which fails
   // when multiple Docker containers share the same host IP address.
-  const bool sameWorker = handshakePtr->workerId == communicator->getWorkerId();
+  const bool sameWorker = handshake.workerId == communicator->getWorkerId();
   bool isIntraNodeTransfer =
       cudf_velox::CudfConfig::getInstance().intraNodeExchange && sameWorker;
 
@@ -71,7 +85,7 @@ void Acceptor::cStyleAMCallback(
     const bool canUseIntraNode = queueMgr->canUseIntraNode(key.taskId);
     VLOG(2) << "[UCX-ACCEPTOR-INTRA-CHECK] task=" << key.taskId
             << " destination=" << key.destination << " peer=" << peerAddress
-            << " sourceWorkerId=" << handshakePtr->workerId
+            << " sourceWorkerId=" << handshake.workerId
             << " localWorkerId=" << communicator->getWorkerId()
             << " sameWorker=" << sameWorker
             << " canUseIntraNode=" << canUseIntraNode
@@ -84,7 +98,7 @@ void Acceptor::cStyleAMCallback(
   } else {
     VLOG(2) << "[UCX-ACCEPTOR-REMOTE] task=" << key.taskId
             << " destination=" << key.destination << " peer=" << peerAddress
-            << " sourceWorkerId=" << handshakePtr->workerId
+            << " sourceWorkerId=" << handshake.workerId
             << " localWorkerId=" << communicator->getWorkerId()
             << " sameWorker=" << sameWorker << " intraNodeEnabled="
             << cudf_velox::CudfConfig::getInstance().intraNodeExchange;

--- a/velox/experimental/ucx-exchange/Acceptor.cpp
+++ b/velox/experimental/ucx-exchange/Acceptor.cpp
@@ -15,8 +15,8 @@
  */
 #include <cstring>
 
-#include "velox/experimental/ucx-exchange/Acceptor.h"
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/ucx-exchange/Acceptor.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
 #include "velox/experimental/ucx-exchange/EndpointRef.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -246,7 +246,11 @@ void Communicator::run() {
       // or worker_->signal() is called (from addToWorkQueue,
       // deferEndpointCleanup, or stop).
       if (blockingMode) {
-        worker_->progressWorkerEvent(0);
+        // UCXX defines -1 as an indefinite epoll wait. Passing 0 here turns
+        // the supposedly blocking loop into a busy poll: epoll_wait returns
+        // immediately and the worker's eventfd is read repeatedly with
+        // EAGAIN, consuming a full CPU core per executor while idle.
+        worker_->progressWorkerEvent(-1);
       } else {
         worker_->progress();
       }

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -130,6 +130,11 @@ void Communicator::run() {
   } else {
     context_ = ucxx::createContext({}, UCP_FEATURE_TAG | UCP_FEATURE_AM);
   }
+  LOG(INFO) << "UCX CUDA transport support="
+            << (context_->hasCudaSupport() ? "enabled" : "disabled")
+            << "; remote transfers will use "
+            << (context_->hasCudaSupport() ? "direct device buffers"
+                                           : "host staging");
 
   worker_ = context_->createWorker();
 
@@ -193,6 +198,8 @@ void Communicator::run() {
                 << " workItemsProcessed=" << workItemsProcessed_
                 << " GPU=" << gpuUsedMB << "/" << gpuTotalMB << "MB"
                 << " (free=" << gpuFreeMB << "MB)";
+        VELOX_DCHECK_EQ(
+            numCommElements_.load(std::memory_order_relaxed), elements_.size());
         workItemsProcessed_ = 0;
         lastHeartbeat_ = now;
       }
@@ -246,11 +253,16 @@ void Communicator::run() {
       // or worker_->signal() is called (from addToWorkQueue,
       // deferEndpointCleanup, or stop).
       if (blockingMode) {
-        // UCXX defines -1 as an indefinite epoll wait. Passing 0 here turns
-        // the supposedly blocking loop into a busy poll: epoll_wait returns
-        // immediately and the worker's eventfd is read repeatedly with
-        // EAGAIN, consuming a full CPU core per executor while idle.
-        worker_->progressWorkerEvent(-1);
+        // CUDA IPC/copy completions are not guaranteed to signal the UCX
+        // worker event fd. Busy-progress while an exchange or a deferred
+        // request is active; otherwise a rendezvous can sleep until an
+        // unrelated signal arrives and serialize large GPU shuffles. Once the
+        // communicator is idle, retain the indefinite wait to avoid burning a
+        // CPU core per executor.
+        const bool needsBusyProgress =
+            numCommElements_.load(std::memory_order_relaxed) > 0 ||
+            !deferredRequests_.empty();
+        worker_->progressWorkerEvent(needsBusyProgress ? 0 : -1);
       } else {
         worker_->progress();
       }
@@ -270,7 +282,7 @@ void Communicator::stop() {
   // endpoints_ is only accessed from the Communicator thread, so reading
   // it here would be a data race.
   VLOG(3) << "In Communicator::stop "
-          << " elements_.size(): " << elements_.size()
+          << " elements: " << numCommElements_.load(std::memory_order_relaxed)
           << " workQueue_.size(): " << workQueue_.size();
 }
 
@@ -278,6 +290,7 @@ void Communicator::registerCommElement(std::shared_ptr<CommElement> comms) {
   std::lock_guard<std::mutex> lock(elemMutex_);
   auto ret = elements_.insert(comms);
   VELOX_CHECK(ret.second, "CommElement already registered!");
+  numCommElements_.fetch_add(1, std::memory_order_relaxed);
   // Also put the comms element into the work queue.
   workQueue_.push(comms);
   signalWorker();
@@ -303,7 +316,11 @@ void Communicator::unregister(std::shared_ptr<CommElement> comms) {
     return;
   }
   workQueue_.erase(comms);
-  elements_.erase(comms);
+  if (elements_.erase(comms) > 0) {
+    const auto previous =
+        numCommElements_.fetch_sub(1, std::memory_order_relaxed);
+    VELOX_DCHECK_GT(previous, 0);
+  }
 }
 
 std::shared_ptr<EndpointRef> Communicator::assocEndpointRef(

--- a/velox/experimental/ucx-exchange/Communicator.h
+++ b/velox/experimental/ucx-exchange/Communicator.h
@@ -145,6 +145,14 @@ class Communicator {
     return workerId_;
   }
 
+  /// Returns true when the active UCX context can transfer CUDA memory with
+  /// the configured transports. UCXX derives this from both the UCP-supported
+  /// memory types and UCX_TLS, so callers can safely choose a device receive
+  /// buffer instead of inferring transport support from environment strings.
+  bool hasCudaTransport() const {
+    return context_ != nullptr && context_->hasCudaSupport();
+  }
+
   /// Looks up the EndpointRef associated with a raw UCP endpoint handle.
   /// Used by the Acceptor's active-message callback to resolve the endpoint
   /// that received a handshake request.
@@ -196,6 +204,9 @@ class Communicator {
   // protect elements_ by a mutex. Needs to be mutable if called from a const
   // function.
   std::mutex elemMutex_;
+  // Mirrors elements_.size() without putting a mutex acquisition in the UCX
+  // progress hot loop. Registrations are paired with worker_->signal().
+  std::atomic<size_t> numCommElements_{0};
 
   // The work queue for communication elements that need to do things on
   // the communicator thread.

--- a/velox/experimental/ucx-exchange/EndpointRef.cpp
+++ b/velox/experimental/ucx-exchange/EndpointRef.cpp
@@ -106,7 +106,6 @@ void EndpointRef::closeAndDrainCommunicators() {
   // localCopy is destroyed here, releasing all weak_ptrs.
 }
 
-
 bool EndpointRef::operator<(EndpointRef const& other) {
   if (endpoint_ == other.endpoint_) {
     return false; // covers the case where both are nullptr

--- a/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
+++ b/velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h
@@ -126,8 +126,9 @@ class IntraNodeTransferRegistry {
   /// @param wake Callback fired once when data becomes available or the task is
   ///        cancelled; must be safe to call from the Communicator thread.
   /// @return true if data is ALREADY available (or the task is cancelled) — the
-  ///         caller should re-poll instead of going dormant; false if registered
-  ///         (the caller should go dormant and will be woken via @p wake).
+  ///         caller should re-poll instead of going dormant; false if
+  ///         registered (the caller should go dormant and will be woken via @p
+  ///         wake).
   [[nodiscard]] bool registerWaiter(
       const IntraNodeTransferKey& key,
       std::function<void()> wake);

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 #include "velox/experimental/ucx-exchange/UcxExchangeServer.h"
-#include <algorithm>
 #include <glog/logging.h>
 #include <malloc.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <algorithm>
 #include <cstdlib>
 #include <limits>
 #include <string>
@@ -499,12 +499,12 @@ void UcxExchangeServer::sendData() {
     }
   } else {
     // REMOTE EXCHANGE PATH: Use UCXX for metadata and data transfer
+    const bool useHostStaging = !communicator_->hasCudaTransport();
     std::shared_ptr<DataSendContext> dataCtx;
     if (dataPtr_) {
-      const auto hostBytes =
-          static_cast<int64_t>(dataPtr_->gpu_data->size());
+      const auto hostBytes = static_cast<int64_t>(dataPtr_->gpu_data->size());
       dataCtx = std::make_shared<DataSendContext>();
-      if (!dataCtx->reserveHostBytes(hostBytes)) {
+      if (useHostStaging && !dataCtx->reserveHostBytes(hostBytes)) {
         // Keep dataPtr_ and state=DataReady.  Completed UCX callbacks release
         // process-wide credit; requeueing lets this server retry without
         // dequeuing or staging another packed table.
@@ -611,29 +611,36 @@ void UcxExchangeServer::sendData() {
       // it after the DMA completes, while the Request (and context shell)
       // stays alive for UCP wireup replay.
       dataCtx->data = dataPtr_;
-      dataCtx->hostData = std::make_shared<std::vector<uint8_t>>(bytes_);
-      const auto producerStream = dataCtx->data->gpu_data->stream();
-      CUDF_CUDA_TRY(cudaStreamSynchronize(producerStream.value()));
-      CUDF_CUDA_TRY(cudaMemcpy(
-          dataCtx->hostData->data(),
-          dataCtx->data->gpu_data->data(),
-          bytes_,
-          cudaMemcpyDeviceToHost));
+      void* sendBuffer = dataCtx->data->gpu_data->data();
+      if (useHostStaging) {
+        dataCtx->hostData = std::make_shared<std::vector<uint8_t>>(bytes_);
+        const auto producerStream = dataCtx->data->gpu_data->stream();
+        CUDF_CUDA_TRY(cudaStreamSynchronize(producerStream.value()));
+        CUDF_CUDA_TRY(cudaMemcpy(
+            dataCtx->hostData->data(),
+            dataCtx->data->gpu_data->data(),
+            bytes_,
+            cudaMemcpyDeviceToHost));
+        sendBuffer = dataCtx->hostData->data();
+      }
+      VLOG(2) << "@" << partitionKey_.taskId << " posting "
+              << (useHostStaging ? "host-staged" : "direct-device")
+              << " send for " << bytes_ << " bytes";
 
       dataRequest_ = endpointRef_->endpoint_->tagSend(
-          dataCtx->hostData->data(),
+          sendBuffer,
           static_cast<size_t>(bytes_),
           ucxx::Tag{dataTag},
           false,
           [weakData](ucs_status_t status, std::shared_ptr<void> arg) {
-            // Release both payload buffers from the context.  completedRequests_
-            // deliberately retains the UCXX Request (and therefore callbackData)
-            // for wireup replay safety, so leaving hostData in this context leaks
-            // one complete host-staging copy per batch until the exchange server
-            // is destroyed.  Large MPP exchanges otherwise consume hundreds of
-            // GiB even though every send has completed.  The callback means UCX
-            // has finished with both payloads; only the empty context shell must
-            // remain alive with the Request.
+            // Release both payload buffers from the context. completedRequests_
+            // deliberately retains the UCXX Request (and therefore
+            // callbackData) for wireup replay safety, so leaving hostData in
+            // this context leaks one complete host-staging copy per batch until
+            // the exchange server is destroyed.  Large MPP exchanges otherwise
+            // consume hundreds of GiB even though every send has completed. The
+            // callback means UCX has finished with both payloads; only the
+            // empty context shell must remain alive with the Request.
             auto ctx = std::static_pointer_cast<DataSendContext>(arg);
             auto dataHolder = std::move(ctx->data);
             auto hostDataHolder = std::move(ctx->hostData);

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 #include "velox/experimental/ucx-exchange/UcxExchangeServer.h"
+#include <algorithm>
 #include <glog/logging.h>
+#include <malloc.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <cstdlib>
 #include <limits>
@@ -28,6 +30,40 @@
 namespace facebook::velox::ucx_exchange {
 
 namespace {
+void accountFreedHostBytesAndTrim(uint64_t bytes) {
+  constexpr uint64_t kTrimInterval = 64ULL * 1024 * 1024;
+  static std::atomic<uint64_t> freedSinceTrim{0};
+  if (bytes == 0) {
+    return;
+  }
+  const auto accumulated =
+      freedSinceTrim.fetch_add(bytes, std::memory_order_acq_rel) + bytes;
+  if (accumulated >= kTrimInterval) {
+    const auto claimed = freedSinceTrim.exchange(0, std::memory_order_acq_rel);
+    if (claimed >= kTrimInterval) {
+      malloc_trim(0);
+    }
+  }
+}
+
+void retireRequest(
+    std::shared_ptr<ucxx::Request>& current,
+    std::vector<std::shared_ptr<ucxx::Request>>& inFlight) {
+  inFlight.erase(
+      std::remove_if(
+          inFlight.begin(),
+          inFlight.end(),
+          [](const auto& request) {
+            return request == nullptr || request->isCompleted();
+          }),
+      inFlight.end());
+  if (current != nullptr && !current->isCompleted()) {
+    inFlight.push_back(std::move(current));
+  } else {
+    current.reset();
+  }
+}
+
 const folly::F14FastMap<UcxExchangeServer::ServerState, std::string_view>&
 serverStateNames() {
   static const folly::
@@ -76,6 +112,54 @@ int64_t intraNodeProducerPollRequeueLimit() {
   return limit;
 }
 
+int64_t maxInFlightSendHostBytes() {
+  static const int64_t limit = [] {
+    if (const char* value =
+            std::getenv("GLUTEN_UCX_MAX_INFLIGHT_SEND_HOST_BYTES")) {
+      try {
+        const auto parsed = static_cast<int64_t>(std::stoll(value));
+        if (parsed > 0) {
+          return parsed;
+        }
+      } catch (...) {
+      }
+    }
+    return static_cast<int64_t>(2) * 1024 * 1024 * 1024;
+  }();
+  return limit;
+}
+
+std::atomic<int64_t> inFlightSendHostBytes{0};
+
+bool tryReserveSendHostBytes(int64_t bytes) {
+  VELOX_CHECK_GE(bytes, 0);
+  auto current = inFlightSendHostBytes.load(std::memory_order_relaxed);
+  while (true) {
+    // Permit one oversized transfer when no other host staging is active. A
+    // single packed table cannot be split by the current wire protocol, and
+    // rejecting it forever would deadlock the exchange.
+    if (current > 0 && current + bytes > maxInFlightSendHostBytes()) {
+      return false;
+    }
+    if (inFlightSendHostBytes.compare_exchange_weak(
+            current,
+            current + bytes,
+            std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      return true;
+    }
+  }
+}
+
+void releaseSendHostBytes(int64_t bytes) {
+  if (bytes <= 0) {
+    return;
+  }
+  const auto previous =
+      inFlightSendHostBytes.fetch_sub(bytes, std::memory_order_acq_rel);
+  VELOX_CHECK_GE(previous, bytes);
+}
+
 } // namespace
 
 VELOX_DEFINE_EMBEDDED_ENUM_NAME(
@@ -98,6 +182,32 @@ struct MetaSendContext {
 
 struct DataSendContext {
   std::shared_ptr<cudf::packed_columns> data;
+  // The UCX build used by Gluten MPP may not include CUDA memory-type
+  // transports.  In that case handing an rmm device pointer to tagSend makes
+  // the shared-memory transport memcpy from an inaccessible address.  Keep a
+  // host staging buffer alive with the request and let UCX move host memory.
+  std::shared_ptr<std::vector<uint8_t>> hostData;
+  int64_t reservedHostBytes{0};
+
+  ~DataSendContext() {
+    releaseHostReservation();
+  }
+
+  bool reserveHostBytes(int64_t bytes) {
+    VELOX_CHECK_EQ(reservedHostBytes, 0);
+    if (!tryReserveSendHostBytes(bytes)) {
+      return false;
+    }
+    reservedHostBytes = bytes;
+    return true;
+  }
+
+  void releaseHostReservation() {
+    if (reservedHostBytes > 0) {
+      releaseSendHostBytes(reservedHostBytes);
+      reservedHostBytes = 0;
+    }
+  }
 };
 
 void UcxExchangeServer::setState(ServerState newState) {
@@ -389,6 +499,19 @@ void UcxExchangeServer::sendData() {
     }
   } else {
     // REMOTE EXCHANGE PATH: Use UCXX for metadata and data transfer
+    std::shared_ptr<DataSendContext> dataCtx;
+    if (dataPtr_) {
+      const auto hostBytes =
+          static_cast<int64_t>(dataPtr_->gpu_data->size());
+      dataCtx = std::make_shared<DataSendContext>();
+      if (!dataCtx->reserveHostBytes(hostBytes)) {
+        // Keep dataPtr_ and state=DataReady.  Completed UCX callbacks release
+        // process-wide credit; requeueing lets this server retry without
+        // dequeuing or staging another packed table.
+        communicator_->addToWorkQueue(getSelfPtr());
+        return;
+      }
+    }
     std::shared_ptr<MetadataMsg> metadataMsg = std::make_shared<MetadataMsg>();
 
     if (dataPtr_) {
@@ -417,9 +540,7 @@ void UcxExchangeServer::sendData() {
     // Use weak_ptr to prevent use-after-free if close() is called during
     // callback
     std::weak_ptr<UcxExchangeServer> weakMeta = weak_from_this();
-    if (metaRequest_) {
-      completedRequests_.push_back(std::move(metaRequest_));
-    }
+    retireRequest(metaRequest_, completedRequests_);
 
     // Wrap the serialized metadata in a context so the callback can release
     // it after the send completes, while the Request (and context shell)
@@ -484,33 +605,53 @@ void UcxExchangeServer::sendData() {
       // Use weak_ptr to prevent use-after-free if close() is called during
       // callback
       std::weak_ptr<UcxExchangeServer> weakData = weak_from_this();
-      if (dataRequest_) {
-        completedRequests_.push_back(std::move(dataRequest_));
-      }
+      retireRequest(dataRequest_, completedRequests_);
 
       // Wrap the GPU data buffer in a context so the callback can release
       // it after the DMA completes, while the Request (and context shell)
       // stays alive for UCP wireup replay.
-      auto dataCtx = std::make_shared<DataSendContext>();
       dataCtx->data = dataPtr_;
+      dataCtx->hostData = std::make_shared<std::vector<uint8_t>>(bytes_);
+      const auto producerStream = dataCtx->data->gpu_data->stream();
+      CUDF_CUDA_TRY(cudaStreamSynchronize(producerStream.value()));
+      CUDF_CUDA_TRY(cudaMemcpy(
+          dataCtx->hostData->data(),
+          dataCtx->data->gpu_data->data(),
+          bytes_,
+          cudaMemcpyDeviceToHost));
 
       dataRequest_ = endpointRef_->endpoint_->tagSend(
-          dataCtx->data->gpu_data->data(),
-          dataCtx->data->gpu_data->size(),
+          dataCtx->hostData->data(),
+          static_cast<size_t>(bytes_),
           ucxx::Tag{dataTag},
           false,
           [weakData](ucs_status_t status, std::shared_ptr<void> arg) {
-            // Release the GPU data buffer from the context. The DMA has
-            // completed by the time this callback fires, so the buffer is
-            // safe to free. The context shell stays alive with the Request.
+            // Release both payload buffers from the context.  completedRequests_
+            // deliberately retains the UCXX Request (and therefore callbackData)
+            // for wireup replay safety, so leaving hostData in this context leaks
+            // one complete host-staging copy per batch until the exchange server
+            // is destroyed.  Large MPP exchanges otherwise consume hundreds of
+            // GiB even though every send has completed.  The callback means UCX
+            // has finished with both payloads; only the empty context shell must
+            // remain alive with the Request.
             auto ctx = std::static_pointer_cast<DataSendContext>(arg);
             auto dataHolder = std::move(ctx->data);
+            auto hostDataHolder = std::move(ctx->hostData);
+            const auto releasedHostBytes = ctx->reservedHostBytes;
+            ctx->releaseHostReservation();
+            hostDataHolder.reset();
+            // The default allocator retains these very large vector arenas in
+            // the executor even after free().  A long exchange therefore has
+            // bounded live staging but unbounded RSS. Return completed large
+            // transfers to the OS instead of waiting for process teardown.
+            accountFreedHostBytesAndTrim(releasedHostBytes);
 
             if (auto self = weakData.lock()) {
               self->sendComplete(status, arg);
             }
-            // dataHolder is destroyed here, releasing the GPU buffer if
-            // sendComplete() already reset the server's dataPtr_.
+            // The holders are destroyed here, releasing the GPU buffer if
+            // sendComplete() already reset the server's dataPtr_, and always
+            // releasing the completed transfer's host staging allocation.
           },
           dataCtx);
     } else {

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <algorithm>
 #include <cstdlib>
 #include <string>
 #include <thread>
@@ -22,6 +23,8 @@
 #include <cudf/contiguous_split.hpp>
 #include <folly/String.h>
 #include <folly/Uri.h>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/statistics_resource_adaptor.hpp>
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h"
@@ -31,6 +34,30 @@ using namespace facebook::velox::exec;
 namespace facebook::velox::ucx_exchange {
 
 namespace {
+void retireRequest(
+    std::shared_ptr<ucxx::Request>& current,
+    std::vector<std::shared_ptr<ucxx::Request>>& inFlight) {
+  // UCXX removes a request from the endpoint/worker inflight collections and
+  // frees its UCP handle before invoking the user completion callback.  A
+  // completed Request therefore does not need to be retained.  Keeping every
+  // completed receive until exchange teardown grows without bound on packet-
+  // heavy shuffles.  Preserve only requests that are genuinely still in
+  // progress, and prune those as soon as a later packet observes completion.
+  inFlight.erase(
+      std::remove_if(
+          inFlight.begin(),
+          inFlight.end(),
+          [](const auto& request) {
+            return request == nullptr || request->isCompleted();
+          }),
+      inFlight.end());
+  if (current != nullptr && !current->isCompleted()) {
+    inFlight.push_back(std::move(current));
+  } else {
+    current.reset();
+  }
+}
+
 const folly::F14FastMap<UcxExchangeSource::ReceiverState, std::string_view>&
 receiverStateNames() {
   static const folly::F14FastMap<
@@ -53,6 +80,97 @@ receiverStateNames() {
           {UcxExchangeSource::ReceiverState::Done, "Done"},
       };
   return kNames;
+}
+
+int64_t maxInFlightRecvHostBytes() {
+  static const int64_t limit = [] {
+    if (const char* value =
+            std::getenv("GLUTEN_UCX_MAX_INFLIGHT_RECV_HOST_BYTES")) {
+      try {
+        const auto parsed = static_cast<int64_t>(std::stoll(value));
+        if (parsed > 0) {
+          return parsed;
+        }
+      } catch (...) {
+      }
+    }
+    return static_cast<int64_t>(2) * 1024 * 1024 * 1024;
+  }();
+  return limit;
+}
+
+std::atomic<int64_t> inFlightRecvHostBytes{0};
+
+rmm::mr::statistics_resource_adaptor& receiveDeviceMemoryResource() {
+  // Keep UCX receive allocations on a synchronous, fresh cudaMalloc resource,
+  // but wrap it with RMM statistics so queued packed pages are visible in
+  // diagnostics even after ownership moves out of UcxExchangeSource.
+  static rmm::mr::statistics_resource_adaptor resource{
+      cuda::mr::any_resource<cuda::mr::device_accessible>{
+          rmm::mr::cuda_memory_resource{}}};
+  return resource;
+}
+
+int64_t maxInFlightRecvDeviceBytes() {
+  static const int64_t limit = [] {
+    if (const char* value =
+            std::getenv("GLUTEN_UCX_MAX_INFLIGHT_RECV_DEVICE_BYTES")) {
+      try {
+        const auto parsed = static_cast<int64_t>(std::stoll(value));
+        if (parsed > 0) {
+          return parsed;
+        }
+      } catch (...) {
+      }
+    }
+    // A query-wide credit pool needs dependency-aware wakeups. A blind global
+    // cap can deadlock a DAG when an edge holding credit is downstream of an
+    // edge waiting for credit. Keep this diagnostic mechanism opt-in until
+    // the coordinator owns that dependency-aware arbitration.
+    return static_cast<int64_t>(0);
+  }();
+  return limit;
+}
+
+bool hasRecvDeviceCredit(int64_t bytes) {
+  const auto limit = maxInFlightRecvDeviceBytes();
+  if (limit <= 0) {
+    return true;
+  }
+  const auto current = receiveDeviceMemoryResource().get_bytes_counter().value;
+  // Packed tables cannot be split. Permit one oversized receive only when no
+  // other receive page is live, matching the host-credit behavior.
+  return current == 0 || current + bytes <= limit;
+}
+
+std::atomic<int64_t> lastReportedReceiveDevicePeakBucket{0};
+
+bool tryReserveRecvHostBytes(int64_t bytes) {
+  VELOX_CHECK_GE(bytes, 0);
+  auto current = inFlightRecvHostBytes.load(std::memory_order_relaxed);
+  while (true) {
+    // The current protocol cannot split one packed table. Permit one
+    // oversized receive when the process has no other host receive buffer.
+    if (current > 0 && current + bytes > maxInFlightRecvHostBytes()) {
+      return false;
+    }
+    if (inFlightRecvHostBytes.compare_exchange_weak(
+            current,
+            current + bytes,
+            std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      return true;
+    }
+  }
+}
+
+void releaseRecvHostBytes(int64_t bytes) {
+  if (bytes <= 0) {
+    return;
+  }
+  const auto previous =
+      inFlightRecvHostBytes.fetch_sub(bytes, std::memory_order_acq_rel);
+  VELOX_CHECK_GE(previous, bytes);
 }
 } // namespace
 
@@ -383,11 +501,14 @@ void UcxExchangeSource::deliverEndMarker() {
 }
 
 void UcxExchangeSource::releaseReceiveReservation() {
-  if (reservedReceiveBytes_ <= 0) {
-    return;
+  if (reservedReceiveBytes_ > 0) {
+    queue_->releaseReservedReceive(reservedReceiveBytes_);
+    reservedReceiveBytes_ = 0;
   }
-  queue_->releaseReservedReceive(reservedReceiveBytes_);
-  reservedReceiveBytes_ = 0;
+  if (reservedGlobalHostReceiveBytes_ > 0) {
+    releaseRecvHostBytes(reservedGlobalHostReceiveBytes_);
+    reservedGlobalHostReceiveBytes_ = 0;
+  }
 }
 
 void UcxExchangeSource::setEndpoint(std::shared_ptr<EndpointRef> endpointRef) {
@@ -395,7 +516,8 @@ void UcxExchangeSource::setEndpoint(std::shared_ptr<EndpointRef> endpointRef) {
 }
 
 void UcxExchangeSource::sendHandshake() {
-  std::shared_ptr<HandshakeMsg> handshakeReq = std::make_shared<HandshakeMsg>();
+  handshakeRequestBuffer_ = std::make_shared<HandshakeMsg>();
+  auto& handshakeReq = handshakeRequestBuffer_;
   handshakeReq->destination = partitionKey_.destination;
   // Use sizeof(...) - 1 and explicitly null-terminate to prevent buffer
   // overread if taskId is longer than the destination buffer.
@@ -416,9 +538,7 @@ void UcxExchangeSource::sendHandshake() {
       communicator_->kAmCallbackOwner, communicator_->kAmCallbackId);
   // Use weak_ptr to prevent use-after-free if close() is called during callback
   std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
-  if (request_) {
-    completedRequests_.push_back(std::move(request_));
-  }
+  retireRequest(request_, completedRequests_);
   // Pass handshakeReq as the callback arg to keep the send buffer alive until
   // the async amSend completes. UCXX stores it as shared_ptr<void> but the
   // type-erased deleter still calls ~HandshakeMsg correctly.
@@ -481,8 +601,14 @@ void UcxExchangeSource::onHandshake(
 
 void UcxExchangeSource::getMetadata() {
   // Use kMaxMetaBufSize to support tables with many columns.
-  // The sender allocates exact size needed; receiver pre-allocates max.
-  auto metadataReq = std::make_shared<std::vector<uint8_t>>(kMaxMetaBufSize);
+  // The sender allocates exact size needed; receiver pre-allocates max. A
+  // source has only one receive in flight, so reuse this buffer for all
+  // packets instead of creating one mmap-backed allocation per request.
+  if (metadataReceiveBuffer_ == nullptr) {
+    metadataReceiveBuffer_ =
+        std::make_shared<std::vector<uint8_t>>(kMaxMetaBufSize);
+  }
+  auto metadataReq = metadataReceiveBuffer_;
   uint64_t metadataTag = getMetadataTag(partitionKeyHash_, sequenceNumber_);
 
   VLOG(3) << toString()
@@ -491,9 +617,7 @@ void UcxExchangeSource::getMetadata() {
 
   // Use weak_ptr to prevent use-after-free if close() is called during callback
   std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
-  if (request_) {
-    completedRequests_.push_back(std::move(request_));
-  }
+  retireRequest(request_, completedRequests_);
   request_ = endpointRef_->endpoint_->tagRecv(
       reinterpret_cast<void*>(metadataReq->data()),
       kMaxMetaBufSize,
@@ -501,8 +625,10 @@ void UcxExchangeSource::getMetadata() {
       ucxx::TagMaskFull,
       false,
       [weak](ucs_status_t status, std::shared_ptr<void> arg) {
+        auto metadata =
+            std::static_pointer_cast<std::vector<uint8_t>>(arg);
         if (auto self = weak.lock()) {
-          self->onMetadata(status, arg);
+          self->onMetadata(status, metadata);
         }
       },
       metadataReq);
@@ -596,6 +722,31 @@ bool UcxExchangeSource::tryStartDataReceive(
   }
   reservedReceiveBytes_ = ptr->metadata.dataSizeBytes;
 
+  if (!tryReserveRecvHostBytes(ptr->metadata.dataSizeBytes)) {
+    queue_->releaseReservedReceive(reservedReceiveBytes_);
+    reservedReceiveBytes_ = 0;
+    if (getState() == expectedState) {
+      setStateIf(expectedState, ReceiverState::WaitingForReceiveCredit);
+    }
+    // Global credit is shared across otherwise unrelated ExchangeQueues, so
+    // a dequeue from this queue cannot wake us. Retry from the communicator
+    // work loop; completed receives release the process-wide credit below.
+    communicator_->addToWorkQueue(getSelfPtr());
+    return false;
+  }
+  reservedGlobalHostReceiveBytes_ = ptr->metadata.dataSizeBytes;
+
+  if (!hasRecvDeviceCredit(ptr->metadata.dataSizeBytes)) {
+    releaseReceiveReservation();
+    if (getState() == expectedState) {
+      setStateIf(expectedState, ReceiverState::WaitingForReceiveCredit);
+    }
+    // A different ExchangeQueue may release the process-wide credit. Retry
+    // from the communicator loop instead of waiting on this queue's promise.
+    communicator_->addToWorkQueue(getSelfPtr());
+    return false;
+  }
+
   // REMOTE EXCHANGE PATH: Allocate buffer and receive via UCXX.
   auto stream =
       facebook::velox::cudf_velox::cudfGlobalStreamPool().get_stream();
@@ -613,13 +764,49 @@ bool UcxExchangeSource::tryStartDataReceive(
   // cuda_memory_resource (raw cudaMalloc) returns fresh, never-reused memory
   // that is valid immediately, so no stream sync is needed and there is no reuse
   // race. These buffers are short-lived and bounded by queue receive credit.
-  static rmm::mr::cuda_memory_resource recvMemoryResource;
   try {
+    auto& recvMemoryResource = receiveDeviceMemoryResource();
     ptr->dataBuf = std::make_unique<rmm::device_buffer>(
         ptr->metadata.dataSizeBytes,
         stream,
         cuda::mr::any_resource<cuda::mr::device_accessible>{
             recvMemoryResource});
+    if (facebook::velox::cudf_velox::deviceMemoryDiagnosticsEnabled()) {
+      constexpr int64_t kReportStep = 512LL << 20;
+      const auto bytes = recvMemoryResource.get_bytes_counter();
+      const auto peakBucket = bytes.peak / kReportStep;
+      auto reported =
+          lastReportedReceiveDevicePeakBucket.load(std::memory_order_relaxed);
+      bool crossedPeakBucket = false;
+      while (peakBucket > reported) {
+        if (lastReportedReceiveDevicePeakBucket.compare_exchange_weak(
+                reported,
+                peakBucket,
+                std::memory_order_acq_rel,
+                std::memory_order_relaxed)) {
+          crossedPeakBucket = true;
+          break;
+        }
+      }
+      if (crossedPeakBucket ||
+          ptr->metadata.dataSizeBytes >= static_cast<uint64_t>(64) << 20) {
+        facebook::velox::cudf_velox::logDeviceMemorySnapshot(fmt::format(
+            "operator=UcxExchangeSource state=receive.allocate "
+            "task={} remoteTask={} destination={} allocationBytes={} "
+            "ucxRecvCurrentBytes={} ucxRecvPeakBytes={} "
+            "ucxRecvTotalBytes={} queueBytes={} pendingReceiveBytes={} cap={}",
+            taskId_,
+            partitionKey_.taskId,
+            partitionKey_.destination,
+            ptr->metadata.dataSizeBytes,
+            bytes.value,
+            bytes.peak,
+            bytes.total,
+            stats.queuedBytes,
+            stats.pendingReceiveBytes,
+            maxInFlightRecvBytes()));
+      }
+    }
   } catch (const rmm::bad_alloc& e) {
     releaseReceiveReservation();
     VLOG(0) << toString() << " *** RMM failed to allocate "
@@ -634,6 +821,18 @@ bool UcxExchangeSource::tryStartDataReceive(
   VLOG(3) << toString() << " Allocated " << ptr->metadata.dataSizeBytes
           << " bytes of device memory";
 
+  // UCX without CUDA transports must receive into host memory.  Receiving
+  // directly into dataBuf lets the sm/tcp transports write through a device
+  // pointer and crashes the executor.  The completed host buffer is copied to
+  // the cuDF device buffer in onData before unpacking.
+  const auto receiveSize = static_cast<size_t>(ptr->metadata.dataSizeBytes);
+  if (dataReceiveBuffer_ == nullptr) {
+    dataReceiveBuffer_ = std::make_shared<std::vector<uint8_t>>(receiveSize);
+  } else if (dataReceiveBuffer_->size() < receiveSize) {
+    dataReceiveBuffer_->resize(receiveSize);
+  }
+  ptr->hostData = dataReceiveBuffer_;
+
   uint64_t dataTag = getDataTag(partitionKeyHash_, sequenceNumber_);
   VLOG(3) << toString() << " waiting for data for chunk: " << sequenceNumber_
           << " using tag: " << std::hex << dataTag << std::dec;
@@ -645,11 +844,9 @@ bool UcxExchangeSource::tryStartDataReceive(
   }
 
   std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
-  if (request_) {
-    completedRequests_.push_back(std::move(request_));
-  }
+  retireRequest(request_, completedRequests_);
   request_ = endpointRef_->endpoint_->tagRecv(
-      ptr->dataBuf->data(),
+      ptr->hostData->data(),
       ptr->metadata.dataSizeBytes,
       ucxx::Tag{dataTag},
       ucxx::TagMaskFull,
@@ -705,6 +902,20 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
     std::shared_ptr<DataAndMetadata> ptr =
         std::static_pointer_cast<DataAndMetadata>(arg);
 
+    CUDF_CUDA_TRY(cudaMemcpy(
+        ptr->dataBuf->data(),
+        ptr->hostData->data(),
+        ptr->metadata.dataSizeBytes,
+        cudaMemcpyHostToDevice));
+    ptr->hostData.reset();
+    if (reservedGlobalHostReceiveBytes_ > 0) {
+      releaseRecvHostBytes(reservedGlobalHostReceiveBytes_);
+      reservedGlobalHostReceiveBytes_ = 0;
+    }
+    // The source-level pageable staging buffer is intentionally retained and
+    // reused by the next serial receive, so there is no host allocation to
+    // trim here.
+
     metrics_.numPackedColumns_.addValue(1);
     metrics_.totalBytes_.addValue(ptr->metadata.dataSizeBytes);
 
@@ -739,9 +950,7 @@ void UcxExchangeSource::receiveHandshakeResponse() {
 
   // Use weak_ptr to prevent use-after-free if close() is called during callback
   std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
-  if (request_) {
-    completedRequests_.push_back(std::move(request_));
-  }
+  retireRequest(request_, completedRequests_);
   request_ = endpointRef_->endpoint_->tagRecv(
       responseBuffer.get(),
       sizeof(*responseBuffer),
@@ -759,6 +968,9 @@ void UcxExchangeSource::receiveHandshakeResponse() {
 void UcxExchangeSource::onHandshakeResponse(
     ucs_status_t status,
     std::shared_ptr<void> arg) {
+  // The peer has now consumed the AM payload and returned a response, so the
+  // retained handshake buffer can finally be released.
+  handshakeRequestBuffer_.reset();
   // Check if close() was called - avoid processing if we're shutting down
   if (closed_.load(std::memory_order_acquire)) {
     VLOG(3) << toString()

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -755,31 +755,22 @@ bool UcxExchangeSource::tryStartDataReceive(
       facebook::velox::cudf_velox::cudfGlobalStreamPool().get_stream();
   ptr->stream = stream;
 
-  // A CUDA-aware receive uses the same async/pool resource as cuDF compute.
-  // Allocating every packet with raw cudaMalloc globally synchronizes the
-  // device and dominates large shuffles. Synchronize only this receive stream
-  // after the allocation so UCX cannot write into a block whose stream-ordered
-  // reuse is still pending. The packed page keeps this stream through the
-  // consumer handoff.
+  // UCX writes receive buffers from its progress thread, outside CUDA stream
+  // ordering. Keep these buffers on a dedicated synchronous resource so UCX
+  // can never write into a block that a stream-ordered pool has recycled while
+  // work on another stream is still in flight. This also avoids waiting on an
+  // unrelated compute stream in the single UCX progress thread.
   //
-  // Without a CUDA transport, keep using fresh synchronous memory. The host
-  // fallback copies into it with cudaMemcpy and does not need to compete with
-  // cuDF's async pool.
+  // Only transports without CUDA support stage through host memory and use a
+  // fresh synchronous device allocation for the final copy.
   try {
-    if (useHostStaging) {
-      auto& recvMemoryResource = receiveDeviceMemoryResource();
-      ptr->dataBuf = std::make_unique<rmm::device_buffer>(
-          ptr->metadata.dataSizeBytes,
-          stream,
-          cuda::mr::any_resource<cuda::mr::device_accessible>{
-              recvMemoryResource});
-    } else {
-      ptr->dataBuf = std::make_unique<rmm::device_buffer>(
-          ptr->metadata.dataSizeBytes, stream);
-      stream.synchronize();
-    }
+    auto& recvMemoryResource = receiveDeviceMemoryResource();
+    ptr->dataBuf = std::make_unique<rmm::device_buffer>(
+        ptr->metadata.dataSizeBytes,
+        stream,
+        cuda::mr::any_resource<cuda::mr::device_accessible>{
+            recvMemoryResource});
     if (facebook::velox::cudf_velox::deviceMemoryDiagnosticsEnabled()) {
-      auto& recvMemoryResource = receiveDeviceMemoryResource();
       constexpr int64_t kReportStep = 512LL << 20;
       const auto bytes = recvMemoryResource.get_bytes_counter();
       const auto peakBucket = bytes.peak / kReportStep;

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -330,7 +330,8 @@ void UcxExchangeSource::process() {
       // Waiting for metadata is handled by an upcall from UCXX. Nothing to do
       break;
     case ReceiverState::WaitingForReceiveCredit:
-      tryStartDataReceive(pendingReceive_, ReceiverState::WaitingForReceiveCredit);
+      tryStartDataReceive(
+          pendingReceive_, ReceiverState::WaitingForReceiveCredit);
       break;
     case ReceiverState::WaitingForData:
       // Waiting for data is handled by an upcall from UCXX. Nothing to do.
@@ -625,8 +626,7 @@ void UcxExchangeSource::getMetadata() {
       ucxx::TagMaskFull,
       false,
       [weak](ucs_status_t status, std::shared_ptr<void> arg) {
-        auto metadata =
-            std::static_pointer_cast<std::vector<uint8_t>>(arg);
+        auto metadata = std::static_pointer_cast<std::vector<uint8_t>>(arg);
         if (auto self = weak.lock()) {
           self->onMetadata(status, metadata);
         }
@@ -722,7 +722,8 @@ bool UcxExchangeSource::tryStartDataReceive(
   }
   reservedReceiveBytes_ = ptr->metadata.dataSizeBytes;
 
-  if (!tryReserveRecvHostBytes(ptr->metadata.dataSizeBytes)) {
+  const bool useHostStaging = !communicator_->hasCudaTransport();
+  if (useHostStaging && !tryReserveRecvHostBytes(ptr->metadata.dataSizeBytes)) {
     queue_->releaseReservedReceive(reservedReceiveBytes_);
     reservedReceiveBytes_ = 0;
     if (getState() == expectedState) {
@@ -734,7 +735,9 @@ bool UcxExchangeSource::tryStartDataReceive(
     communicator_->addToWorkQueue(getSelfPtr());
     return false;
   }
-  reservedGlobalHostReceiveBytes_ = ptr->metadata.dataSizeBytes;
+  if (useHostStaging) {
+    reservedGlobalHostReceiveBytes_ = ptr->metadata.dataSizeBytes;
+  }
 
   if (!hasRecvDeviceCredit(ptr->metadata.dataSizeBytes)) {
     releaseReceiveReservation();
@@ -752,26 +755,31 @@ bool UcxExchangeSource::tryStartDataReceive(
       facebook::velox::cudf_velox::cudfGlobalStreamPool().get_stream();
   ptr->stream = stream;
 
-  // Receive buffers MUST come from a dedicated, synchronous, fresh-memory
-  // resource — NOT the shared RMM pool. UCX RDMA-writes this buffer from the
-  // progress thread, out of band of any CUDA stream. The two pool-based
-  // alternatives both fail:
-  //   * pool alloc + stream.synchronize() -> deadlocks the UCX progress thread
-  //     (hang on heavy multi-fragment queries, e.g. Q18).
-  //   * pool alloc + no synchronize -> the pool may hand back a block still in
-  //     flight on another stream; UCX writing into it corrupts memory and
-  //     SIGSEGVs the process (observed crashing the driver at Q14).
-  // cuda_memory_resource (raw cudaMalloc) returns fresh, never-reused memory
-  // that is valid immediately, so no stream sync is needed and there is no reuse
-  // race. These buffers are short-lived and bounded by queue receive credit.
+  // A CUDA-aware receive uses the same async/pool resource as cuDF compute.
+  // Allocating every packet with raw cudaMalloc globally synchronizes the
+  // device and dominates large shuffles. Synchronize only this receive stream
+  // after the allocation so UCX cannot write into a block whose stream-ordered
+  // reuse is still pending. The packed page keeps this stream through the
+  // consumer handoff.
+  //
+  // Without a CUDA transport, keep using fresh synchronous memory. The host
+  // fallback copies into it with cudaMemcpy and does not need to compete with
+  // cuDF's async pool.
   try {
-    auto& recvMemoryResource = receiveDeviceMemoryResource();
-    ptr->dataBuf = std::make_unique<rmm::device_buffer>(
-        ptr->metadata.dataSizeBytes,
-        stream,
-        cuda::mr::any_resource<cuda::mr::device_accessible>{
-            recvMemoryResource});
+    if (useHostStaging) {
+      auto& recvMemoryResource = receiveDeviceMemoryResource();
+      ptr->dataBuf = std::make_unique<rmm::device_buffer>(
+          ptr->metadata.dataSizeBytes,
+          stream,
+          cuda::mr::any_resource<cuda::mr::device_accessible>{
+              recvMemoryResource});
+    } else {
+      ptr->dataBuf = std::make_unique<rmm::device_buffer>(
+          ptr->metadata.dataSizeBytes, stream);
+      stream.synchronize();
+    }
     if (facebook::velox::cudf_velox::deviceMemoryDiagnosticsEnabled()) {
+      auto& recvMemoryResource = receiveDeviceMemoryResource();
       constexpr int64_t kReportStep = 512LL << 20;
       const auto bytes = recvMemoryResource.get_bytes_counter();
       const auto peakBucket = bytes.peak / kReportStep;
@@ -790,21 +798,22 @@ bool UcxExchangeSource::tryStartDataReceive(
       }
       if (crossedPeakBucket ||
           ptr->metadata.dataSizeBytes >= static_cast<uint64_t>(64) << 20) {
-        facebook::velox::cudf_velox::logDeviceMemorySnapshot(fmt::format(
-            "operator=UcxExchangeSource state=receive.allocate "
-            "task={} remoteTask={} destination={} allocationBytes={} "
-            "ucxRecvCurrentBytes={} ucxRecvPeakBytes={} "
-            "ucxRecvTotalBytes={} queueBytes={} pendingReceiveBytes={} cap={}",
-            taskId_,
-            partitionKey_.taskId,
-            partitionKey_.destination,
-            ptr->metadata.dataSizeBytes,
-            bytes.value,
-            bytes.peak,
-            bytes.total,
-            stats.queuedBytes,
-            stats.pendingReceiveBytes,
-            maxInFlightRecvBytes()));
+        facebook::velox::cudf_velox::logDeviceMemorySnapshot(
+            fmt::format(
+                "operator=UcxExchangeSource state=receive.allocate "
+                "task={} remoteTask={} destination={} allocationBytes={} "
+                "ucxRecvCurrentBytes={} ucxRecvPeakBytes={} "
+                "ucxRecvTotalBytes={} queueBytes={} pendingReceiveBytes={} cap={}",
+                taskId_,
+                partitionKey_.taskId,
+                partitionKey_.destination,
+                ptr->metadata.dataSizeBytes,
+                bytes.value,
+                bytes.peak,
+                bytes.total,
+                stats.queuedBytes,
+                stats.pendingReceiveBytes,
+                maxInFlightRecvBytes()));
       }
     }
   } catch (const rmm::bad_alloc& e) {
@@ -821,17 +830,24 @@ bool UcxExchangeSource::tryStartDataReceive(
   VLOG(3) << toString() << " Allocated " << ptr->metadata.dataSizeBytes
           << " bytes of device memory";
 
-  // UCX without CUDA transports must receive into host memory.  Receiving
-  // directly into dataBuf lets the sm/tcp transports write through a device
-  // pointer and crashes the executor.  The completed host buffer is copied to
-  // the cuDF device buffer in onData before unpacking.
-  const auto receiveSize = static_cast<size_t>(ptr->metadata.dataSizeBytes);
-  if (dataReceiveBuffer_ == nullptr) {
-    dataReceiveBuffer_ = std::make_shared<std::vector<uint8_t>>(receiveSize);
-  } else if (dataReceiveBuffer_->size() < receiveSize) {
-    dataReceiveBuffer_->resize(receiveSize);
+  // CUDA-aware transports can receive directly into the final device buffer.
+  // Only stage through host memory when the active UCX context has confirmed
+  // that no CUDA transport is available; sm/tcp cannot write through a device
+  // pointer safely in that configuration.
+  void* receiveBuffer = ptr->dataBuf->data();
+  if (useHostStaging) {
+    const auto receiveSize = static_cast<size_t>(ptr->metadata.dataSizeBytes);
+    if (dataReceiveBuffer_ == nullptr) {
+      dataReceiveBuffer_ = std::make_shared<std::vector<uint8_t>>(receiveSize);
+    } else if (dataReceiveBuffer_->size() < receiveSize) {
+      dataReceiveBuffer_->resize(receiveSize);
+    }
+    ptr->hostData = dataReceiveBuffer_;
+    receiveBuffer = ptr->hostData->data();
   }
-  ptr->hostData = dataReceiveBuffer_;
+  VLOG(2) << toString() << " posting "
+          << (useHostStaging ? "host-staged" : "direct-device")
+          << " receive for " << ptr->metadata.dataSizeBytes << " bytes";
 
   uint64_t dataTag = getDataTag(partitionKeyHash_, sequenceNumber_);
   VLOG(3) << toString() << " waiting for data for chunk: " << sequenceNumber_
@@ -846,7 +862,7 @@ bool UcxExchangeSource::tryStartDataReceive(
   std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
   retireRequest(request_, completedRequests_);
   request_ = endpointRef_->endpoint_->tagRecv(
-      ptr->hostData->data(),
+      receiveBuffer,
       ptr->metadata.dataSizeBytes,
       ucxx::Tag{dataTag},
       ucxx::TagMaskFull,
@@ -902,19 +918,20 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
     std::shared_ptr<DataAndMetadata> ptr =
         std::static_pointer_cast<DataAndMetadata>(arg);
 
-    CUDF_CUDA_TRY(cudaMemcpy(
-        ptr->dataBuf->data(),
-        ptr->hostData->data(),
-        ptr->metadata.dataSizeBytes,
-        cudaMemcpyHostToDevice));
-    ptr->hostData.reset();
-    if (reservedGlobalHostReceiveBytes_ > 0) {
-      releaseRecvHostBytes(reservedGlobalHostReceiveBytes_);
-      reservedGlobalHostReceiveBytes_ = 0;
+    if (ptr->hostData != nullptr) {
+      CUDF_CUDA_TRY(cudaMemcpy(
+          ptr->dataBuf->data(),
+          ptr->hostData->data(),
+          ptr->metadata.dataSizeBytes,
+          cudaMemcpyHostToDevice));
+      ptr->hostData.reset();
+      if (reservedGlobalHostReceiveBytes_ > 0) {
+        releaseRecvHostBytes(reservedGlobalHostReceiveBytes_);
+        reservedGlobalHostReceiveBytes_ = 0;
+      }
     }
-    // The source-level pageable staging buffer is intentionally retained and
-    // reused by the next serial receive, so there is no host allocation to
-    // trim here.
+    // The source-level pageable fallback buffer is intentionally retained and
+    // reused by the next serial host-staged receive.
 
     metrics_.numPackedColumns_.addValue(1);
     metrics_.totalBytes_.addValue(ptr->metadata.dataSizeBytes);

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -118,11 +118,12 @@ class UcxExchangeSource
   static constexpr int32_t kBackpressureLowWaterMark = 16;
 
   // Aggregate in-flight RECEIVE byte cap (in addition to the count caps above).
-  // Receive buffers are allocated off the operator memory pool (raw cudaMalloc
-  // via a process-global resource), so without a byte bound the per-peer
-  // in-flight buffers (one UcxExchangeSource per producer peer) scale
-  // O(#peers) and collectively exhaust the GPU at 4 peers (OOM at
-  // concurrentGpuTasks=2, deadlock at =1). Read once; env-overridable via
+  // Each source can own a queued device buffer independently of downstream
+  // consumption. Without a byte bound these buffers (one UcxExchangeSource per
+  // producer peer) scale O(#peers) and collectively exhaust the GPU at 4 peers
+  // (OOM at concurrentGpuTasks=2, deadlock at =1). CUDA-aware transports use
+  // the current cuDF memory resource; the host fallback uses fresh cudaMalloc
+  // memory. Read once; env-overridable via
   // GLUTEN_UCX_MAX_INFLIGHT_RECV_BYTES (default 8 GiB).
   static int64_t maxInFlightRecvBytes();
 

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -121,9 +121,10 @@ class UcxExchangeSource
   // Each source can own a queued device buffer independently of downstream
   // consumption. Without a byte bound these buffers (one UcxExchangeSource per
   // producer peer) scale O(#peers) and collectively exhaust the GPU at 4 peers
-  // (OOM at concurrentGpuTasks=2, deadlock at =1). CUDA-aware transports use
-  // the current cuDF memory resource; the host fallback uses fresh cudaMalloc
-  // memory. Read once; env-overridable via
+  // (OOM at concurrentGpuTasks=2, deadlock at =1). Remote receives use a
+  // dedicated fresh cudaMalloc resource so UCX writes cannot race with
+  // stream-ordered reuse in the cuDF compute pool. Read once; env-overridable
+  // via
   // GLUTEN_UCX_MAX_INFLIGHT_RECV_BYTES (default 8 GiB).
   static int64_t maxInFlightRecvBytes();
 

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -155,8 +155,22 @@ class UcxExchangeSource
   struct DataAndMetadata {
     MetadataMsg metadata;
     std::unique_ptr<rmm::device_buffer> dataBuf;
+    std::shared_ptr<std::vector<uint8_t>> hostData;
     rmm::cuda_stream_view stream; // The stream used to allocate dataBuf
   };
+
+  // Metadata receives are strictly serial for a source. Reuse one fixed-size
+  // receive buffer instead of allocating a new 1 MiB mapping per packet.
+  // Some UCXX request internals outlive the user callback, so per-packet
+  // buffers otherwise accumulate until exchange teardown.
+  std::shared_ptr<std::vector<uint8_t>> metadataReceiveBuffer_;
+
+  // Data receives are also strictly serial for a source. Keep one pageable
+  // staging allocation and use synchronous CUDA copies. Explicit pinned
+  // allocations trigger a PCI SERR on this host, while async copies from
+  // pageable per-packet buffers make the CUDA runtime retain implicit pinned
+  // staging mappings.
+  std::shared_ptr<std::vector<uint8_t>> dataReceiveBuffer_;
 
   /// @brief The constructor is private in order to ensure that exchange sources
   /// are always generated through a shared pointer. This ensures that
@@ -306,6 +320,7 @@ class UcxExchangeSource
   std::atomic<bool> backpressureActive_{false};
   std::shared_ptr<DataAndMetadata> pendingReceive_;
   int64_t reservedReceiveBytes_{0};
+  int64_t reservedGlobalHostReceiveBytes_{0};
 
   // Some metrics/counters:
   UcxExchangeMetrics metrics_;
@@ -315,6 +330,13 @@ class UcxExchangeSource
   // NOTE: The request owns/holds a reference to the upcall function
   // and must therefore exist until the upcall is done.
   std::shared_ptr<ucxx::Request> request_{nullptr};
+
+  // Keep the active-message payload alive until the peer acknowledges the
+  // handshake.  UCXX reports local AM completion before the receiver callback
+  // has necessarily copied an eager payload under a large burst of sources.
+  // Releasing this at local completion can therefore let the allocator reuse
+  // the buffer while the peer is still decoding it.
+  std::shared_ptr<HandshakeMsg> handshakeRequestBuffer_{nullptr};
 
   // Completed UCXX requests are kept alive here to prevent use-after-free.
   // UCP's ucp_wireup_replay_pending_requests can fire callbacks on already-

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -21,8 +21,8 @@
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/Operator.h"
-#include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include <cudf/concatenate.hpp>
@@ -160,7 +160,8 @@ void UcxPartitionedOutput::addInput(RowVectorPtr input) {
 
 void UcxPartitionedOutput::flushPending() {
   CudaAllocationTraceScope allocationTrace(
-      fmt::format("UcxPartitionedOutput task={} method=flushPending", taskId()));
+      fmt::format(
+          "UcxPartitionedOutput task={} method=flushPending", taskId()));
   if (pendingInputs_.empty()) {
     return;
   }
@@ -232,9 +233,7 @@ void UcxPartitionedOutput::flushPending() {
         auto slicedTables = cudf::slice(tableView, {start, end});
         VELOX_CHECK_EQ(slicedTables.size(), 1);
         auto packedCols = cudf::pack(
-            slicedTables[0],
-            stream,
-            cudf::get_current_device_resource_ref());
+            slicedTables[0], stream, cudf::get_current_device_resource_ref());
         stream.synchronize();
         auto packedColsPtr = std::make_unique<cudf::packed_columns>(
             std::move(packedCols.metadata), std::move(packedCols.gpu_data));

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -22,6 +22,7 @@
 #include "velox/exec/Driver.h"
 #include "velox/exec/Operator.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include <cudf/concatenate.hpp>
@@ -34,22 +35,51 @@ using namespace facebook::velox::cudf_velox;
 using facebook::velox::exec::Task;
 namespace facebook::velox::ucx_exchange {
 
+namespace {
+int64_t targetRowsPerUcxChunk(const core::QueryConfig& queryConfig) {
+  if (const char* value =
+          std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_ROWS")) {
+    try {
+      const auto parsed = static_cast<int64_t>(std::stoll(value));
+      if (parsed > 0) {
+        return parsed;
+      }
+    } catch (...) {
+    }
+  }
+  return queryConfig.ucxPartitionedOutputBatchRows();
+}
+} // namespace
+
 // Computes a mapping from names in n2 to names in n1
 // and returns that mapping in remap.
 // Names in n2 must occurs in n1.
 static void getRemapping(
-    const std::vector<std::string>& n1,
-    const std::vector<std::string>& n2,
+    const RowTypePtr& inputType,
+    const RowTypePtr& outputType,
     std::vector<uint32_t>& remap) {
-  std::unordered_map<std::string, uint32_t> lookup;
-  for (uint32_t i = 0; i < n1.size(); ++i) {
-    lookup[n1[i]] = i;
-  }
-
   remap.clear();
-  remap.reserve(n2.size());
-  for (const auto& key : n2) {
-    remap.push_back(lookup.at(key));
+  remap.reserve(outputType->size());
+  std::unordered_map<std::string, size_t> nextOccurrence;
+  for (uint32_t out = 0; out < outputType->size(); ++out) {
+    const auto& name = outputType->nameOf(out);
+    std::vector<uint32_t> matches;
+    for (uint32_t in = 0; in < inputType->size(); ++in) {
+      if (inputType->nameOf(in) == name &&
+          inputType->childAt(in)->equivalent(*outputType->childAt(out))) {
+        matches.push_back(in);
+      }
+    }
+    VELOX_CHECK(
+        !matches.empty(),
+        "UCX output field {}:{} has no name-and-type match in input {}",
+        name,
+        outputType->childAt(out)->toString(),
+        inputType->toString());
+    auto& occurrence = nextOccurrence[name];
+    const auto selected = matches[std::min(occurrence, matches.size() - 1)];
+    ++occurrence;
+    remap.push_back(selected);
   }
 }
 
@@ -72,7 +102,7 @@ UcxPartitionedOutput::UcxPartitionedOutput(
       numPartitions_(planNode->numPartitions()),
       pipelineId_(ctx->pipelineId),
       driverId_(ctx->driverId),
-      targetRowsPerChunk_(ctx->queryConfig().ucxPartitionedOutputBatchRows()) {
+      targetRowsPerChunk_(targetRowsPerUcxChunk(ctx->queryConfig())) {
   if (driverId_ == 0) {
     const auto numDrivers = ctx->task->numOutputDrivers();
     sharedQueueManager()->initializeTask(
@@ -98,11 +128,13 @@ UcxPartitionedOutput::UcxPartitionedOutput(
     outNames.push_back(planNode->outputType()->nameOf(i));
   }
   if (inNames != outNames) {
-    getRemapping(inNames, outNames, remap_);
+    getRemapping(planNode->inputType(), planNode->outputType(), remap_);
   }
 }
 
 void UcxPartitionedOutput::addInput(RowVectorPtr input) {
+  CudaAllocationTraceScope allocationTrace(
+      fmt::format("UcxPartitionedOutput task={} method=addInput", taskId()));
   VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
           << " addInput";
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
@@ -127,6 +159,8 @@ void UcxPartitionedOutput::addInput(RowVectorPtr input) {
 }
 
 void UcxPartitionedOutput::flushPending() {
+  CudaAllocationTraceScope allocationTrace(
+      fmt::format("UcxPartitionedOutput task={} method=flushPending", taskId()));
   if (pendingInputs_.empty()) {
     return;
   }
@@ -180,14 +214,36 @@ void UcxPartitionedOutput::flushPending() {
         equalPartition(tableView, stream);
       }
     } else {
-      auto packedCols = cudf::pack(
-          tableView, stream, cudf::get_current_device_resource_ref());
       const auto tableRows = tableView.num_rows();
-      stream.synchronize();
-      auto packedColsPtr = std::make_unique<cudf::packed_columns>(
-          std::move(packedCols.metadata), std::move(packedCols.gpu_data));
-      queueManager->enqueue(
-          this->taskId(), 0, std::move(packedColsPtr), tableRows);
+      const auto rowsPerChunk = std::max<cudf::size_type>(
+          1,
+          targetRowsPerChunk_ > 0
+              ? std::min<cudf::size_type>(
+                    tableRows,
+                    static_cast<cudf::size_type>(targetRowsPerChunk_))
+              : tableRows);
+      // SINGLE/gather exchanges must obey the same chunk bound as HASH and
+      // RANGE.  Packing the whole input here bypassed splitAndEnqueue and let
+      // a global sort/gather create tens-of-GiB host-staging transfers.
+      for (cudf::size_type start = 0; start < tableRows;
+           start += rowsPerChunk) {
+        const auto end =
+            std::min<cudf::size_type>(tableRows, start + rowsPerChunk);
+        auto slicedTables = cudf::slice(tableView, {start, end});
+        VELOX_CHECK_EQ(slicedTables.size(), 1);
+        auto packedCols = cudf::pack(
+            slicedTables[0],
+            stream,
+            cudf::get_current_device_resource_ref());
+        stream.synchronize();
+        auto packedColsPtr = std::make_unique<cudf::packed_columns>(
+            std::move(packedCols.metadata), std::move(packedCols.gpu_data));
+        queueManager->enqueue(
+            this->taskId(),
+            0,
+            std::move(packedColsPtr),
+            slicedTables[0].num_rows());
+      }
     }
 
     // Check backpressure after enqueue.

--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -43,8 +43,8 @@ void updateDiagnosticGlobalQueue(
                                   columns, std::memory_order_relaxed) +
       columns;
   const auto gib = currentBytes >> 30;
-  const auto previous = diagnosticGlobalQueueGiB.exchange(
-      gib, std::memory_order_relaxed);
+  const auto previous =
+      diagnosticGlobalQueueGiB.exchange(gib, std::memory_order_relaxed);
   if (gib != previous) {
     LOG(WARNING) << "CUDF_DEVICE_QUEUE_GLOBAL event=" << event
                  << " task=" << (task ? task->taskId() : "n/a")
@@ -786,8 +786,7 @@ void UcxOutputQueue::logDeviceQueueResidencyLocked(const char* event) {
                << " task=" << (task_ ? task_->taskId() : "n/a")
                << " queuedBytes=" << queuedBytes_
                << " queuedPackedColumns=" << queuedPackedColumns_
-               << " maxSize=" << maxSize_
-               << " continueSize=" << continueSize_;
+               << " maxSize=" << maxSize_ << " continueSize=" << continueSize_;
 }
 
 void UcxOutputQueue::updateTotalQueuedBytesMsLocked() {

--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -15,11 +15,44 @@
  */
 #include "velox/experimental/ucx-exchange/UcxQueues.h"
 
+#include "velox/experimental/cudf/exec/GpuResources.h"
+
 #include <atomic>
 #include <limits>
 #include <sstream>
 
 namespace facebook::velox::ucx_exchange {
+
+namespace {
+std::atomic<int64_t> diagnosticGlobalQueuedBytes{0};
+std::atomic<int64_t> diagnosticGlobalQueuedColumns{0};
+std::atomic<int64_t> diagnosticGlobalQueueGiB{0};
+
+void updateDiagnosticGlobalQueue(
+    int64_t bytes,
+    int64_t columns,
+    const char* event,
+    const std::shared_ptr<exec::Task>& task) {
+  if (!cudf_velox::deviceMemoryDiagnosticsEnabled()) {
+    return;
+  }
+  const auto currentBytes =
+      diagnosticGlobalQueuedBytes.fetch_add(bytes, std::memory_order_relaxed) +
+      bytes;
+  const auto currentColumns = diagnosticGlobalQueuedColumns.fetch_add(
+                                  columns, std::memory_order_relaxed) +
+      columns;
+  const auto gib = currentBytes >> 30;
+  const auto previous = diagnosticGlobalQueueGiB.exchange(
+      gib, std::memory_order_relaxed);
+  if (gib != previous) {
+    LOG(WARNING) << "CUDF_DEVICE_QUEUE_GLOBAL event=" << event
+                 << " task=" << (task ? task->taskId() : "n/a")
+                 << " queuedBytes=" << currentBytes
+                 << " queuedPackedColumns=" << currentColumns;
+  }
+}
+} // namespace
 
 void UcxDestinationQueue::Stats::recordEnqueue(
     const cudf::packed_columns* data) {
@@ -118,16 +151,12 @@ UcxDestinationQueue::Data UcxDestinationQueue::getData(
   const auto resultSequence = sequence_;
   ++sequence_;
 
+  // The current rendezvous protocol does not use the legacy Presto
+  // remaining-bytes credit list (UcxExchangeServer sends an empty list in its
+  // MetadataMsg). Building it here is O(queue size) for every dequeued packet.
+  // A finely chunked shuffle can therefore allocate hundreds of MiB per
+  // packet and do O(N^2) work even though the list is immediately discarded.
   std::vector<int64_t> remainingBytes;
-  remainingBytes.reserve(queue_.size());
-  // fill in the remainingbytes vector.
-  for (std::size_t i = 0; i < queue_.size(); ++i) {
-    if (queue_[i] == nullptr) {
-      VELOX_CHECK_EQ(i, queue_.size() - 1, "null marker found in the middle");
-      break;
-    }
-    remainingBytes.push_back(queue_[i]->gpu_data->size());
-  }
   return {std::move(data), resultSequence, std::move(remainingBytes), true};
 }
 
@@ -714,6 +743,8 @@ void UcxOutputQueue::updateStatsWithEnqueuedLocked(
   totalBytesSent_ += bytes;
   totalRowsSent_ += rows;
   totalPackedColumnsSent_++;
+  updateDiagnosticGlobalQueue(bytes, 1, "enqueue", task_);
+  logDeviceQueueResidencyLocked("enqueue");
 }
 
 void UcxOutputQueue::updateStatsWithFreedLocked(
@@ -727,6 +758,8 @@ void UcxOutputQueue::updateStatsWithFreedLocked(
 
   VELOX_CHECK_GE(queuedBytes_, 0);
   VELOX_CHECK_GE(queuedPackedColumns_, 0);
+  updateDiagnosticGlobalQueue(-bytes, -numPackedCols, "dequeue", task_);
+  logDeviceQueueResidencyLocked("dequeue");
 
   // Check whether queue is below low-water mark and return outstanding
   // promises
@@ -737,6 +770,24 @@ void UcxOutputQueue::updateStatsWithFreedLocked(
             << " continueSize=" << continueSize_;
     promises = std::move(promises_);
   }
+}
+
+void UcxOutputQueue::logDeviceQueueResidencyLocked(const char* event) {
+  if (!cudf_velox::deviceMemoryDiagnosticsEnabled()) {
+    return;
+  }
+  constexpr int64_t kBucketBytes = 256LL << 20;
+  const auto bucket = queuedBytes_ / kBucketBytes;
+  if (bucket == diagnosticQueueBucket_) {
+    return;
+  }
+  diagnosticQueueBucket_ = bucket;
+  LOG(WARNING) << "CUDF_DEVICE_QUEUE event=" << event
+               << " task=" << (task_ ? task_->taskId() : "n/a")
+               << " queuedBytes=" << queuedBytes_
+               << " queuedPackedColumns=" << queuedPackedColumns_
+               << " maxSize=" << maxSize_
+               << " continueSize=" << continueSize_;
 }
 
 void UcxOutputQueue::updateTotalQueuedBytesMsLocked() {

--- a/velox/experimental/ucx-exchange/UcxQueues.h
+++ b/velox/experimental/ucx-exchange/UcxQueues.h
@@ -272,6 +272,10 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
 
   void updateTotalQueuedBytesMsLocked();
 
+  /// Emits coarse queue-residency diagnostics without changing backpressure.
+  /// Must be called with mutex_ held.
+  void logDeviceQueueResidencyLocked(const char* event);
+
   int64_t getAverageQueueTimeMsLocked() const;
 
   // internal function that is called when all drivers are done.
@@ -340,6 +344,9 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   // actual data in 'queues_'
   int64_t queuedBytes_{0};
   int64_t queuedPackedColumns_{0};
+
+  // Last reported 256 MiB bucket. Diagnostic-only; it does not cap the queue.
+  int64_t diagnosticQueueBucket_{0};
 
   // The total number of bytes/rows/packedColumns sent via this output queue.
   int64_t totalBytesSent_{0};

--- a/velox/experimental/ucx-exchange/tests/IntraNodeTransferRegistryTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/IntraNodeTransferRegistryTest.cpp
@@ -50,8 +50,8 @@ TEST(IntraNodeTransferRegistryTest, registerWaiterWokenByPublish) {
   EXPECT_FALSE(result->atEnd);
 }
 
-// A waiter registered after the data is already published returns true (re-poll,
-// no dormancy) and does not leave a stale wakeup behind.
+// A waiter registered after the data is already published returns true
+// (re-poll, no dormancy) and does not leave a stale wakeup behind.
 TEST(IntraNodeTransferRegistryTest, registerWaiterReadyReturnsTrue) {
   auto registry = IntraNodeTransferRegistry::getInstance();
   const auto key = makeKey("registerWaiterReadyReturnsTrue");
@@ -69,8 +69,8 @@ TEST(IntraNodeTransferRegistryTest, registerWaiterReadyReturnsTrue) {
   EXPECT_TRUE(result->atEnd);
 }
 
-// cancelTask wakes a dormant waiter so it re-polls and observes the atEnd result
-// instead of waiting forever for a producer that will never publish.
+// cancelTask wakes a dormant waiter so it re-polls and observes the atEnd
+// result instead of waiting forever for a producer that will never publish.
 TEST(IntraNodeTransferRegistryTest, registerWaiterWokenByCancel) {
   auto registry = IntraNodeTransferRegistry::getInstance();
   const std::string taskId = "registerWaiterWokenByCancel";

--- a/velox/functions/sparksql/RegexFunctions.cpp
+++ b/velox/functions/sparksql/RegexFunctions.cpp
@@ -109,9 +109,8 @@ struct RegexpReplaceFunction {
         // Only when both the 'replacement' and 'pattern' are constants can they
         // be processed during initialization; otherwise, each row needs to be
         // processed separately.
-        constantReplacement_ =
-            prepareRegexpReplaceReplacement(
-                re_.value(), StringView(replacementText.value()));
+        constantReplacement_ = prepareRegexpReplaceReplacement(
+            re_.value(), StringView(replacementText.value()));
       }
     }
     cache_.setMaxCompiledRegexes(config.exprMaxCompiledRegexes());
@@ -200,9 +199,9 @@ struct RegexpReplaceFunction {
       replacementText = kLeadingZeroPreserveOneJavaReplacement;
     }
 
-    auto& re =
-        patternText.has_value() ? ensurePattern(StringView(patternText.value()))
-                                : ensurePattern(pattern);
+    auto& re = patternText.has_value()
+        ? ensurePattern(StringView(patternText.value()))
+        : ensurePattern(pattern);
     const auto& processedReplacement = constantReplacement_.has_value()
         ? constantReplacement_.value()
         : prepareRegexpReplaceReplacement(

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -112,9 +112,8 @@ FOLLY_ALWAYS_INLINE bool isUtf8DecodeCharset(std::string_view charset) {
     normalized[i] =
         static_cast<char>(std::tolower(static_cast<unsigned char>(charset[i])));
   }
-  return charset.size() == 5
-      ? std::string_view(normalized, 5) == "utf-8"
-      : std::string_view(normalized, 4) == "utf8";
+  return charset.size() == 5 ? std::string_view(normalized, 5) == "utf-8"
+                             : std::string_view(normalized, 4) == "utf8";
 }
 
 template <typename T>
@@ -126,7 +125,8 @@ struct DecodeFunction {
       const arg_type<Varbinary>& input,
       const arg_type<Varchar>& charset) {
     VELOX_USER_CHECK(
-        isUtf8DecodeCharset({charset.data(), static_cast<size_t>(charset.size())}),
+        isUtf8DecodeCharset(
+            {charset.data(), static_cast<size_t>(charset.size())}),
         "Unsupported charset for decode: {}",
         charset);
     result.resize(input.size());

--- a/velox/functions/sparksql/tests/MapTest.cpp
+++ b/velox/functions/sparksql/tests/MapTest.cpp
@@ -20,8 +20,8 @@
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/Variant.h"
 
-#include <map>
 #include <stdint.h>
+#include <map>
 #include <sstream>
 
 namespace facebook::velox::functions::sparksql::test {


### PR DESCRIPTION
## Summary

  This PR improves bounded-memory execution, expression correctness, Iceberg
  nested scans and UCX flow control in the Velox cuDF backend.

  ## Changes

  ### Bounded-memory operators

  - Add bounded sorted-run spilling and streaming merge to cuDF OrderBy.
  - Add incremental per-partition reduction to TopNRowNumber.
  - Spill reduced Top-N candidates instead of retaining the complete input.
  - Add bounded fan-in and multi-pass merge for spilled runs.
  - Preserve rank and dense-rank peer semantics.
  - Add a grouped MIN/MAX fast path for single-key rank filtering.
  - Add bounded external-sort processing for general Window execution.
  - Support partitioned running SUM.
  - Emit bounded output batches from expanding Unnest operations.

  ### Expression and schema correctness

  - Cast precomputed AST children to their expected resolved types.
  - Normalize arithmetic AST operands.
  - Precompute nested operations that cannot be represented directly by libcudf
    AST.
  - Add native Spark expression support required by complex workloads.
  - Validate declared Velox primitive types against physical cuDF columns.
  - Correct nested field resolution after projection rewrites.

  ### Iceberg scans

  - Project exact nested leaves in the requested output order.
  - Avoid returning every physical Parquet struct child for a pruned schema.
  - Preserve row-group-aligned byte ranges.
  - Improve empty and nested scan handling.

  ### UCX exchange

  - Add process-wide and per-queue receive accounting.
  - Improve producer and consumer backpressure.
  - Harden endpoint shutdown and UCX error propagation.
  - Correct positional payload mapping when field names differ.
  - Improve same-process and TCP progress behavior.
  - Prevent unbounded device receive buffering across concurrent fragments.

  ## Motivation

  Complex MPP queries can keep many scans, joins, aggregations, windows and
  exchanges alive concurrently. Previously, several blocking operators and UCX
  queues could retain state proportional to the complete input.

  This could cause device-memory exhaustion, excessive merge fan-in, nested
  schema mismatches and exchange shutdown races.

  ## Testing

  ```bash
  cmake --build /opt/velox/_build/release -j 16
  cmake --build /opt/gluten/cpp/build -j 16

  The combined Gluten package was also built with JDK 17, Spark 3.5 and Iceberg
  enabled.

  The changes were validated with strict multi-executor MPP/cuDF execution on
  four GPUs, with CPU fallback disabled and Parquet read limits left unlimited.


  ## Follow-up work

  - GPU-native Iceberg writing.
  - Query-wide GPU memory arbitration.
  - Production sampled RANGE partitioning.
  - Independent destination flow control for ordered output.
