### PR TITLE
  fix(cudf): Fence async receive buffers before UCX writes

### DIFF
--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -23,8 +23,8 @@
 #include <cudf/contiguous_split.hpp>
 #include <folly/String.h>
 #include <folly/Uri.h>
-#include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/ucx-exchange/IntraNodeTransferRegistry.h"
@@ -102,16 +102,16 @@ int64_t maxInFlightRecvHostBytes() {
 std::atomic<int64_t> inFlightRecvHostBytes{0};
 
 rmm::mr::statistics_resource_adaptor& receiveDeviceMemoryResource() {
-  // Keep UCX receive allocations out of the main cuDF pool. Receive pages are
-  // large, short-lived, and size-variable; mixing them into the operator pool
-  // makes the RMM pool reserve/grow far beyond live cuDF data because of
-  // fragmentation. A dedicated cuda_async resource still avoids synchronous
-  // cudaMalloc/cudaFree per packet, while the receive-only statistics wrapper
-  // keeps queued packed pages visible in diagnostics after ownership moves out
-  // of UcxExchangeSource.
+  // Keep UCX receive allocations out of the main cuDF resource, but match the
+  // configured cuDF resource type. Receive pages are large, short-lived, and
+  // size-variable; mixing them into the operator resource makes pool resources
+  // reserve/grow far beyond live cuDF data because of fragmentation.
+  // The receive-only statistics wrapper keeps queued packed pages visible in
+  // diagnostics after ownership moves out of UcxExchangeSource.
+  const auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
   static rmm::mr::statistics_resource_adaptor resource{
-      cuda::mr::any_resource<cuda::mr::device_accessible>{
-          rmm::mr::cuda_async_memory_resource{}}};
+      cudf_velox::createMemoryResource(
+          cudfConfig.memoryResource, cudfConfig.memoryPercent)};
   return resource;
 }
 

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -23,7 +23,7 @@
 #include <cudf/contiguous_split.hpp>
 #include <folly/String.h>
 #include <folly/Uri.h>
-#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
@@ -102,12 +102,16 @@ int64_t maxInFlightRecvHostBytes() {
 std::atomic<int64_t> inFlightRecvHostBytes{0};
 
 rmm::mr::statistics_resource_adaptor& receiveDeviceMemoryResource() {
-  // Keep UCX receive allocations on a synchronous, fresh cudaMalloc resource,
-  // but wrap it with RMM statistics so queued packed pages are visible in
-  // diagnostics even after ownership moves out of UcxExchangeSource.
+  // Keep UCX receive allocations out of the main cuDF pool. Receive pages are
+  // large, short-lived, and size-variable; mixing them into the operator pool
+  // makes the RMM pool reserve/grow far beyond live cuDF data because of
+  // fragmentation. A dedicated cuda_async resource still avoids synchronous
+  // cudaMalloc/cudaFree per packet, while the receive-only statistics wrapper
+  // keeps queued packed pages visible in diagnostics after ownership moves out
+  // of UcxExchangeSource.
   static rmm::mr::statistics_resource_adaptor resource{
       cuda::mr::any_resource<cuda::mr::device_accessible>{
-          rmm::mr::cuda_memory_resource{}}};
+          rmm::mr::cuda_async_memory_resource{}}};
   return resource;
 }
 
@@ -756,13 +760,12 @@ bool UcxExchangeSource::tryStartDataReceive(
   ptr->stream = stream;
 
   // UCX writes receive buffers from its progress thread, outside CUDA stream
-  // ordering. Keep these buffers on a dedicated synchronous resource so UCX
-  // can never write into a block that a stream-ordered pool has recycled while
-  // work on another stream is still in flight. This also avoids waiting on an
-  // unrelated compute stream in the single UCX progress thread.
+  // ordering. The allocation-ready fence below is required when the active cuDF
+  // resource is stream-ordered: a pooled/async block may be valid only after the
+  // allocation stream reaches the allocation point.
   //
-  // Only transports without CUDA support stage through host memory and use a
-  // fresh synchronous device allocation for the final copy.
+  // Only transports without CUDA support stage through host memory and copy into
+  // the final device buffer after the host receive completes.
   try {
     auto& recvMemoryResource = receiveDeviceMemoryResource();
     ptr->dataBuf = std::make_unique<rmm::device_buffer>(
@@ -817,6 +820,16 @@ bool UcxExchangeSource::tryStartDataReceive(
     communicator_->addToWorkQueue(getSelfPtr());
     return false;
   }
+
+  // RMM pool resources are stream-ordered: if a block is freed and reallocated
+  // on the same stream, the allocator may hand it out without inserting a wait.
+  // That is correct only when the next use is also enqueued on that stream. UCX
+  // writes receive buffers from its progress thread, outside CUDA stream
+  // ordering, so wait until the allocation stream has reached this allocation
+  // before exposing the pointer to UCX. This closes the same-stream reuse race
+  // that can surface later as cudaErrorIllegalAddress or
+  // cudaErrorMisalignedAddress in unrelated cuDF kernels.
+  stream.synchronize();
 
   VLOG(3) << toString() << " Allocated " << ptr->metadata.dataSizeBytes
           << " bytes of device memory";

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -120,8 +120,9 @@ class UcxExchangeSource
   // consumption. Without a byte bound these buffers (one UcxExchangeSource per
   // producer peer) scale O(#peers) and collectively exhaust the GPU at 4 peers
   // (OOM at concurrentGpuTasks=2, deadlock at =1). Remote receives use a
-  // receive-only async resource and fence before exposing a stream-ordered
-  // allocation to UCX. Read once; env-overridable via
+  // receive-only resource matching the configured cuDF resource type, then
+  // fence before exposing a stream-ordered allocation to UCX. Read once;
+  // env-overridable via
   // GLUTEN_UCX_MAX_INFLIGHT_RECV_BYTES (default 8 GiB).
   static int64_t maxInFlightRecvBytes();
 

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -33,8 +33,6 @@
 #include <rmm/cuda_stream_pool.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/pool_memory_resource.hpp>
 
 namespace facebook::velox::ucx_exchange {
 
@@ -122,9 +120,8 @@ class UcxExchangeSource
   // consumption. Without a byte bound these buffers (one UcxExchangeSource per
   // producer peer) scale O(#peers) and collectively exhaust the GPU at 4 peers
   // (OOM at concurrentGpuTasks=2, deadlock at =1). Remote receives use a
-  // dedicated fresh cudaMalloc resource so UCX writes cannot race with
-  // stream-ordered reuse in the cuDF compute pool. Read once; env-overridable
-  // via
+  // receive-only async resource and fence before exposing a stream-ordered
+  // allocation to UCX. Read once; env-overridable via
   // GLUTEN_UCX_MAX_INFLIGHT_RECV_BYTES (default 8 GiB).
   static int64_t maxInFlightRecvBytes();
 


### PR DESCRIPTION
## Summary

  Stabilize UCX GPU receives when cuDF runs with async memory resources.

  This change:

  - Uses a receive-only cuda_async_memory_resource for UCX device receive buffers
  - Keeps UCX receive pages out of the main cuDF operator memory resource
  - Synchronizes the allocation stream before exposing the receive buffer pointer to the UCX progress thread
  - Preserves direct device receive for CUDA-capable transports; host fallback remains only for non-CUDA transport paths

  ## Motivation

  UCX writes receive buffers from its progress thread, outside CUDA stream ordering.

  With stream-ordered async allocation, a device allocation may not be safely visible to an external writer until the allocation stream reaches the
  allocation point. If UCX writes into that pointer too early, the corruption may surface later in unrelated cuDF kernels as errors such as:

  - cudaErrorIllegalAddress
  - cudaErrorMisalignedAddress

  The explicit fence makes the allocation ready before UCX can write into it.

  ## Validation

  TPC-H SF1000 full 22-query validation with cuDF async memory resource:

   Config          Result
  ━━━━━━━━  ━━━━━━━━━━━━━━
   1GPU      22/22 passed
  ────────  ──────────────
   2GPU      22/22 passed
  ────────  ──────────────
   4GPU      22/22 passed
