### PR TITLE
fix(ucx): Correct output queue lifecycle tests

### DIFF
--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -103,19 +103,6 @@ UcxPartitionedOutput::UcxPartitionedOutput(
       pipelineId_(ctx->pipelineId),
       driverId_(ctx->driverId),
       targetRowsPerChunk_(targetRowsPerUcxChunk(ctx->queryConfig())) {
-  if (driverId_ == 0) {
-    const auto numDrivers = ctx->task->numOutputDrivers();
-    sharedQueueManager()->initializeTask(
-        ctx->task,
-        planNode->kind(),
-        static_cast<int>(numPartitions_),
-        numDrivers);
-    VLOG(2) << "UcxPartitionedOutput initialized queue task="
-            << ctx->task->taskId() << " destinations=" << numPartitions_
-            << " drivers=" << numDrivers
-            << " kind=" << core::PartitionedOutputNode::toName(planNode->kind())
-            << " targetRowsPerChunk=" << targetRowsPerChunk_;
-  }
   this->initPartitionKeys(planNode);
   auto sources = planNode->sources();
   std::vector<std::string> inNames, outNames;

--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -518,14 +518,13 @@ TEST_F(UcxOutputQueueManagerTest, basicAsyncFetch) {
 
 TEST_F(UcxOutputQueueManagerTest, lateTaskCreation) {
   const vector_size_t size = 10;
-  const std::string taskId = "t0";
+  // Task IDs are unique in production. Do not reuse "t0" from
+  // basicAsyncFetch: removeTask intentionally retains its tombstone so stale
+  // UCX fetches cannot recreate a removed task.
+  const std::string taskId = "lateTaskCreation";
   int numPartitions = 1;
   bool earlyTermination = false;
   int destination = 0;
-
-  // Clear stale state from prior tests (removeTask on a non-existing queue
-  // clears the removedTasks_ set, allowing getData to create a placeholder).
-  queueManager_->removeTask(taskId);
 
   // Fetch data from a non-existing task.
   struct Response {


### PR DESCRIPTION
## Summary

Fix two lifecycle defects that made `ucx_exchange_test` fail before exercising the intended UCX data path:

- keep UCX output queue registration owned by `Task::initializePartitionOutput()`;
- isolate `lateTaskCreation` from the tombstone left by an earlier test.

Fixes #45.

## Changes

### 1. Restore Task-owned queue initialization

#### What was broken

`UcxPartitionedOutput` repeated the queue initialization already performed by `Task::initializePartitionOutput()`. Its constructor called `Task::numOutputDrivers()`, which assumes driver factories and output-pipeline metadata already exist.

`SourceDriverMock` intentionally constructs the real operator without starting a complete Task pipeline. The duplicate constructor dependency therefore caused 29 `realPartitionedOutput*` cases to fail with:

```text
Output pipeline not found for task ...
```

The failure occurred before UCX transfer setup and was not caused by module loading, device selection, or transport behavior.

#### How it is fixed

- Remove constructor-side `UcxOutputQueueManager::initializeTask()`.
- Keep `Task::initializePartitionOutput()` as the single lifecycle owner.
- Continue using the authoritative driver count after driver factories exist.
- Leave `SourceDriverMock` unchanged and avoid adding a test-only seam to production code.

### 2. Preserve tombstone semantics without cross-test contamination

#### What was broken

`basicAsyncFetch` and `lateTaskCreation` both used task ID `t0`. `removeTask()` intentionally retains a tombstone to prevent stale fetches from recreating a removed task, but `lateTaskCreation` assumed a second removal cleared that state.

Consequently, `lateTaskCreation` passed alone and failed when run after `basicAsyncFetch`.

#### How it is fixed

- Give `lateTaskCreation` its own production-realistic task ID.
- Remove the misleading cleanup call.
- Preserve the queue manager's stale-fetch protection.

## Scope

The PR changes only:

- `velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp`
- `velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp`

It is one commit on top of `2026-q3` at `dec75de0a` and preserves the bounded-memory and resilient-flow-control changes already present on that branch.

## Validation

### Complete binary before the target-branch update

The exact two-file fix passed the complete binary on `daa858c25`:

```text
[==========] 158 tests from 3 test suites ran.
[  PASSED  ] 71 tests.
[  SKIPPED ] 87 tests.
0 failed
```

### Rebased live `2026-q3` verification

- The updated cuDF and UCX targets compile successfully on `dec75de0a`.
- The order-sensitive regression pair passes 2/2:

```text
[ RUN      ] UcxOutputQueueManagerTest.basicAsyncFetch
[       OK ] UcxOutputQueueManagerTest.basicAsyncFetch
[ RUN      ] UcxOutputQueueManagerTest.lateTaskCreation
[       OK ] UcxOutputQueueManagerTest.lateTaskCreation
[  PASSED  ] 2 tests.
```

The complete binary on `dec75de0a` currently reaches unrelated base-branch failures in three `remainingBytes` assertions followed by `CudfVector` schema-order validation. This PR neither introduces nor expands those failures; they arise outside its two changed hunks.

Generated-by: OpenAI Codex (GPT-5)
