### PR TITLE
fix(ucx): Align exchange unit tests with count-only flow and schema checks

### DIFF
--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -353,7 +353,8 @@ TEST_F(UcxOutputQueueManagerTest, v1RepeatedFetchAdvancesQueue) {
 
   auto first = fetchV1Data(taskId, destination);
   ASSERT_NE(first.data, nullptr);
-  EXPECT_EQ(first.remainingBytes.size(), 1);
+  // Count-only flow leaves remainingBytes empty; advancement is via later fetches.
+  EXPECT_TRUE(first.remainingBytes.empty());
 
   auto second = fetchV1Data(taskId, destination);
   ASSERT_NE(second.data, nullptr);
@@ -382,7 +383,8 @@ TEST_F(UcxOutputQueueManagerTest, v2FetchesSequencesZeroAndOne) {
   auto first = fetchV2Data(taskId, destination, maxBytes, 0);
   ASSERT_NE(first.data, nullptr);
   EXPECT_EQ(first.sequence, 0);
-  EXPECT_EQ(first.remainingBytes.size(), 1);
+  // Count-only flow leaves remainingBytes empty; advancement is via sequence fetches.
+  EXPECT_TRUE(first.remainingBytes.empty());
 
   auto second = fetchV2Data(taskId, destination, maxBytes, 1);
   ASSERT_NE(second.data, nullptr);
@@ -419,7 +421,8 @@ TEST_F(UcxOutputQueueManagerTest, v2OversizeRequestReturnsOneChunk) {
   ASSERT_NE(first.data, nullptr);
   EXPECT_EQ(first.sequence, 0);
   EXPECT_EQ(first.data->gpu_data->size(), firstBytes);
-  EXPECT_EQ(first.remainingBytes.size(), 1);
+  // Count-only flow leaves remainingBytes empty; chunking is checked via size/sequence.
+  EXPECT_TRUE(first.remainingBytes.empty());
 
   auto second =
       fetchV2Data(taskId, destination, std::numeric_limits<uint64_t>::max(), 1);

--- a/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
@@ -263,8 +263,8 @@ void UcxTestData::initialize(
           << "]";
   numRows_ = numRows;
   strings_ = std::make_shared<std::vector<std::string>>();
-  integers_ = std::make_shared<std::vector<uint32_t>>();
-  floats_ = std::make_shared<std::vector<float>>();
+  integers_ = std::make_shared<std::vector<int32_t>>();
+  floats_ = std::make_shared<std::vector<double>>();
 
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -293,10 +293,10 @@ std::unique_ptr<cudf::table> UcxTestData::makeTable(
     rmm::cuda_stream_view stream) {
   std::vector<std::unique_ptr<cudf::column>> columns;
 
-  // Column 0: INT32 (integers)
+  // Column 0: INT32 (integers) - matches kTestColumnTypes INTEGER()
   columns.push_back(makeNumericColumn(*integers_, stream));
 
-  // Column 1: FLOAT32
+  // Column 1: FLOAT64 - matches kTestColumnTypes DOUBLE()
   columns.push_back(makeNumericColumn(*floats_, stream));
 
   // Column 2: STRING
@@ -317,8 +317,8 @@ bool UcxTestData::verifyTable(
   }
 
   // Get the data from the received table
-  auto receivedInts = getColVector<uint32_t>(table.column(0), numRows, stream);
-  auto receivedDoubles = getColVector<float>(table.column(1), numRows, stream);
+  auto receivedInts = getColVector<int32_t>(table.column(0), numRows, stream);
+  auto receivedDoubles = getColVector<double>(table.column(1), numRows, stream);
   auto receivedStrings = getStringCol(table.column(2), numRows, stream);
 
   // Compare with expected data. Use modular indexing because batch

--- a/velox/experimental/ucx-exchange/tests/UcxTestData.h
+++ b/velox/experimental/ucx-exchange/tests/UcxTestData.h
@@ -151,18 +151,18 @@ class UcxTestData : public BaseTableGenerator {
     return strings_;
   }
 
-  std::shared_ptr<std::vector<uint32_t>> getIntegers() {
+  std::shared_ptr<std::vector<int32_t>> getIntegers() {
     return integers_;
   }
 
-  std::shared_ptr<std::vector<float>> getFloats() {
+  std::shared_ptr<std::vector<double>> getFloats() {
     return floats_;
   }
 
   /// @brief Sets the data directly (used for creating partitioned test data).
   void setData(
-      std::shared_ptr<std::vector<uint32_t>> integers,
-      std::shared_ptr<std::vector<float>> floats,
+      std::shared_ptr<std::vector<int32_t>> integers,
+      std::shared_ptr<std::vector<double>> floats,
       std::shared_ptr<std::vector<std::string>> strings) {
     integers_ = std::move(integers);
     floats_ = std::move(floats);
@@ -172,8 +172,9 @@ class UcxTestData : public BaseTableGenerator {
 
  protected:
   std::shared_ptr<std::vector<std::string>> strings_;
-  std::shared_ptr<std::vector<uint32_t>> integers_;
-  std::shared_ptr<std::vector<float>> floats_;
+  // Must match kTestColumnTypes: INTEGER() -> INT32, DOUBLE() -> FLOAT64.
+  std::shared_ptr<std::vector<int32_t>> integers_;
+  std::shared_ptr<std::vector<double>> floats_;
   size_t numRows_ = 0;
 };
 

--- a/velox/experimental/ucx-exchange/tests/UcxTestHelpers.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxTestHelpers.cpp
@@ -281,21 +281,19 @@ std::unique_ptr<cudf::table> makeTable(
     const std::string& name = rowType->nameOf(i);
     const auto& type = rowType->childAt(i);
 
-    cudf::type_id cudfType;
     std::unique_ptr<cudf::column> col;
 
     switch (type->kind()) {
       case TypeKind::INTEGER: {
-        cudfType = cudf::type_id::INT32;
-        std::vector<uint32_t> values(numRows);
+        // Host vector element type must match Velox INTEGER -> cuDF INT32.
+        std::vector<int32_t> values(numRows);
         col = make_numeric_column_from_vector(values);
         break;
       }
       case TypeKind::DOUBLE: {
-        cudfType = cudf::type_id::FLOAT64;
-        std::vector<float> values(numRows);
+        // Host vector element type must match Velox DOUBLE -> cuDF FLOAT64.
+        std::vector<double> values(numRows);
         col = make_numeric_column_from_vector(values);
-
         break;
       }
       case TypeKind::VARCHAR: {


### PR DESCRIPTION
Closes #47
Closes #48

## Summary

Fix the two remaining `ucx_exchange_test` failures left after #46 on `2026-q3`:

- update count-only `remainingBytes` expectations;
- align Narrow helper tables with the declared `INTEGER` / `DOUBLE` RowType so `CudfVector` schema validation no longer aborts the suite.

## Changes

### 1. Update remainingBytes expectations for count-only fetches

#### What was broken

`v1RepeatedFetchAdvancesQueue`, `v2FetchesSequencesZeroAndOne`, and `v2OversizeRequestReturnsOneChunk` still expected:

```text
EXPECT_EQ(first.remainingBytes.size(), 1);
```

Count-only UCX flow leaves `remainingBytes` empty after a successful fetch and advances via later fetches or sequence numbers instead.

#### How it is fixed

- Assert `remainingBytes` is empty after the first fetch.
- Keep advancement coverage through the later fetch and sequence checks already present in those cases.

### 2. Align Narrow test tables with declared RowType

#### What was broken

Narrow helpers built cuDF columns from host `uint32_t` / `float` while `kTestRowType` advertised `INTEGER` / `DOUBLE` (`INT32` / `FLOAT64`).

`CudfVector::validatePhysicalSchema` now rejects that mismatch, so the first Narrow `basicTest` aborted with:

```text
CudfVector schema mismatch at column 0 (c0): Velox INTEGER -> cuDF 3, actual cuDF 7
```

and stopped the suite early (`38/158`).

#### How it is fixed

- Generate and verify Narrow columns as `int32_t` and `double`.
- Keep host vectors, cuDF types, and RowType consistent.

## Scope

This PR changes only:

- `velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp`
- `velox/experimental/ucx-exchange/tests/UcxTestData.cpp`
- `velox/experimental/ucx-exchange/tests/UcxTestData.h`
- `velox/experimental/ucx-exchange/tests/UcxTestHelpers.cpp`

It is one commit on top of `2026-q3` at `5545cf022`.

## Validation

- Reproduced the aborting Narrow case on the pre-fix tree.
- After the fix, the previously aborting case and the remaining Narrow `basicTest` cases plus `UcxOutputQueueManagerTest` / `IntraNodeTransferRegistryTest` passed:

```text
[==========] 28 tests from 3 test suites ran.
[  PASSED  ] 28 tests.
```