### PR TITLE
fix(cudf): Preserve probe schema for right semi joins

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -668,11 +668,10 @@ void CudfHashJoinProbe::doNoMoreInput() {
 
   auto stream = cudfGlobalStreamPool().get_stream();
   // Using output_mr here to allow spilling queued up large tables
+  // This intermediate is still the complete probe input. The right-semi
+  // output schema applies only after rightSemiFilterJoin gathers build rows.
   auto tbl = getConcatenatedTable(
-      std::exchange(inputs_, {}),
-      joinNode_->sources()[1]->outputType(),
-      stream,
-      get_output_mr());
+      std::exchange(inputs_, {}), probeType_, stream, get_output_mr());
 
   VELOX_CHECK_NOT_NULL(tbl);
 
@@ -684,7 +683,7 @@ void CudfHashJoinProbe::doNoMoreInput() {
   // Store the concatenated table in input_
   input_ = std::make_shared<CudfVector>(
       operatorCtx_->pool(),
-      joinNode_->outputType(),
+      probeType_,
       tbl->num_rows(),
       std::move(tbl),
       stream);

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -868,6 +868,67 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilter) {
       .run();
 }
 
+TEST_P(
+    MultiThreadedHashJoinTest,
+    rightSemiJoinFilterWithAsymmetricSchemas) {
+  auto probeVectors = makeBatches(3, [&](int32_t batch) {
+    return makeRowVector(
+        {"t0", "t1", "t2"},
+        {makeFlatVector<int32_t>(
+             32, [batch](auto row) { return batch * 16 + row; }),
+         makeFlatVector<int64_t>(
+             32, [batch](auto row) { return batch * 1'000 + row; }),
+         makeFlatVector<double>(
+             32, [batch](auto row) { return batch + row / 10.0; })});
+  });
+  auto buildVectors = makeBatches(2, [&](int32_t batch) {
+    return makeRowVector(
+        {"u0", "u1"},
+        {makeFlatVector<int32_t>(
+             32, [batch](auto row) { return batch * 24 + row; }),
+         makeFlatVector<int64_t>(
+             32, [batch](auto row) { return batch * 10'000 + row; })});
+  });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeKeys({"t0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u0"})
+      .buildVectors(std::move(buildVectors))
+      .joinType(core::JoinType::kRightSemiFilter)
+      .joinOutputLayout({"u1"})
+      .referenceQuery("SELECT u.u1 FROM u WHERE u.u0 IN (SELECT t.t0 FROM t)")
+      .run();
+}
+
+TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyProbe) {
+  auto probeType = ROW(
+      {{"t0", INTEGER()}, {"t1", BIGINT()}, {"t2", DOUBLE()}});
+  auto buildVectors = makeBatches(2, [&](int32_t batch) {
+    return makeRowVector(
+        {"u0", "u1"},
+        {makeFlatVector<int32_t>(
+             32, [batch](auto row) { return batch * 32 + row; }),
+         makeFlatVector<int64_t>(
+             32, [batch](auto row) { return batch * 1'000 + row; })});
+  });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeType(probeType)
+      .probeVectors(0, 3)
+      .probeKeys({"t0"})
+      .buildKeys({"u0"})
+      .buildVectors(std::move(buildVectors))
+      .joinType(core::JoinType::kRightSemiFilter)
+      .joinOutputLayout({"u1"})
+      .referenceQuery("SELECT u.u1 FROM u WHERE u.u0 IN (SELECT t.t0 FROM t)")
+      .run();
+}
+
 TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyBuild) {
   const std::vector<bool> finishOnEmptys = {false, true};
   for (const auto finishOnEmpty : finishOnEmptys) {


### PR DESCRIPTION
## Summary

- Preserve the complete probe schema while concatenating queued right-semi probe input.
- Apply the final join output schema only after `rightSemiFilterJoin()` gathers matching build-side columns.
- Add focused coverage for asymmetric schemas and empty probe input with one and three drivers.

## Problem

For `kRightSemiFilter`, `CudfHashJoinProbe::doAddInput()` queues left/probe-side `CudfVector`s in `inputs_`. At `noMoreInput`, the existing code concatenates those vectors using `sources()[1]->outputType()`—the right/build type—and wraps the resulting physical probe table using the final join `outputType()`.

With a three-column probe and one-column output, this violates the `CudfVector` schema contract:

```text
Reason: (1 vs. 3) CudfVector physical column count does not match RowType
Expression: rowType->size() == table.num_columns()
Context: Operator: CudfHashJoinProbe
```

The wrong concatenation type is also significant for empty probe input because `getConcatenatedTable()` uses the supplied type to construct an empty table.

## Fix

- Pass `probeType_` to `getConcatenatedTable()`.
- Construct the temporary concatenated-input `CudfVector` with `probeType_`.
- Continue using `outputType_` for the final table returned after build-row gathering.
- Document that the concatenated intermediate is still the complete probe input.

This is a metadata-only correction. It does not unpack or copy GPU columns and does not change concatenation ownership or the right-semi lifecycle.

## Tests

- Added `rightSemiJoinFilterWithAsymmetricSchemas`:
  - three-column probe;
  - differently shaped build;
  - one-column output;
  - one and three drivers.
- Added `rightSemiJoinFilterWithEmptyProbe` with one and three drivers.
- Retained coverage for zero-column `count(*)` output.

Verification results:

- Focused right-semi GPU tests on `2026-q3`: 15/15 passed.
- Identical patch on a clean upstream `main` checkout: 15/15 passed.
- Spark-MPP TPC-H Q20 correctness: passed with 147 matching rows.
- Spark-MPP TPC-H 1-22 correctness: 22/22 passed.

The complete hash-join test binary was also attempted. It encounters an independently reproducible pre-existing SIGSEGV in `leftJoinWithNoJoin/0` inside `CudfFilterProject::CastFunction::eval`; the focused right-semi suite remains green.

## Portability

The same two-file patch applies without semantic adaptation to upstream Velox `main`. Correctness does not depend on the `CudfVector` physical-schema validator present on `2026-q3`.

## Tracking

Fixes #50
