### PR TITLE
feat(cudf): Harden MPP exchange and bounded operator execution

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -340,17 +340,16 @@ class QueryConfig {
       2UL << 20,
       "Minimum bytes to accumulate before unblocking an exchange consumer.")
 
-  /// Minimum number of rows to accumulate in CudfPartitionedOutput before
-  /// flushing. Small inputs are buffered and concatenated into a single merged
-  /// table when this threshold is reached, avoiding pathologically small
-  /// exchange chunks. Set to 0 to disable accumulation.
+  /// Target number of rows in a CudfPartitionedOutput exchange chunk. Small
+  /// inputs are accumulated to this threshold, while larger outputs are split
+  /// into bounded slices. Set to 0 to disable accumulation and slicing.
   VELOX_QUERY_CONFIG(
       kUcxPartitionedOutputBatchRows,
       ucxPartitionedOutputBatchRows,
       "cudf.partitioned_output_batch_rows",
       int64_t,
       10'000,
-      "Minimum rows to accumulate in CudfPartitionedOutput before flushing.")
+      "Target rows per CudfPartitionedOutput exchange chunk.")
 
   VELOX_QUERY_CONFIG(
       kMaxPartialAggregationMemory,

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -54,6 +54,11 @@ struct CudfConfig {
   static constexpr const char* kCudfFunctionEngine{"cudf.function_engine"};
   /// Query session configs for the cuDF Operators.
   static constexpr const char* kCudfTopNBatchSize{"cudf.topk_batch_size"};
+  // Hard limit for the complete build table retained by CudfNestedLoopJoin.
+  // The default is intentionally unbounded for non-MPP callers; Gluten MPP
+  // supplies a conservative value for replicated Cartesian joins.
+  static constexpr const char* kCudfNestedLoopJoinMaxBuildBytes{
+      "cudf.nested_loop_join.max_build_bytes"};
   static constexpr const char* kCudfSkipOutputToVelox{
       "velox.cudf.skip_output_to_velox"};
 

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -54,6 +54,10 @@ struct CudfConfig {
   static constexpr const char* kCudfFunctionEngine{"cudf.function_engine"};
   /// Query session configs for the cuDF Operators.
   static constexpr const char* kCudfTopNBatchSize{"cudf.topk_batch_size"};
+  // Maximum retained candidate bytes before CudfTopNRowNumber writes a
+  // sorted run. The default remains 128 MiB.
+  static constexpr const char* kCudfTopNRowNumberCandidateRunBytes{
+      "cudf.topn_row_number.candidate_run_bytes"};
   // Hard limit for the complete build table retained by CudfNestedLoopJoin.
   // The default is intentionally unbounded for non-MPP callers; Gluten MPP
   // supplies a conservative value for replicated Cartesian joins.

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -54,8 +54,10 @@ struct CudfConfig {
   static constexpr const char* kCudfFunctionEngine{"cudf.function_engine"};
   /// Query session configs for the cuDF Operators.
   static constexpr const char* kCudfTopNBatchSize{"cudf.topk_batch_size"};
-  // Maximum retained candidate bytes before CudfTopNRowNumber writes a
-  // sorted run. The default remains 128 MiB.
+  // Maximum retained candidate bytes before CudfTopNRowNumber writes a sorted
+  // run. The value must be a plain unsigned decimal byte count with no unit
+  // suffix; the default is 134217728 bytes (128 MiB). If this threshold causes
+  // a spill, the Task must be configured with an explicit spill root.
   static constexpr const char* kCudfTopNRowNumberCandidateRunBytes{
       "cudf.topn_row_number.candidate_run_bytes"};
   // Hard limit for the complete build table retained by CudfNestedLoopJoin.

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -906,6 +906,19 @@ bool canGroupbyAggregationBeEvaluatedByCudf(
     core::AggregationNode::Step step,
     const std::vector<TypePtr>& rawInputTypes,
     core::QueryCtx* queryCtx) {
+  const auto prefix = CudfConfig::getInstance().functionNamePrefix;
+  const auto originalName = getOriginalName(call.name());
+  if ((originalName == prefix + "collect_list" ||
+       originalName == prefix + "collect_set") &&
+      std::any_of(
+          call.inputs().begin(), call.inputs().end(), [](const auto& input) {
+            return dynamic_cast<const core::ConstantTypedExpr*>(input.get()) !=
+                nullptr;
+          })) {
+    // Collection aggregators currently consume a physical input column and do
+    // not materialize constants like the simple grouped aggregators do.
+    return false;
+  }
   return canAggregationBeEvaluatedByRegistry(
       getGroupbyAggregationRegistry(), call, step, rawInputTypes, queryCtx);
 }

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -68,8 +68,7 @@ constexpr const char* kFinalAggregationMergeBytes =
 constexpr const char* kFinalAggregationMaxLevel =
     "cudfFinalAggregationMaxLevel";
 constexpr const char* kFinalStreamingBatches = "cudfFinalStreamingBatches";
-constexpr const char* kFinalStreamingInputRows =
-    "cudfFinalStreamingInputRows";
+constexpr const char* kFinalStreamingInputRows = "cudfFinalStreamingInputRows";
 constexpr const char* kFinalStreamingDistinctKeys =
     "cudfFinalStreamingDistinctKeys";
 constexpr const char* kFinalStreamingOutputRows =
@@ -1283,14 +1282,12 @@ void CudfGroupby::computeFinalGroupbyStreaming(CudfVectorPtr tbl) {
   bool allRequestsSupported = !regularRequests.empty();
   std::vector<size_t> requestAggregationCounts;
   requestAggregationCounts.reserve(regularRequests.size());
-  std::vector<cudf::groupby::streaming_aggregation_request>
-      streamingRequests;
+  std::vector<cudf::groupby::streaming_aggregation_request> streamingRequests;
   for (auto& request : regularRequests) {
     VELOX_CHECK_LT(
         packedColumns.size(),
         static_cast<size_t>(std::numeric_limits<cudf::size_type>::max()));
-    const auto valueIndex =
-        static_cast<cudf::size_type>(packedColumns.size());
+    const auto valueIndex = static_cast<cudf::size_type>(packedColumns.size());
     packedColumns.push_back(request.values);
     requestAggregationCounts.push_back(request.aggregations.size());
     for (auto& aggregation : request.aggregations) {
@@ -1328,21 +1325,19 @@ void CudfGroupby::computeFinalGroupbyStreaming(CudfVectorPtr tbl) {
       return;
     }
     finalStreamingRequestAggregationCounts_ = requestAggregationCounts;
-    finalStreamingGroupby_ =
-        std::make_unique<cudf::groupby::streaming_groupby>(
-            keyIndices,
-            streamingRequests,
-            finalStreamingMaxDistinctKeys_,
-            ignoreNullKeys_ ? cudf::null_policy::EXCLUDE
-                            : cudf::null_policy::INCLUDE);
+    finalStreamingGroupby_ = std::make_unique<cudf::groupby::streaming_groupby>(
+        keyIndices,
+        streamingRequests,
+        finalStreamingMaxDistinctKeys_,
+        ignoreNullKeys_ ? cudf::null_policy::EXCLUDE
+                        : cudf::null_policy::INCLUDE);
     finalAggregationMode_ = FinalAggregationMode::kStreaming;
     LOG(INFO) << "CUDF_GROUPBY_STREAMING node=" << diagnosticNodeId_
               << " state=selected maxDistinctKeys="
-              << finalStreamingMaxDistinctKeys_ << " keys="
-              << keyIndices.size() << " requests=" << streamingRequests.size();
+              << finalStreamingMaxDistinctKeys_ << " keys=" << keyIndices.size()
+              << " requests=" << streamingRequests.size();
   } else {
-    VELOX_CHECK(
-        finalAggregationMode_ == FinalAggregationMode::kStreaming);
+    VELOX_CHECK(finalAggregationMode_ == FinalAggregationMode::kStreaming);
     VELOX_CHECK(
         allRequestsSupported,
         "CudfGroupby FINAL request support changed after streaming state "
@@ -1384,16 +1379,16 @@ void CudfGroupby::computeFinalGroupbyStreaming(CudfVectorPtr tbl) {
         RuntimeCounter(static_cast<int64_t>(representedRows)));
   }
   if (deviceMemoryDiagnosticsEnabled() &&
-      (finalStreamingBatchCount_ == 1 ||
-       finalStreamingBatchCount_ % 64 == 0)) {
-    logDeviceMemorySnapshot(fmt::format(
-        "operator=CudfGroupby node={} state=final_streaming.aggregate "
-        "batch={} inputRows={} distinctKeys={} maxDistinctKeys={}",
-        diagnosticNodeId_,
-        finalStreamingBatchCount_,
-        representedRows,
-        distinctKeys,
-        finalStreamingMaxDistinctKeys_));
+      (finalStreamingBatchCount_ == 1 || finalStreamingBatchCount_ % 64 == 0)) {
+    logDeviceMemorySnapshot(
+        fmt::format(
+            "operator=CudfGroupby node={} state=final_streaming.aggregate "
+            "batch={} inputRows={} distinctKeys={} maxDistinctKeys={}",
+            diagnosticNodeId_,
+            finalStreamingBatchCount_,
+            representedRows,
+            distinctKeys,
+            finalStreamingMaxDistinctKeys_));
   }
 }
 
@@ -1405,11 +1400,9 @@ void CudfGroupby::addFinalAggregationRun(FinalAggregationRun run) {
   auto level = aggregationRunLevel(run.representedRows);
   {
     auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(kFinalAggregationInputRuns, RuntimeCounter(1));
     lockedStats->addRuntimeStat(
-        kFinalAggregationInputRuns, RuntimeCounter(1));
-    lockedStats->addRuntimeStat(
-        kFinalAggregationMaxLevel,
-        RuntimeCounter(static_cast<int64_t>(level)));
+        kFinalAggregationMaxLevel, RuntimeCounter(static_cast<int64_t>(level)));
   }
 
   for (;;) {
@@ -1448,11 +1441,10 @@ CudfGroupby::FinalAggregationRun CudfGroupby::mergeFinalAggregationRuns(
 
   const auto inputRows = static_cast<int64_t>(left.data->size()) +
       static_cast<int64_t>(right.data->size());
-  const auto inputBytes = left.data->estimateFlatSize() +
-      right.data->estimateFlatSize();
+  const auto inputBytes =
+      left.data->estimateFlatSize() + right.data->estimateFlatSize();
   VELOX_CHECK_LE(
-      inputBytes,
-      static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+      inputBytes, static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
   const auto representedRows =
       addRepresentedRows(left.representedRows, right.representedRows);
 
@@ -1474,8 +1466,7 @@ CudfGroupby::FinalAggregationRun CudfGroupby::mergeFinalAggregationRuns(
   ++finalRunMergeCount_;
   {
     auto lockedStats = stats_.wlock();
-    lockedStats->addRuntimeStat(
-        kFinalAggregationRunMerges, RuntimeCounter(1));
+    lockedStats->addRuntimeStat(kFinalAggregationRunMerges, RuntimeCounter(1));
     if (finalizing) {
       lockedStats->addRuntimeStat(
           kFinalAggregationFinalizeMerges, RuntimeCounter(1));
@@ -1493,19 +1484,20 @@ CudfGroupby::FinalAggregationRun CudfGroupby::mergeFinalAggregationRuns(
   if (deviceMemoryDiagnosticsEnabled() &&
       (finalizing || finalRunMergeCount_ == 1 ||
        finalRunMergeCount_ % 64 == 0)) {
-    logDeviceMemorySnapshot(fmt::format(
-        "operator=CudfGroupby node={} state=final_run.merge phase={} "
-        "level={} merge={} inputRows={} inputBytes={} outputRows={} "
-        "outputBytes={} representedRows={}",
-        diagnosticNodeId_,
-        finalizing ? "finalize" : "online",
-        outputLevel,
-        finalRunMergeCount_,
-        inputRows,
-        inputBytes,
-        output->size(),
-        output->estimateFlatSize(),
-        representedRows));
+    logDeviceMemorySnapshot(
+        fmt::format(
+            "operator=CudfGroupby node={} state=final_run.merge phase={} "
+            "level={} merge={} inputRows={} inputBytes={} outputRows={} "
+            "outputBytes={} representedRows={}",
+            diagnosticNodeId_,
+            finalizing ? "finalize" : "online",
+            outputLevel,
+            finalRunMergeCount_,
+            inputRows,
+            inputBytes,
+            output->size(),
+            output->estimateFlatSize(),
+            representedRows));
   }
 
   return FinalAggregationRun{std::move(output), representedRows};
@@ -1523,16 +1515,17 @@ CudfVectorPtr CudfGroupby::drainFinalAggregationRuns() {
     }
   }
   if (deviceMemoryDiagnosticsEnabled()) {
-    logDeviceMemorySnapshot(fmt::format(
-        "operator=CudfGroupby node={} state=final_runs.drain.begin "
-        "inputRuns={} retainedRuns={} retainedRows={} retainedBytes={} "
-        "onlineMerges={}",
-        diagnosticNodeId_,
-        finalInputRunCount_,
-        retainedRuns,
-        retainedRows,
-        retainedBytes,
-        finalRunMergeCount_));
+    logDeviceMemorySnapshot(
+        fmt::format(
+            "operator=CudfGroupby node={} state=final_runs.drain.begin "
+            "inputRuns={} retainedRuns={} retainedRows={} retainedBytes={} "
+            "onlineMerges={}",
+            diagnosticNodeId_,
+            finalInputRunCount_,
+            retainedRuns,
+            retainedRows,
+            retainedBytes,
+            finalRunMergeCount_));
   }
 
   std::optional<FinalAggregationRun> carry;
@@ -1565,13 +1558,14 @@ CudfVectorPtr CudfGroupby::finalizeStreamingFinalAggregation() {
   VELOX_CHECK_NOT_NULL(finalStreamingGroupby_);
 
   const auto distinctKeys = finalStreamingGroupby_->distinct_keys();
-  logDeviceMemorySnapshot(fmt::format(
-      "operator=CudfGroupby node={} state=final_streaming.finalize.begin "
-      "batches={} distinctKeys={} maxDistinctKeys={}",
-      diagnosticNodeId_,
-      finalStreamingBatchCount_,
-      distinctKeys,
-      finalStreamingMaxDistinctKeys_));
+  logDeviceMemorySnapshot(
+      fmt::format(
+          "operator=CudfGroupby node={} state=final_streaming.finalize.begin "
+          "batches={} distinctKeys={} maxDistinctKeys={}",
+          diagnosticNodeId_,
+          finalStreamingBatchCount_,
+          distinctKeys,
+          finalStreamingMaxDistinctKeys_));
 
   auto [groupKeys, flatResults] =
       finalStreamingGroupby_->finalize(stateStream_, get_output_mr());
@@ -1585,8 +1579,7 @@ CudfVectorPtr CudfGroupby::finalizeStreamingFinalAggregation() {
   std::vector<cudf::groupby::aggregation_result> regularResults;
   regularResults.reserve(finalStreamingRequestAggregationCounts_.size());
   size_t flatResultIndex = 0;
-  for (const auto aggregationCount :
-       finalStreamingRequestAggregationCounts_) {
+  for (const auto aggregationCount : finalStreamingRequestAggregationCounts_) {
     auto& regularResult = regularResults.emplace_back();
     regularResult.results.reserve(aggregationCount);
     for (size_t i = 0; i < aggregationCount; ++i) {
@@ -1618,13 +1611,14 @@ CudfVectorPtr CudfGroupby::finalizeStreamingFinalAggregation() {
   // Complete it before destroying that state. Both state and output use the
   // configured async resources; no pool resource or release threshold is used.
   stateStream_.synchronize();
-  logDeviceMemorySnapshot(fmt::format(
-      "operator=CudfGroupby node={} state=final_streaming.finalize.end "
-      "batches={} distinctKeys={} outputRows={}",
-      diagnosticNodeId_,
-      finalStreamingBatchCount_,
-      distinctKeys,
-      outputRows));
+  logDeviceMemorySnapshot(
+      fmt::format(
+          "operator=CudfGroupby node={} state=final_streaming.finalize.end "
+          "batches={} distinctKeys={} outputRows={}",
+          diagnosticNodeId_,
+          finalStreamingBatchCount_,
+          distinctKeys,
+          outputRows));
   finalStreamingGroupby_.reset();
 
   if (outputRows == 0) {
@@ -1920,8 +1914,7 @@ void CudfGroupby::doClose() {
   try {
     stateStream_.synchronize();
   } catch (const std::exception& error) {
-    LOG(WARNING) << "CudfGroupby state stream cleanup failed: "
-                 << error.what();
+    LOG(WARNING) << "CudfGroupby state stream cleanup failed: " << error.what();
   }
   finalStreamingGroupby_.reset();
   finalStreamingRequestAggregationCounts_.clear();

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -787,6 +787,45 @@ struct GroupbyCollectSetAggregator : GroupbyAggregator {
   uint32_t outputIdx_{0};
 };
 
+struct GroupbyCollectListAggregator : GroupbyAggregator {
+  GroupbyCollectListAggregator(
+      core::AggregationNode::Step step,
+      uint32_t inputIndex,
+      VectorPtr constant,
+      const TypePtr& resultType)
+      : GroupbyAggregator(step, inputIndex, constant, resultType) {}
+
+  void addGroupbyRequest(
+      cudf::table_view const& tbl,
+      std::vector<cudf::groupby::aggregation_request>& requests,
+      rmm::cuda_stream_view /*stream*/) override {
+    VELOX_CHECK(
+        constant == nullptr,
+        "GroupbyCollectListAggregator does not support constant input");
+    auto& request = requests.emplace_back();
+    outputIdx_ = requests.size() - 1;
+    request.values = tbl.column(inputIndex);
+    if (exec::isRawInput(step)) {
+      request.aggregations.push_back(
+          cudf::make_collect_list_aggregation<cudf::groupby_aggregation>(
+              cudf::null_policy::EXCLUDE));
+      return;
+    }
+    request.aggregations.push_back(
+        cudf::make_merge_lists_aggregation<cudf::groupby_aggregation>());
+  }
+
+  std::unique_ptr<cudf::column> makeOutputColumn(
+      std::vector<cudf::groupby::aggregation_result>& results,
+      rmm::cuda_stream_view /*stream*/,
+      rmm::device_async_resource_ref /*mr*/) override {
+    return std::move(results[outputIdx_].results[0]);
+  }
+
+ private:
+  uint32_t outputIdx_{0};
+};
+
 std::unique_ptr<GroupbyAggregator> createGroupbyAggregator(
     const ResolvedAggregateInfo& p) {
   auto const& kind = p.kind;
@@ -824,6 +863,9 @@ std::unique_ptr<GroupbyAggregator> createGroupbyAggregator(
         p.companionStep, p.inputIndex, p.constant, p.resultType);
   } else if (kind.rfind(prefix + "collect_set", 0) == 0) {
     return std::make_unique<GroupbyCollectSetAggregator>(
+        p.companionStep, p.inputIndex, p.constant, p.resultType);
+  } else if (kind.rfind(prefix + "collect_list", 0) == 0) {
+    return std::make_unique<GroupbyCollectListAggregator>(
         p.companionStep, p.inputIndex, p.constant, p.resultType);
   } else {
     VELOX_NYI("Aggregation not yet supported, kind: {}", kind);

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -181,17 +181,19 @@ void CudfNestedLoopJoinBuild::doAddInput(RowVectorPtr input) {
     // is the runtime backstop for planner estimates used by replicated MPP
     // Cartesian joins.
     const auto inputBytes = cudfInput->estimateFlatSize();
-    auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
-        operatorCtx_->driverCtx()->splitGroupId, planNodeId());
-    auto bridge =
-        std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(joinBridge);
-    VELOX_CHECK_NOT_NULL(bridge);
-    bridge->reserveBuildBytes(inputBytes, maxBuildBytes_);
+    if (!buildBridge_) {
+      auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
+          operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+      buildBridge_ =
+          std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(joinBridge);
+      VELOX_CHECK_NOT_NULL(buildBridge_);
+    }
+    buildBridge_->reserveBuildBytes(inputBytes, maxBuildBytes_);
     try {
       inputs_.push_back(std::move(cudfInput)); // Store in GPU memory
       bufferedBuildBytes_ += inputBytes;
     } catch (...) {
-      bridge->releaseBuildBytes(inputBytes);
+      buildBridge_->releaseBuildBytes(inputBytes);
       throw;
     }
   }
@@ -278,6 +280,7 @@ void CudfNestedLoopJoinBuild::doNoMoreInput() {
       operatorCtx_->driverCtx()->splitGroupId, planNodeId());
   auto bridge = std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(joinBridge);
   VELOX_CHECK_NOT_NULL(bridge);
+  buildBridge_ = bridge;
 
   try {
     auto table = getConcatenatedTable(
@@ -320,15 +323,12 @@ bool CudfNestedLoopJoinBuild::isFinished() {
 
 void CudfNestedLoopJoinBuild::doClose() {
   if (bufferedBuildBytes_ > 0 && !inputs_.empty()) {
-    auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
-        operatorCtx_->driverCtx()->splitGroupId, planNodeId());
-    auto bridge =
-        std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(joinBridge);
-    VELOX_CHECK_NOT_NULL(bridge);
-    bridge->releaseBuildBytes(bufferedBuildBytes_);
+    VELOX_CHECK_NOT_NULL(buildBridge_);
+    buildBridge_->releaseBuildBytes(bufferedBuildBytes_);
   }
   inputs_.clear();
   bufferedBuildBytes_ = 0;
+  buildBridge_.reset();
   Operator::close();
 }
 

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -17,7 +17,6 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfNestedLoopJoin.h"
-
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
@@ -157,7 +156,7 @@ CudfNestedLoopJoinBuild::CudfNestedLoopJoinBuild(
           nvtx3::rgb{65, 105, 225}, // Royal Blue
           NvtxMethodFlag::kNoMoreInput,
           std::nullopt,
-      joinNode),
+          joinNode),
       joinNode_(joinNode),
       maxBuildBytes_(driverCtx->queryConfig().get<uint64_t>(
           CudfConfig::kCudfNestedLoopJoinMaxBuildBytes,

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -17,6 +17,7 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfNestedLoopJoin.h"
+
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
@@ -40,6 +41,8 @@
 #include <cudf/search.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/unary.hpp>
+
+#include <limits>
 
 namespace facebook::velox::cudf_velox {
 
@@ -105,6 +108,36 @@ CudfNestedLoopJoinBridge::getBuildStream() {
   return buildStream_;
 }
 
+void CudfNestedLoopJoinBridge::reserveBuildBytes(
+    uint64_t bytes,
+    uint64_t maxBuildBytes) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_USER_CHECK_LE(
+      retainedBuildBytes_,
+      maxBuildBytes,
+      "CudfNestedLoopJoin build byte accounting exceeded configured limit: "
+      "retained={} limit={} config={}",
+      retainedBuildBytes_,
+      maxBuildBytes,
+      CudfConfig::kCudfNestedLoopJoinMaxBuildBytes);
+  VELOX_USER_CHECK_LE(
+      bytes,
+      maxBuildBytes - retainedBuildBytes_,
+      "CudfNestedLoopJoin build exceeds configured device-memory limit "
+      "before retaining next batch: retained={} next={} limit={} config={}",
+      retainedBuildBytes_,
+      bytes,
+      maxBuildBytes,
+      CudfConfig::kCudfNestedLoopJoinMaxBuildBytes);
+  retainedBuildBytes_ += bytes;
+}
+
+void CudfNestedLoopJoinBridge::releaseBuildBytes(uint64_t bytes) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_GE(retainedBuildBytes_, bytes);
+  retainedBuildBytes_ -= bytes;
+}
+
 // ============================================================================
 // Build Operator Implementation
 // ============================================================================
@@ -124,8 +157,19 @@ CudfNestedLoopJoinBuild::CudfNestedLoopJoinBuild(
           nvtx3::rgb{65, 105, 225}, // Royal Blue
           NvtxMethodFlag::kNoMoreInput,
           std::nullopt,
-          joinNode),
-      joinNode_(joinNode) {}
+      joinNode),
+      joinNode_(joinNode),
+      maxBuildBytes_(driverCtx->queryConfig().get<uint64_t>(
+          CudfConfig::kCudfNestedLoopJoinMaxBuildBytes,
+          std::numeric_limits<uint64_t>::max())) {}
+
+std::unique_ptr<exec::Operator> makeCudfNestedLoopJoinBuild(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::NestedLoopJoinNode> joinNode) {
+  return std::make_unique<CudfNestedLoopJoinBuild>(
+      operatorId, driverCtx, std::move(joinNode));
+}
 
 // Accumulates input batches in memory.
 // All batches are kept as CudfVectors (GPU memory) until join completes.
@@ -133,7 +177,23 @@ void CudfNestedLoopJoinBuild::doAddInput(RowVectorPtr input) {
   if (input->size() > 0) {
     auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
     VELOX_CHECK_NOT_NULL(cudfInput);
-    inputs_.push_back(std::move(cudfInput)); // Store in GPU memory
+    // Enforce the exact device payload before retaining the next batch. This
+    // is the runtime backstop for planner estimates used by replicated MPP
+    // Cartesian joins.
+    const auto inputBytes = cudfInput->estimateFlatSize();
+    auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
+        operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+    auto bridge =
+        std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(joinBridge);
+    VELOX_CHECK_NOT_NULL(bridge);
+    bridge->reserveBuildBytes(inputBytes, maxBuildBytes_);
+    try {
+      inputs_.push_back(std::move(cudfInput)); // Store in GPU memory
+      bufferedBuildBytes_ += inputBytes;
+    } catch (...) {
+      bridge->releaseBuildBytes(inputBytes);
+      throw;
+    }
   }
 }
 
@@ -166,24 +226,46 @@ void CudfNestedLoopJoinBuild::doNoMoreInput() {
     return; // Not the last driver - just wait
   }
 
-  // This driver was chosen to collect data from all peers
-  for (auto& peer : peers) {
-    auto op = peer->findOperator(planNodeId());
-    auto* build = dynamic_cast<CudfNestedLoopJoinBuild*>(op);
-    VELOX_CHECK_NOT_NULL(build);
-    inputs_.insert(
-        inputs_.end(),
-        std::make_move_iterator(build->inputs_.begin()),
-        std::make_move_iterator(build->inputs_.end()));
-  }
-
-  // Wake up peer build operators when we finish transferring data
+  // Always wake the waiting build peers, including when host-vector growth or
+  // build concatenation throws. Leaving this guard after the peer merge would
+  // strand the other drivers on an allocation failure.
   SCOPE_EXIT {
     peers.clear();
     for (auto& promise : promises) {
       promise.setValue(); // Unblock other build operators
     }
   };
+
+  std::vector<CudfNestedLoopJoinBuild*> peerBuilds;
+  peerBuilds.reserve(peers.size());
+  auto mergedInputCount = inputs_.size();
+  for (auto& peer : peers) {
+    auto op = peer->findOperator(planNodeId());
+    auto* build = dynamic_cast<CudfNestedLoopJoinBuild*>(op);
+    VELOX_CHECK_NOT_NULL(build);
+    VELOX_CHECK_LE(
+        build->inputs_.size(),
+        inputs_.max_size() - mergedInputCount,
+        "CudfNestedLoopJoin build input vector exceeds host size limit");
+    mergedInputCount += build->inputs_.size();
+    peerBuilds.push_back(build);
+  }
+
+  // Allocate once before moving peer-owned vectors and byte-accounting
+  // ownership. With sufficient capacity, shared_ptr moves below are noexcept.
+  inputs_.reserve(mergedInputCount);
+
+  // This driver was chosen to collect data from all peers
+  for (auto* build : peerBuilds) {
+    // The shared join bridge reserved these bytes before each peer retained
+    // its batches, so transferring ownership does not need another reserve.
+    inputs_.insert(
+        inputs_.end(),
+        std::make_move_iterator(build->inputs_.begin()),
+        std::make_move_iterator(build->inputs_.end()));
+    bufferedBuildBytes_ += build->bufferedBuildBytes_;
+    build->bufferedBuildBytes_ = 0;
+  }
 
   // Concatenate all input batches into a single cuDF table.
   // getConcatenatedTable throws if the total row count exceeds cudf::size_type
@@ -192,23 +274,35 @@ void CudfNestedLoopJoinBuild::doNoMoreInput() {
   // join output is probe_rows × build_rows regardless of how the build is
   // split.
   auto stream = cudfGlobalStreamPool().get_stream();
-  auto table = getConcatenatedTable(
-      std::exchange(inputs_, {}),
-      joinNode_->sources()[1]->outputType(),
-      stream,
-      get_output_mr());
-
-  // Transfer build data to bridge - this will unblock probe operators.
-  // No stream sync is required: the probe side uses syncBuildStream() via a
-  // CUDA event to ensure the build table is ready before reading it.
   auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
       operatorCtx_->driverCtx()->splitGroupId, planNodeId());
   auto bridge = std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(joinBridge);
+  VELOX_CHECK_NOT_NULL(bridge);
 
-  bridge->setBuildStream(stream); // Pass stream for CUDA synchronization
-  bridge->setData(
-      std::make_optional(
-          std::shared_ptr<cudf::table>(std::move(table)))); // Wake probes
+  try {
+    auto table = getConcatenatedTable(
+        std::exchange(inputs_, {}),
+        joinNode_->sources()[1]->outputType(),
+        stream,
+        get_output_mr());
+
+    // Transfer build data to bridge - this will unblock probe operators.
+    // No stream sync is required: the probe side uses syncBuildStream() via a
+    // CUDA event to ensure the build table is ready before reading it.
+    bridge->setBuildStream(stream); // Pass stream for CUDA synchronization
+    bridge->setData(
+        std::make_optional(
+            std::shared_ptr<cudf::table>(std::move(table)))); // Wake probes
+    // The bridge now owns the complete build. Keep its global accounting until
+    // bridge destruction, but disarm this operator's close-time release.
+    bufferedBuildBytes_ = 0;
+  } catch (...) {
+    // std::exchange empties inputs_ before concatenation. Release accounting
+    // here because doClose() can no longer observe those retained vectors.
+    bridge->releaseBuildBytes(bufferedBuildBytes_);
+    bufferedBuildBytes_ = 0;
+    throw;
+  }
 }
 
 exec::BlockingReason CudfNestedLoopJoinBuild::isBlocked(
@@ -225,7 +319,16 @@ bool CudfNestedLoopJoinBuild::isFinished() {
 }
 
 void CudfNestedLoopJoinBuild::doClose() {
+  if (bufferedBuildBytes_ > 0 && !inputs_.empty()) {
+    auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
+        operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+    auto bridge =
+        std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(joinBridge);
+    VELOX_CHECK_NOT_NULL(bridge);
+    bridge->releaseBuildBytes(bufferedBuildBytes_);
+  }
   inputs_.clear();
+  bufferedBuildBytes_ = 0;
   Operator::close();
 }
 
@@ -1020,8 +1123,7 @@ exec::OperatorSupplier CudfNestedLoopJoinBridgeTranslator::toOperatorSupplier(
   if (auto joinNode =
           std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(node)) {
     return [joinNode](int32_t operatorId, exec::DriverCtx* ctx) {
-      return std::make_unique<CudfNestedLoopJoinBuild>(
-          operatorId, ctx, joinNode);
+      return makeCudfNestedLoopJoinBuild(operatorId, ctx, joinNode);
     };
   }
   return nullptr;

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
@@ -59,9 +59,14 @@ class CudfNestedLoopJoinBridge : public exec::JoinBridge {
 
   std::optional<rmm::cuda_stream_view> getBuildStream();
 
+  void reserveBuildBytes(uint64_t bytes, uint64_t maxBuildBytes);
+
+  void releaseBuildBytes(uint64_t bytes);
+
  private:
   std::optional<build_data_type> data_;
   std::optional<rmm::cuda_stream_view> buildStream_;
+  uint64_t retainedBuildBytes_{0};
 };
 
 /// Accumulates build-side input for nested loop join.
@@ -100,8 +105,20 @@ class CudfNestedLoopJoinBuild : public CudfOperatorBase {
  private:
   std::shared_ptr<const core::NestedLoopJoinNode> joinNode_;
   std::vector<CudfVectorPtr> inputs_;
+  uint64_t maxBuildBytes_;
+  uint64_t bufferedBuildBytes_{0};
   ContinueFuture future_{ContinueFuture::makeEmpty()};
 };
+
+/// Constructs the build operator in the same translation unit that defines
+/// CudfNestedLoopJoinBuild.  Keep external adapters on this factory instead of
+/// inlining make_unique<CudfNestedLoopJoinBuild>: doing so prevents a stale
+/// caller object from baking in an older concrete class size after the build
+/// operator gains or removes private state.
+std::unique_ptr<exec::Operator> makeCudfNestedLoopJoinBuild(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::NestedLoopJoinNode> joinNode);
 
 /// Performs nested loop join using cuDF APIs.
 ///

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
@@ -105,6 +105,7 @@ class CudfNestedLoopJoinBuild : public CudfOperatorBase {
  private:
   std::shared_ptr<const core::NestedLoopJoinNode> joinNode_;
   std::vector<CudfVectorPtr> inputs_;
+  std::shared_ptr<CudfNestedLoopJoinBridge> buildBridge_;
   uint64_t maxBuildBytes_;
   uint64_t bufferedBuildBytes_{0};
   ContinueFuture future_{ContinueFuture::makeEmpty()};

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -20,6 +20,7 @@
 #include "velox/experimental/cudf/exec/Utilities.h"
 
 #include "velox/exec/OperatorUtils.h"
+#include "velox/exec/Task.h"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
@@ -356,8 +357,13 @@ void CudfTopNRowNumber::spillSortedRun() {
 
   namespace fs = std::filesystem;
   if (!spilled_) {
+    const auto& taskSpillRoot =
+        operatorCtx_->task()->getOrCreateSpillDirectory();
+    VELOX_CHECK(
+        !taskSpillRoot.empty(),
+        "CudfTopNRowNumber requires an explicit Task spill directory");
     const auto sequence = spillDirectorySequence.fetch_add(1);
-    spillDirectory_ = (fs::temp_directory_path() /
+    spillDirectory_ = (fs::path(taskSpillRoot) /
                        fmt::format(
                            "velox-cudf-topn-spill-{}-{}",
                            static_cast<int64_t>(::getpid()),

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -733,7 +733,12 @@ void CudfTopNRowNumber::cleanupSpillFiles() {
   }
   std::error_code error;
   std::filesystem::remove_all(spillDirectory_, error);
-  spillDirectory_.clear();
+  if (error) {
+    LOG(ERROR) << "Failed to remove CudfTopNRowNumber spill directory '"
+               << spillDirectory_ << "': " << error.message();
+  } else {
+    spillDirectory_.clear();
+  }
   ::malloc_trim(0);
 }
 

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfTopNRowNumber.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
@@ -47,7 +48,7 @@ namespace facebook::velox::cudf_velox {
 namespace {
 
 constexpr uint64_t kSortedRunBytes = 3ULL << 30;
-constexpr uint64_t kCandidateRunBytes = 128ULL << 20;
+constexpr uint64_t kDefaultCandidateRunBytes = 128ULL << 20;
 constexpr uint64_t kMergeChunkBytes = 32ULL << 20;
 constexpr size_t kMergeFanIn = 4;
 constexpr cudf::size_type kMaxCompleteOutputRows = 262144;
@@ -144,8 +145,15 @@ CudfTopNRowNumber::CudfTopNRowNumber(
       rankFunction_(node->rankFunction()),
       generateRowNumber_(node->generateRowNumber()),
       inputType_(node->inputType()),
-      diagnosticNodeId_(node->id()) {
+      diagnosticNodeId_(node->id()),
+      candidateRunBytes_(driverCtx->queryConfig().get<uint64_t>(
+          CudfConfig::kCudfTopNRowNumberCandidateRunBytes,
+          kDefaultCandidateRunBytes)) {
   VELOX_CHECK_EQ(limit_, 1, "CudfTopNRowNumber only supports limit=1");
+  VELOX_CHECK_GT(
+      candidateRunBytes_,
+      0,
+      "CudfTopNRowNumber candidate run bytes must be greater than zero");
   VELOX_CHECK(
       rankFunction_ == core::TopNRowNumberNode::RankFunction::kRowNumber ||
           rankFunction_ == core::TopNRowNumberNode::RankFunction::kRank ||
@@ -260,7 +268,7 @@ void CudfTopNRowNumber::doAddInput(RowVectorPtr input) {
       std::move(candidates_),
       stream);
   const auto candidateBytes = candidateVector->estimateFlatSize();
-  if (candidateBytes >= kCandidateRunBytes) {
+  if (candidateBytes >= candidateRunBytes_) {
     inputs_.push_back(std::move(candidateVector));
     bufferedBytes_ = candidateBytes;
     spillSortedRun();

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.h
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.h
@@ -97,6 +97,7 @@ class CudfTopNRowNumber : public CudfOperatorBase {
   const bool generateRowNumber_;
   const RowTypePtr inputType_;
   const core::PlanNodeId diagnosticNodeId_;
+  const uint64_t candidateRunBytes_;
 
   std::vector<cudf::size_type> partitionKeys_;
   std::vector<cudf::size_type> sortKeys_;

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -630,8 +630,7 @@ class NestedLoopJoinBuildAdapter : public CudfNestedLoopJoinBaseAdapter {
 
     std::vector<std::unique_ptr<exec::Operator>> result;
     result.push_back(
-        std::make_unique<CudfNestedLoopJoinBuild>(
-            operatorId, ctx, joinPlanNode));
+        makeCudfNestedLoopJoinBuild(operatorId, ctx, std::move(joinPlanNode)));
     return result;
   }
 };

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -1351,9 +1351,8 @@ class MergeExchangeAdapter : public OperatorAdapter {
         mergeExchangeNode->transportType() ==
             core::ExchangeNode::TransportType::kUcx;
     const bool orderBySupported = mergeExchangeNode &&
-        CudfOrderBy::isSupported(
-            mergeExchangeNode->outputType(),
-            mergeExchangeNode->sortingKeys());
+        CudfOrderBy::isSupported(mergeExchangeNode->outputType(),
+                                 mergeExchangeNode->sortingKeys());
     LOG(WARNING) << "CudfMergeExchangeAdapter: canRunOnGPU node="
                  << (mergeExchangeNode ? mergeExchangeNode->id() : "<null>")
                  << " isUcx=" << isUcx

--- a/velox/experimental/cudf/exec/SparkAggregateFunctions.cpp
+++ b/velox/experimental/cudf/exec/SparkAggregateFunctions.cpp
@@ -79,12 +79,12 @@ void registerSparkAggregateFunctions(const std::string& prefix) {
           .build());
   // AVG final: row(DOUBLE,BIGINT)->DOUBLE already registered.
 
-  auto collectSetRawSignature = FunctionSignatureBuilder()
+  auto collectionRawSignature = FunctionSignatureBuilder()
                                     .typeVariable("T")
                                     .returnType("array(T)")
                                     .argumentType("T")
                                     .build();
-  auto collectSetMergeSignature = FunctionSignatureBuilder()
+  auto collectionMergeSignature = FunctionSignatureBuilder()
                                       .typeVariable("T")
                                       .returnType("array(T)")
                                       .argumentType("array(T)")
@@ -92,19 +92,39 @@ void registerSparkAggregateFunctions(const std::string& prefix) {
   appendGroupbyAggregationFunctionForStep(
       prefix + "collect_set",
       core::AggregationNode::Step::kSingle,
-      collectSetRawSignature);
+      collectionRawSignature);
   appendGroupbyAggregationFunctionForStep(
       prefix + "collect_set",
       core::AggregationNode::Step::kPartial,
-      collectSetRawSignature);
+      collectionRawSignature);
   appendGroupbyAggregationFunctionForStep(
       prefix + "collect_set",
       core::AggregationNode::Step::kIntermediate,
-      collectSetMergeSignature);
+      collectionMergeSignature);
   appendGroupbyAggregationFunctionForStep(
       prefix + "collect_set",
       core::AggregationNode::Step::kFinal,
-      collectSetMergeSignature);
+      collectionMergeSignature);
+
+  // Spark collect_list ignores null input values and preserves duplicates.
+  // libcudf implements it only for grouped aggregation, so do not advertise
+  // these signatures in the reduce registry.
+  appendGroupbyAggregationFunctionForStep(
+      prefix + "collect_list",
+      core::AggregationNode::Step::kSingle,
+      collectionRawSignature);
+  appendGroupbyAggregationFunctionForStep(
+      prefix + "collect_list",
+      core::AggregationNode::Step::kPartial,
+      collectionRawSignature);
+  appendGroupbyAggregationFunctionForStep(
+      prefix + "collect_list",
+      core::AggregationNode::Step::kIntermediate,
+      collectionMergeSignature);
+  appendGroupbyAggregationFunctionForStep(
+      prefix + "collect_list",
+      core::AggregationNode::Step::kFinal,
+      collectionMergeSignature);
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/SparkAggregateFunctions.cpp
+++ b/velox/experimental/cudf/exec/SparkAggregateFunctions.cpp
@@ -107,8 +107,8 @@ void registerSparkAggregateFunctions(const std::string& prefix) {
       collectionMergeSignature);
 
   // Spark collect_list ignores null input values and preserves duplicates.
-  // libcudf implements it only for grouped aggregation, so do not advertise
-  // these signatures in the reduce registry.
+  // The Velox-cuDF adapter implements it only for grouped aggregation, so do
+  // not advertise these signatures in the reduce registry.
   appendGroupbyAggregationFunctionForStep(
       prefix + "collect_list",
       core::AggregationNode::Step::kSingle,

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -269,6 +269,12 @@ velox_add_cudf_test(
   LIBS ${CUDF_TEST_DEFAULT_LIBS} fmt::fmt
 )
 
+velox_add_cudf_test(
+  NAME velox_cudf_top_n_row_number_test
+  SOURCES Main.cpp TopNRowNumberTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS}
+)
+
 add_subdirectory(iceberg)
 add_subdirectory(utils)
 

--- a/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
+++ b/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"

--- a/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
+++ b/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
@@ -100,9 +100,7 @@ TEST_F(CudfNestedLoopJoinTest, buildByteLimitAndCleanup) {
   VELOX_ASSERT_THROW(
       AssertQueryBuilder(plan)
           .config(
-              cudf_velox::CudfConfig::
-                  kCudfNestedLoopJoinMaxBuildBytes,
-              "16")
+              cudf_velox::CudfConfig::kCudfNestedLoopJoinMaxBuildBytes, "16")
           .copyResults(pool()),
       "CudfNestedLoopJoin build exceeds configured device-memory limit");
 

--- a/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
+++ b/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -66,6 +67,45 @@ TEST_F(CudfNestedLoopJoinTest, crossJoin) {
                   .planNode();
 
   // Cross join produces 3 * 2 = 6 rows
+  assertQuery(plan, "SELECT * FROM t, u");
+}
+
+// The replicated MPP path retains the complete build table on every GPU.
+// Reject the next device batch before retaining it when the runtime cap is
+// exceeded, then verify a fresh task can reuse the same plan successfully.
+TEST_F(CudfNestedLoopJoinTest, buildByteLimitAndCleanup) {
+  auto probeVectors = {makeRowVector({sequence<int32_t>(3)})};
+  // The first batch fits and is retained; the second one crosses the cap. This
+  // exercises close-time release of already-accounted build data, rather than
+  // rejecting before the bridge owns anything.
+  std::vector<RowVectorPtr> buildVectors{
+      makeRowVector({sequence<int32_t>(1)}),
+      makeRowVector({sequence<int32_t>(128)})};
+
+  createDuckDbTable("t", {probeVectors});
+  createDuckDbTable("u", {buildVectors});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values({probeVectors})
+                  .nestedLoopJoin(
+                      PlanBuilder(planNodeIdGenerator)
+                          .values({buildVectors})
+                          .project({"c0 AS u_c0"})
+                          .planNode(),
+                      {"c0", "u_c0"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .config(
+              cudf_velox::CudfConfig::
+                  kCudfNestedLoopJoinMaxBuildBytes,
+              "16")
+          .copyResults(pool()),
+      "CudfNestedLoopJoin build exceeds configured device-memory limit");
+
+  // A rejected task must release all retained build vectors on close.
   assertQuery(plan, "SELECT * FROM t, u");
 }
 

--- a/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
+++ b/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
@@ -476,6 +476,17 @@ TEST_F(
     EXPECT_FALSE(canReduceAggregationBeEvaluatedByCudf(
         *mergeCall, step, {arrayOfRows}, queryCtx_.get()));
   }
+
+  const auto constantCall = std::make_shared<core::CallTypedExpr>(
+      ARRAY(BIGINT()),
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::ConstantTypedExpr>(BIGINT(), variant(7LL))},
+      "collect_list");
+  EXPECT_FALSE(canGroupbyAggregationBeEvaluatedByCudf(
+      *constantCall,
+      core::AggregationNode::Step::kSingle,
+      {BIGINT()},
+      queryCtx_.get()));
 }
 
 TEST_F(

--- a/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
+++ b/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
@@ -454,10 +454,11 @@ TEST_F(
   ASSERT_NE(groupbyIt, groupbyRegistry.end());
   EXPECT_EQ(reduceRegistry.find("collect_list"), reduceRegistry.end());
 
-  for (const auto step : {core::AggregationNode::Step::kSingle,
-                          core::AggregationNode::Step::kPartial,
-                          core::AggregationNode::Step::kIntermediate,
-                          core::AggregationNode::Step::kFinal}) {
+  for (const auto step :
+       {core::AggregationNode::Step::kSingle,
+        core::AggregationNode::Step::kPartial,
+        core::AggregationNode::Step::kIntermediate,
+        core::AggregationNode::Step::kFinal}) {
     const auto stepIt = groupbyIt->second.find(step);
     ASSERT_NE(stepIt, groupbyIt->second.end());
     EXPECT_FALSE(stepIt->second.empty());
@@ -477,15 +478,17 @@ TEST_F(
               arrayOfRows, "intermediate")},
       "collect_list");
 
-  for (const auto step : {core::AggregationNode::Step::kSingle,
-                          core::AggregationNode::Step::kPartial}) {
+  for (const auto step :
+       {core::AggregationNode::Step::kSingle,
+        core::AggregationNode::Step::kPartial}) {
     EXPECT_TRUE(canGroupbyAggregationBeEvaluatedByCudf(
         *rawCall, step, {rowType}, queryCtx_.get()));
     EXPECT_FALSE(canReduceAggregationBeEvaluatedByCudf(
         *rawCall, step, {rowType}, queryCtx_.get()));
   }
-  for (const auto step : {core::AggregationNode::Step::kIntermediate,
-                          core::AggregationNode::Step::kFinal}) {
+  for (const auto step :
+       {core::AggregationNode::Step::kIntermediate,
+        core::AggregationNode::Step::kFinal}) {
     EXPECT_TRUE(canGroupbyAggregationBeEvaluatedByCudf(
         *mergeCall, step, {arrayOfRows}, queryCtx_.get()));
     EXPECT_FALSE(canReduceAggregationBeEvaluatedByCudf(

--- a/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
+++ b/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
@@ -445,6 +445,41 @@ TEST_F(
 
 TEST_F(
     StepAwareAggregationRegistryTest,
+    sparkCollectListSupportsAllGroupbyStepsButNotReduce) {
+  registerSparkAggregateFunctions("");
+
+  const auto rowType = ROW({BIGINT(), VARCHAR()});
+  const auto arrayOfRows = ARRAY(rowType);
+  const auto rawCall = std::make_shared<core::CallTypedExpr>(
+      arrayOfRows,
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(rowType, "input")},
+      "collect_list");
+  const auto mergeCall = std::make_shared<core::CallTypedExpr>(
+      arrayOfRows,
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(
+              arrayOfRows, "intermediate")},
+      "collect_list");
+
+  for (const auto step : {core::AggregationNode::Step::kSingle,
+                          core::AggregationNode::Step::kPartial}) {
+    EXPECT_TRUE(canGroupbyAggregationBeEvaluatedByCudf(
+        *rawCall, step, {rowType}, queryCtx_.get()));
+    EXPECT_FALSE(canReduceAggregationBeEvaluatedByCudf(
+        *rawCall, step, {rowType}, queryCtx_.get()));
+  }
+  for (const auto step : {core::AggregationNode::Step::kIntermediate,
+                          core::AggregationNode::Step::kFinal}) {
+    EXPECT_TRUE(canGroupbyAggregationBeEvaluatedByCudf(
+        *mergeCall, step, {arrayOfRows}, queryCtx_.get()));
+    EXPECT_FALSE(canReduceAggregationBeEvaluatedByCudf(
+        *mergeCall, step, {arrayOfRows}, queryCtx_.get()));
+  }
+}
+
+TEST_F(
+    StepAwareAggregationRegistryTest,
     appendGroupbySignatureOnlyAffectsGroupbyRegistryAndValidation) {
   unregisterAggregateFunctions();
 

--- a/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
+++ b/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
@@ -448,6 +448,21 @@ TEST_F(
     sparkCollectListSupportsAllGroupbyStepsButNotReduce) {
   registerSparkAggregateFunctions("");
 
+  const auto& groupbyRegistry = getGroupbyAggregationRegistry();
+  const auto& reduceRegistry = getReduceAggregationRegistry();
+  const auto groupbyIt = groupbyRegistry.find("collect_list");
+  ASSERT_NE(groupbyIt, groupbyRegistry.end());
+  EXPECT_EQ(reduceRegistry.find("collect_list"), reduceRegistry.end());
+
+  for (const auto step : {core::AggregationNode::Step::kSingle,
+                          core::AggregationNode::Step::kPartial,
+                          core::AggregationNode::Step::kIntermediate,
+                          core::AggregationNode::Step::kFinal}) {
+    const auto stepIt = groupbyIt->second.find(step);
+    ASSERT_NE(stepIt, groupbyIt->second.end());
+    EXPECT_FALSE(stepIt->second.empty());
+  }
+
   const auto rowType = ROW({BIGINT(), VARCHAR()});
   const auto arrayOfRows = ARRAY(rowType);
   const auto rawCall = std::make_shared<core::CallTypedExpr>(

--- a/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
+++ b/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 
+#include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/exec/Cursor.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
@@ -105,6 +106,7 @@ class CudfTopNRowNumberTest : public OperatorTestBase {
 
   void SetUp() override {
     OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
     previousAllowCpuFallback_ =
         cudf_velox::CudfConfig::getInstance().allowCpuFallback;
     cudf_velox::CudfConfig::getInstance().allowCpuFallback = false;

--- a/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
+++ b/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/exec/Cursor.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+#include <unistd.h>
+
+#include <filesystem>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace facebook::velox;
+using namespace facebook::velox::common::testutil;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr std::string_view kSpillDirectoryPrefix{"velox-cudf-topn-spill-"};
+
+bool hasSpillDirectoryPrefix(const fs::path& path) {
+  return path.filename().string().rfind(kSpillDirectoryPrefix, 0) == 0;
+}
+
+std::vector<fs::path> findSpillDirectories(const fs::path& root) {
+  std::vector<fs::path> paths;
+  std::error_code error;
+  if (!fs::exists(root, error)) {
+    return paths;
+  }
+
+  fs::recursive_directory_iterator iterator(
+      root, fs::directory_options::skip_permission_denied, error);
+  const fs::recursive_directory_iterator end;
+  while (iterator != end) {
+    if (!error && iterator->is_directory(error) &&
+        hasSpillDirectoryPrefix(iterator->path())) {
+      paths.push_back(iterator->path());
+    }
+    error.clear();
+    iterator.increment(error);
+  }
+  return paths;
+}
+
+std::set<fs::path> findTopLevelProcessSpillDirectories() {
+  const auto processPrefix =
+      std::string(kSpillDirectoryPrefix) + std::to_string(::getpid()) + "-";
+  std::set<fs::path> paths;
+  std::error_code error;
+  fs::directory_iterator iterator(
+      fs::temp_directory_path(),
+      fs::directory_options::skip_permission_denied,
+      error);
+  const fs::directory_iterator end;
+  while (iterator != end) {
+    if (!error && iterator->is_directory(error) &&
+        iterator->path().filename().string().rfind(processPrefix, 0) == 0) {
+      paths.insert(iterator->path());
+    }
+    error.clear();
+    iterator.increment(error);
+  }
+  return paths;
+}
+
+bool usedCudfTopNRowNumber(const TaskStats& stats) {
+  for (const auto& pipelineStats : stats.pipelineStats) {
+    for (const auto& operatorStats : pipelineStats.operatorStats) {
+      if (operatorStats.operatorType == "CudfTopNRowNumber") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+class CudfTopNRowNumberTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    previousAllowCpuFallback_ =
+        cudf_velox::CudfConfig::getInstance().allowCpuFallback;
+    cudf_velox::CudfConfig::getInstance().allowCpuFallback = false;
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    cudf_velox::CudfConfig::getInstance().allowCpuFallback =
+        previousAllowCpuFallback_;
+    OperatorTestBase::TearDown();
+  }
+
+ private:
+  bool previousAllowCpuFallback_{true};
+};
+
+TEST_F(CudfTopNRowNumberTest, spillUsesTaskRootAndCleansUp) {
+  constexpr vector_size_t kNumRows = 32;
+  auto data = makeRowVector(
+      {"p", "s", "v"},
+      {makeFlatVector<int64_t>(kNumRows, [](vector_size_t row) { return row; }),
+       makeFlatVector<int64_t>(
+           kNumRows, [](vector_size_t row) { return kNumRows - row; }),
+       makeFlatVector<int64_t>(
+           kNumRows, [](vector_size_t row) { return row * 10; })});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .topNRowNumber({"p"}, {"s"}, 1, true)
+                  .planNode();
+
+  const auto spillRoot = TempDirectoryPath::create();
+  const auto preexistingTopLevelSpills = findTopLevelProcessSpillDirectories();
+
+  CursorParameters params;
+  params.planNode = plan;
+  params.maxDrivers = 1;
+  params.serialExecution = true;
+  params.spillDirectory = spillRoot->getPath();
+  params.queryConfigs = {
+      {cudf_velox::CudfConfig::kCudfEnabled, "true"},
+      {cudf_velox::CudfConfig::kCudfTopNRowNumberCandidateRunBytes, "1"}};
+
+  auto cursor = TaskCursor::create(params);
+  ASSERT_TRUE(cursor->moveNext());
+
+  const fs::path taskSpillRoot(cursor->task()->spillDirectory());
+  EXPECT_EQ(taskSpillRoot.parent_path(), fs::path(spillRoot->getPath()));
+
+  const auto activeSpillDirectories =
+      findSpillDirectories(spillRoot->getPath());
+  ASSERT_EQ(activeSpillDirectories.size(), 1);
+  EXPECT_EQ(activeSpillDirectories.front().parent_path(), taskSpillRoot);
+  EXPECT_TRUE(hasSpillDirectoryPrefix(activeSpillDirectories.front()));
+  EXPECT_EQ(findTopLevelProcessSpillDirectories(), preexistingTopLevelSpills)
+      << "CudfTopNRowNumber created a spill directory outside the Task root";
+
+  vector_size_t outputRows = cursor->current()->size();
+  while (cursor->moveNext()) {
+    outputRows += cursor->current()->size();
+  }
+  EXPECT_EQ(outputRows, kNumRows);
+  EXPECT_TRUE(findSpillDirectories(spillRoot->getPath()).empty());
+  EXPECT_EQ(findTopLevelProcessSpillDirectories(), preexistingTopLevelSpills);
+
+  auto task = cursor->task();
+  EXPECT_TRUE(usedCudfTopNRowNumber(task->taskStats()));
+
+  cursor.reset();
+  task.reset();
+  EXPECT_FALSE(fs::exists(taskSpillRoot));
+  EXPECT_TRUE(fs::is_empty(spillRoot->getPath()));
+}
+
+} // namespace

--- a/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
+++ b/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/exec/Cursor.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 
 #include <unistd.h>
 
@@ -100,6 +101,8 @@ bool usedCudfTopNRowNumber(const TaskStats& stats) {
 
 class CudfTopNRowNumberTest : public OperatorTestBase {
  protected:
+  static constexpr vector_size_t kNumRows = 32;
+
   void SetUp() override {
     OperatorTestBase::SetUp();
     previousAllowCpuFallback_ =
@@ -115,38 +118,55 @@ class CudfTopNRowNumberTest : public OperatorTestBase {
     OperatorTestBase::TearDown();
   }
 
+  core::PlanNodePtr makePlan() {
+    auto data = makeRowVector(
+        {"p", "s", "v"},
+        {makeFlatVector<int64_t>(
+             kNumRows, [](vector_size_t row) { return row; }),
+         makeFlatVector<int64_t>(
+             kNumRows, [](vector_size_t row) { return kNumRows - row; }),
+         makeFlatVector<int64_t>(
+             kNumRows, [](vector_size_t row) { return row * 10; })});
+
+    return PlanBuilder()
+        .values({data})
+        .topNRowNumber({"p"}, {"s"}, 1, true)
+        .planNode();
+  }
+
+  RowVectorPtr makeExpectedResult() {
+    return makeRowVector(
+        {"p", "s", "v", "row_number"},
+        {makeFlatVector<int64_t>(
+             kNumRows, [](vector_size_t row) { return row; }),
+         makeFlatVector<int64_t>(
+             kNumRows, [](vector_size_t row) { return kNumRows - row; }),
+         makeFlatVector<int64_t>(
+             kNumRows, [](vector_size_t row) { return row * 10; }),
+         makeFlatVector<int64_t>(
+             kNumRows, [](vector_size_t /*row*/) { return 1; })});
+  }
+
+  std::unique_ptr<TaskCursor> makeSpillingCursor(const std::string& spillRoot) {
+    CursorParameters params;
+    params.planNode = makePlan();
+    params.maxDrivers = 1;
+    params.serialExecution = true;
+    params.spillDirectory = spillRoot;
+    params.queryConfigs = {
+        {cudf_velox::CudfConfig::kCudfEnabled, "true"},
+        {cudf_velox::CudfConfig::kCudfTopNRowNumberCandidateRunBytes, "1"}};
+    return TaskCursor::create(params);
+  }
+
  private:
   bool previousAllowCpuFallback_{true};
 };
 
 TEST_F(CudfTopNRowNumberTest, spillUsesTaskRootAndCleansUp) {
-  constexpr vector_size_t kNumRows = 32;
-  auto data = makeRowVector(
-      {"p", "s", "v"},
-      {makeFlatVector<int64_t>(kNumRows, [](vector_size_t row) { return row; }),
-       makeFlatVector<int64_t>(
-           kNumRows, [](vector_size_t row) { return kNumRows - row; }),
-       makeFlatVector<int64_t>(
-           kNumRows, [](vector_size_t row) { return row * 10; })});
-
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .topNRowNumber({"p"}, {"s"}, 1, true)
-                  .planNode();
-
   const auto spillRoot = TempDirectoryPath::create();
   const auto preexistingTopLevelSpills = findTopLevelProcessSpillDirectories();
-
-  CursorParameters params;
-  params.planNode = plan;
-  params.maxDrivers = 1;
-  params.serialExecution = true;
-  params.spillDirectory = spillRoot->getPath();
-  params.queryConfigs = {
-      {cudf_velox::CudfConfig::kCudfEnabled, "true"},
-      {cudf_velox::CudfConfig::kCudfTopNRowNumberCandidateRunBytes, "1"}};
-
-  auto cursor = TaskCursor::create(params);
+  auto cursor = makeSpillingCursor(spillRoot->getPath());
   ASSERT_TRUE(cursor->moveNext());
 
   const fs::path taskSpillRoot(cursor->task()->spillDirectory());
@@ -160,18 +180,46 @@ TEST_F(CudfTopNRowNumberTest, spillUsesTaskRootAndCleansUp) {
   EXPECT_EQ(findTopLevelProcessSpillDirectories(), preexistingTopLevelSpills)
       << "CudfTopNRowNumber created a spill directory outside the Task root";
 
-  vector_size_t outputRows = cursor->current()->size();
+  std::vector<RowVectorPtr> actualResults{cursor->current()};
   while (cursor->moveNext()) {
-    outputRows += cursor->current()->size();
+    actualResults.push_back(cursor->current());
   }
-  EXPECT_EQ(outputRows, kNumRows);
+  assertEqualResults({makeExpectedResult()}, actualResults);
   EXPECT_TRUE(findSpillDirectories(spillRoot->getPath()).empty());
   EXPECT_EQ(findTopLevelProcessSpillDirectories(), preexistingTopLevelSpills);
 
   auto task = cursor->task();
   EXPECT_TRUE(usedCudfTopNRowNumber(task->taskStats()));
 
+  actualResults.clear();
   cursor.reset();
+  task.reset();
+  EXPECT_FALSE(fs::exists(taskSpillRoot));
+  EXPECT_TRUE(fs::is_empty(spillRoot->getPath()));
+}
+
+TEST_F(CudfTopNRowNumberTest, earlyCloseCleansUp) {
+  const auto spillRoot = TempDirectoryPath::create();
+  const auto preexistingTopLevelSpills = findTopLevelProcessSpillDirectories();
+  auto cursor = makeSpillingCursor(spillRoot->getPath());
+  ASSERT_TRUE(cursor->moveNext());
+
+  auto task = cursor->task();
+  const fs::path taskSpillRoot(task->spillDirectory());
+  EXPECT_EQ(taskSpillRoot.parent_path(), fs::path(spillRoot->getPath()));
+  const auto activeSpillDirectories =
+      findSpillDirectories(spillRoot->getPath());
+  ASSERT_EQ(activeSpillDirectories.size(), 1);
+  EXPECT_EQ(activeSpillDirectories.front().parent_path(), taskSpillRoot);
+  EXPECT_EQ(findTopLevelProcessSpillDirectories(), preexistingTopLevelSpills);
+
+  // SingleThreadedTaskCursor synchronously cancels the Task in its destructor.
+  // The Task closes off-thread Drivers before requestCancel().wait() returns.
+  cursor.reset();
+  EXPECT_TRUE(findSpillDirectories(spillRoot->getPath()).empty());
+  EXPECT_EQ(findTopLevelProcessSpillDirectories(), preexistingTopLevelSpills);
+  EXPECT_TRUE(usedCudfTopNRowNumber(task->taskStats()));
+
   task.reset();
   EXPECT_FALSE(fs::exists(taskSpillRoot));
   EXPECT_TRUE(fs::is_empty(spillRoot->getPath()));

--- a/velox/experimental/cudf/tests/sparksql/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/AggregationTest.cpp
@@ -72,4 +72,61 @@ TEST_F(AggregationTest, sumReal) {
   assertQuery(plan, expected);
 }
 
+TEST_F(AggregationTest, groupedCollectListOfRow) {
+  const auto makeBatch = [&](std::vector<int32_t> keys,
+                             std::vector<int64_t> ids,
+                             std::vector<std::optional<std::string>> labels,
+                             std::function<bool(vector_size_t)> isRowNull) {
+    auto rows = makeRowVector(
+        {"id", "label"},
+        {makeFlatVector<int64_t>(ids),
+         makeNullableFlatVector<std::string>(labels)},
+        std::move(isRowNull));
+    return makeRowVector(
+        {"k", "s"}, {makeFlatVector<int32_t>(keys), rows});
+  };
+
+  // Null ROW values are ignored, nested field nulls are preserved, and
+  // duplicate non-null ROW values are retained. Key 3 has only null input
+  // ROWs and must therefore produce an empty ARRAY<ROW>.
+  auto batch1 = makeBatch(
+      {1, 1, 2, 2, 3},
+      {10, -1, 20, 20, -1},
+      {"a", "ignored", "x", "x", "ignored"},
+      [](auto row) { return row == 1 || row == 4; });
+  auto batch2 = makeBatch(
+      {1, 2, 3, 3},
+      {11, 21, -1, -1},
+      {std::nullopt, "y", "ignored", "ignored"},
+      [](auto row) { return row == 2 || row == 3; });
+
+  auto expectedRows = makeRowVector(
+      {"id", "label"},
+      {makeFlatVector<int64_t>({10, 11, 20, 20, 21}),
+       makeNullableFlatVector<std::string>(
+           {"a", std::nullopt, "x", "x", "y"})});
+  auto expected = makeRowVector(
+      {"k", "items"},
+      {makeFlatVector<int32_t>({1, 2, 3}),
+       makeArrayVector({0, 2, 5, 5}, expectedRows)});
+
+  auto single = PlanBuilder()
+                    .values({batch1, batch2})
+                    .singleAggregation(
+                        {"k"}, {"collect_list(s) AS items"})
+                    .planNode();
+  assertQuery(single, expected);
+
+  // Keep two input vectors so partial aggregation consumes multiple batches.
+  // Final aggregation must merge its ARRAY<ROW> state without dropping
+  // duplicates, nested nulls, or the empty all-null group.
+  auto partialFinal = PlanBuilder()
+                          .values({batch1, batch2})
+                          .partialAggregation(
+                              {"k"}, {"collect_list(s) AS items"})
+                          .finalAggregation()
+                          .planNode();
+  assertQuery(partialFinal, expected);
+}
+
 } // namespace facebook::velox::exec::sparksql::test

--- a/velox/experimental/cudf/tests/sparksql/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/AggregationTest.cpp
@@ -82,8 +82,7 @@ TEST_F(AggregationTest, groupedCollectListOfRow) {
         {makeFlatVector<int64_t>(ids),
          makeNullableFlatVector<std::string>(labels)},
         std::move(isRowNull));
-    return makeRowVector(
-        {"k", "s"}, {makeFlatVector<int32_t>(keys), rows});
+    return makeRowVector({"k", "s"}, {makeFlatVector<int32_t>(keys), rows});
   };
 
   // Null ROW values are ignored, nested field nulls are preserved, and
@@ -112,20 +111,19 @@ TEST_F(AggregationTest, groupedCollectListOfRow) {
 
   auto single = PlanBuilder()
                     .values({batch1, batch2})
-                    .singleAggregation(
-                        {"k"}, {"collect_list(s) AS items"})
+                    .singleAggregation({"k"}, {"collect_list(s) AS items"})
                     .planNode();
   assertQuery(single, expected);
 
   // Keep two input vectors so partial aggregation consumes multiple batches.
   // Final aggregation must merge its ARRAY<ROW> state without dropping
   // duplicates, nested nulls, or the empty all-null group.
-  auto partialFinal = PlanBuilder()
-                          .values({batch1, batch2})
-                          .partialAggregation(
-                              {"k"}, {"collect_list(s) AS items"})
-                          .finalAggregation()
-                          .planNode();
+  auto partialFinal =
+      PlanBuilder()
+          .values({batch1, batch2})
+          .partialAggregation({"k"}, {"collect_list(s) AS items"})
+          .finalAggregation()
+          .planNode();
   assertQuery(partialFinal, expected);
 }
 

--- a/velox/experimental/ucx-exchange/Acceptor.cpp
+++ b/velox/experimental/ucx-exchange/Acceptor.cpp
@@ -29,124 +29,135 @@ namespace facebook::velox::ucx_exchange {
 void Acceptor::cStyleAMCallback(
     std::shared_ptr<ucxx::Request> request,
     ucp_ep_h ep) {
-  VELOX_CHECK_NOT_NULL(request, "AMCallback called with nullptr request!");
-  VELOX_CHECK(
-      request->isCompleted(), "AMCallback called with incomplete request!");
-  auto buffer =
-      std::dynamic_pointer_cast<ucxx::Buffer>(request->getRecvBuffer());
-  VELOX_CHECK_NOT_NULL(buffer, "AMCallback: failed to get receive buffer.");
-  // Validate buffer size BEFORE casting to prevent reading past buffer bounds.
-  VELOX_CHECK_GE(
-      buffer->getSize(),
-      sizeof(HandshakeMsg),
-      "AMCallback: received buffer size ({}) is smaller than HandshakeMsg ({}). "
-      "Possible protocol mismatch or truncated message.",
-      buffer->getSize(),
-      sizeof(HandshakeMsg));
-  // Copy out of UCXX-owned storage before parsing.  This also avoids relying
-  // on the alignment of the active-message receive buffer.
-  HandshakeMsg handshake{};
-  std::memcpy(&handshake, buffer->data(), sizeof(handshake));
-  const auto taskIdEnd = static_cast<const char*>(
-      std::memchr(handshake.taskId, '\0', sizeof(handshake.taskId)));
-  VELOX_CHECK_NOT_NULL(taskIdEnd, "Handshake task id is not NUL terminated");
-  VELOX_CHECK_GT(taskIdEnd, handshake.taskId, "Handshake task id is empty");
-  VELOX_CHECK_LT(
-      handshake.destination,
-      65536,
-      "Handshake destination is invalid: {}",
-      handshake.destination);
-
-  // Create a exchangeServer based on the information received in the initial
-  // handshake.
-  std::shared_ptr<Communicator> communicator = Communicator::getInstance();
-
-  auto epRef = communicator->findEndpointRefByHandle(ep);
-  VELOX_CHECK_NOT_NULL(epRef, "Could not find endpoint reference");
-  const std::string peerAddress = epRef->getPeerAddress();
-
-  const PartitionKey key = {handshake.taskId, handshake.destination};
-
-  // Determine if this is an intra-process transfer by comparing the source's
-  // workerId with our Communicator's workerId. A match means both source and
-  // server are in the same Communicator singleton (same process), so
-  // IntraNodeTransferRegistry (in-process std::promise/future) can be used.
-  //
-  // Previous approach used IP comparison (getLocalIpAddresses), which fails
-  // when multiple Docker containers share the same host IP address.
-  const bool sameWorker = handshake.workerId == communicator->getWorkerId();
-  bool isIntraNodeTransfer =
-      cudf_velox::CudfConfig::getInstance().intraNodeExchange && sameWorker;
-
-  // Disable intra-node until the task is initialized. Broadcast is safe after
-  // initialization because the intra-node source clones shared pages.
-  if (isIntraNodeTransfer) {
-    auto queueMgr = UcxOutputQueueManager::getInstanceRef();
-    const bool canUseIntraNode = queueMgr->canUseIntraNode(key.taskId);
-    VLOG(2) << "[UCX-ACCEPTOR-INTRA-CHECK] task=" << key.taskId
-            << " destination=" << key.destination << " peer=" << peerAddress
-            << " sourceWorkerId=" << handshake.workerId
-            << " localWorkerId=" << communicator->getWorkerId()
-            << " sameWorker=" << sameWorker
-            << " canUseIntraNode=" << canUseIntraNode
-            << " queue=" << queueMgr->describeQueueForIntraNode(key.taskId);
-    if (!canUseIntraNode) {
-      VLOG(2) << "[ACCEPTOR] Disabling intra-node for task " << key.taskId
-              << " (not initialized or broadcast)";
-      isIntraNodeTransfer = false;
+  try {
+    VELOX_CHECK_NOT_NULL(request, "AMCallback called with nullptr request!");
+    VELOX_CHECK(
+        request->isCompleted(), "AMCallback called with incomplete request!");
+    if (request->getStatus() != UCS_OK) {
+      return;
     }
-  } else {
-    VLOG(2) << "[UCX-ACCEPTOR-REMOTE] task=" << key.taskId
-            << " destination=" << key.destination << " peer=" << peerAddress
-            << " sourceWorkerId=" << handshake.workerId
-            << " localWorkerId=" << communicator->getWorkerId()
-            << " sameWorker=" << sameWorker << " intraNodeEnabled="
-            << cudf_velox::CudfConfig::getInstance().intraNodeExchange;
+    auto communicator = Communicator::tryGetInstance();
+    if (!communicator || communicator->isShuttingDown()) {
+      return;
+    }
+    auto buffer =
+        std::dynamic_pointer_cast<ucxx::Buffer>(request->getRecvBuffer());
+    VELOX_CHECK_NOT_NULL(buffer, "AMCallback: failed to get receive buffer.");
+    // Validate buffer size BEFORE casting to prevent reading past buffer bounds.
+    VELOX_CHECK_GE(
+        buffer->getSize(),
+        sizeof(HandshakeMsg),
+        "AMCallback: received buffer size ({}) is smaller than HandshakeMsg ({}). "
+        "Possible protocol mismatch or truncated message.",
+        buffer->getSize(),
+        sizeof(HandshakeMsg));
+    // Copy out of UCXX-owned storage before parsing.  This also avoids relying
+    // on the alignment of the active-message receive buffer.
+    HandshakeMsg handshake{};
+    std::memcpy(&handshake, buffer->data(), sizeof(handshake));
+    const auto taskIdEnd = static_cast<const char*>(
+        std::memchr(handshake.taskId, '\0', sizeof(handshake.taskId)));
+    VELOX_CHECK_NOT_NULL(taskIdEnd, "Handshake task id is not NUL terminated");
+    VELOX_CHECK_GT(taskIdEnd, handshake.taskId, "Handshake task id is empty");
+    VELOX_CHECK_LT(
+        handshake.destination,
+        65536,
+        "Handshake destination is invalid: {}",
+        handshake.destination);
+
+    // Create a exchangeServer based on the information received in the initial
+    // handshake.
+    auto epRef = communicator->findEndpointRefByHandle(ep);
+    VELOX_CHECK_NOT_NULL(epRef, "Could not find endpoint reference");
+    const std::string peerAddress = epRef->getPeerAddress();
+
+    const PartitionKey key = {handshake.taskId, handshake.destination};
+
+    // Determine if this is an intra-process transfer by comparing the source's
+    // workerId with our Communicator's workerId. A match means both source and
+    // server are in the same Communicator singleton (same process), so
+    // IntraNodeTransferRegistry (in-process std::promise/future) can be used.
+    //
+    // Previous approach used IP comparison (getLocalIpAddresses), which fails
+    // when multiple Docker containers share the same host IP address.
+    const bool sameWorker = handshake.workerId == communicator->getWorkerId();
+    bool isIntraNodeTransfer =
+        cudf_velox::CudfConfig::getInstance().intraNodeExchange && sameWorker;
+
+    // Disable intra-node until the task is initialized. Broadcast is safe after
+    // initialization because the intra-node source clones shared pages.
+    if (isIntraNodeTransfer) {
+      auto queueMgr = UcxOutputQueueManager::getInstanceRef();
+      const bool canUseIntraNode = queueMgr->canUseIntraNode(key.taskId);
+      VLOG(2) << "[UCX-ACCEPTOR-INTRA-CHECK] task=" << key.taskId
+              << " destination=" << key.destination << " peer=" << peerAddress
+              << " sourceWorkerId=" << handshake.workerId
+              << " localWorkerId=" << communicator->getWorkerId()
+              << " sameWorker=" << sameWorker
+              << " canUseIntraNode=" << canUseIntraNode
+              << " queue=" << queueMgr->describeQueueForIntraNode(key.taskId);
+      if (!canUseIntraNode) {
+        VLOG(2) << "[ACCEPTOR] Disabling intra-node for task " << key.taskId
+                << " (not initialized or broadcast)";
+        isIntraNodeTransfer = false;
+      }
+    } else {
+      VLOG(2) << "[UCX-ACCEPTOR-REMOTE] task=" << key.taskId
+              << " destination=" << key.destination << " peer=" << peerAddress
+              << " sourceWorkerId=" << handshake.workerId
+              << " localWorkerId=" << communicator->getWorkerId()
+              << " sameWorker=" << sameWorker << " intraNodeEnabled="
+              << cudf_velox::CudfConfig::getInstance().intraNodeExchange;
+    }
+
+    auto exchangeServer =
+        UcxExchangeServer::create(communicator, epRef, key, isIntraNodeTransfer);
+
+    // Add this exchangeServer to the endpoint reference.
+    epRef->addCommElem(exchangeServer);
+
+    // Register exchangeServer with communicator.
+    communicator->registerCommElement(exchangeServer);
+    VLOG(2) << "[ACCEPTOR] new server: " << exchangeServer->toString()
+            << " peer=" << peerAddress
+            << " isIntraNodeTransfer=" << isIntraNodeTransfer;
+
+    // Send HandshakeResponse back to the source to inform about intra-node
+    // transfer. This allows the source to bypass UCXX for all subsequent data
+    // transfers.
+    auto response = std::make_shared<HandshakeResponse>();
+    response->isIntraNodeTransfer = exchangeServer->isIntraNodeTransfer();
+
+    uint32_t keyHash = fnv1a_32(key.toString());
+    uint64_t responseTag = getHandshakeResponseTag(keyHash);
+
+    VLOG(3) << "Sending HandshakeResponse to " << key.toString()
+            << " peer=" << peerAddress
+            << " isIntraNodeTransfer=" << response->isIntraNodeTransfer
+            << " tag=" << std::hex << responseTag;
+
+    // Fire-and-forget: we don't need to track this request completion
+    epRef->endpoint_->tagSend(
+        response.get(),
+        sizeof(*response),
+        ucxx::Tag{responseTag},
+        false,
+        [response, keyStr = key.toString(), peerAddress](
+            ucs_status_t status, std::shared_ptr<void> arg) {
+          if (status == UCS_OK) {
+            VLOG(3) << "HandshakeResponse sent successfully to " << keyStr
+                    << " peer=" << peerAddress;
+          } else {
+            VLOG(0) << "Failed to send HandshakeResponse to " << keyStr << ": "
+                    << ucs_status_string(status) << " peer=" << peerAddress;
+          }
+        },
+        response);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Ignoring UCX active-message callback failure: " << e.what();
+  } catch (...) {
+    LOG(ERROR) << "Ignoring unknown UCX active-message callback failure";
   }
-
-  auto exchangeServer =
-      UcxExchangeServer::create(communicator, epRef, key, isIntraNodeTransfer);
-
-  // Add this exchangeServer to the endpoint reference.
-  epRef->addCommElem(exchangeServer);
-
-  // Register exchangeServer with communicator.
-  communicator->registerCommElement(exchangeServer);
-  VLOG(2) << "[ACCEPTOR] new server: " << exchangeServer->toString()
-          << " peer=" << peerAddress
-          << " isIntraNodeTransfer=" << isIntraNodeTransfer;
-
-  // Send HandshakeResponse back to the source to inform about intra-node
-  // transfer. This allows the source to bypass UCXX for all subsequent data
-  // transfers.
-  auto response = std::make_shared<HandshakeResponse>();
-  response->isIntraNodeTransfer = exchangeServer->isIntraNodeTransfer();
-
-  uint32_t keyHash = fnv1a_32(key.toString());
-  uint64_t responseTag = getHandshakeResponseTag(keyHash);
-
-  VLOG(3) << "Sending HandshakeResponse to " << key.toString()
-          << " peer=" << peerAddress
-          << " isIntraNodeTransfer=" << response->isIntraNodeTransfer
-          << " tag=" << std::hex << responseTag;
-
-  // Fire-and-forget: we don't need to track this request completion
-  epRef->endpoint_->tagSend(
-      response.get(),
-      sizeof(*response),
-      ucxx::Tag{responseTag},
-      false,
-      [response, keyStr = key.toString(), peerAddress](
-          ucs_status_t status, std::shared_ptr<void> arg) {
-        if (status == UCS_OK) {
-          VLOG(3) << "HandshakeResponse sent successfully to " << keyStr
-                  << " peer=" << peerAddress;
-        } else {
-          VLOG(0) << "Failed to send HandshakeResponse to " << keyStr << ": "
-                  << ucs_status_string(status) << " peer=" << peerAddress;
-        }
-      },
-      response);
 }
 
 // Add endpoint reference to ucp_cp -> epRef map.

--- a/velox/experimental/ucx-exchange/Acceptor.cpp
+++ b/velox/experimental/ucx-exchange/Acceptor.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <fmt/format.h>
 #include <cstring>
 
 #include "velox/experimental/cudf/CudfConfig.h"
@@ -24,6 +25,35 @@
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
 
 namespace facebook::velox::ucx_exchange {
+namespace {
+
+// Active-message callbacks run on the UCX progress thread and must not throw or
+// call closeBlocking(). Defer endpoint teardown so the peer's outstanding
+// HandshakeResponse receive completes with an error instead of waiting forever.
+void rejectHandshake(ucp_ep_h ep, const std::string& reason) noexcept {
+  LOG(ERROR) << "Rejecting UCX exchange handshake: " << reason;
+  try {
+    auto communicator = Communicator::tryGetInstance();
+    if (!communicator || communicator->isShuttingDown()) {
+      return;
+    }
+    auto epRef = communicator->findEndpointRefByHandle(ep);
+    if (!epRef) {
+      LOG(ERROR) << "Cannot close rejected UCX handshake endpoint: endpoint "
+                    "reference is unavailable";
+      return;
+    }
+    communicator->deferEndpointCleanup(std::move(epRef));
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to defer rejected UCX handshake cleanup: "
+               << e.what();
+  } catch (...) {
+    LOG(ERROR)
+        << "Failed to defer rejected UCX handshake cleanup: unknown error";
+  }
+}
+
+} // namespace
 
 /*static*/
 void Acceptor::cStyleAMCallback(
@@ -34,6 +64,11 @@ void Acceptor::cStyleAMCallback(
     VELOX_CHECK(
         request->isCompleted(), "AMCallback called with incomplete request!");
     if (request->getStatus() != UCS_OK) {
+      rejectHandshake(
+          ep,
+          fmt::format(
+              "active-message receive failed: {}",
+              ucs_status_string(request->getStatus())));
       return;
     }
     auto communicator = Communicator::tryGetInstance();
@@ -43,7 +78,8 @@ void Acceptor::cStyleAMCallback(
     auto buffer =
         std::dynamic_pointer_cast<ucxx::Buffer>(request->getRecvBuffer());
     VELOX_CHECK_NOT_NULL(buffer, "AMCallback: failed to get receive buffer.");
-    // Validate buffer size BEFORE casting to prevent reading past buffer bounds.
+    // Validate buffer size BEFORE casting to prevent reading past buffer
+    // bounds.
     VELOX_CHECK_GE(
         buffer->getSize(),
         sizeof(HandshakeMsg),
@@ -110,8 +146,8 @@ void Acceptor::cStyleAMCallback(
               << cudf_velox::CudfConfig::getInstance().intraNodeExchange;
     }
 
-    auto exchangeServer =
-        UcxExchangeServer::create(communicator, epRef, key, isIntraNodeTransfer);
+    auto exchangeServer = UcxExchangeServer::create(
+        communicator, epRef, key, isIntraNodeTransfer);
 
     // Add this exchangeServer to the endpoint reference.
     epRef->addCommElem(exchangeServer);
@@ -154,9 +190,9 @@ void Acceptor::cStyleAMCallback(
         },
         response);
   } catch (const std::exception& e) {
-    LOG(ERROR) << "Ignoring UCX active-message callback failure: " << e.what();
+    rejectHandshake(ep, e.what());
   } catch (...) {
-    LOG(ERROR) << "Ignoring unknown UCX active-message callback failure";
+    rejectHandshake(ep, "unknown active-message callback failure");
   }
 }
 

--- a/velox/experimental/ucx-exchange/CMakeLists.txt
+++ b/velox/experimental/ucx-exchange/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 set(
   UCX_EXCHANGE_SOURCES
+  RangePartitionFunction.cpp
   UcxPartitionedOutput.cpp
   UcxOutputQueueManager.cpp
   UcxQueues.cpp

--- a/velox/experimental/ucx-exchange/CommElement.h
+++ b/velox/experimental/ucx-exchange/CommElement.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <stdexcept>
+#include <memory>
 
 // The CommElement is the abstract base class of both the
 // per-client context on the exchange server side as well as the
@@ -46,7 +46,15 @@ class CommElement {
   virtual void close() = 0;
 
  protected:
-  const std::shared_ptr<Communicator> communicator_;
+  /// Locks the non-owning back-reference for one complete operation. The
+  /// Communicator owns CommElements through its registry/work queue, so a
+  /// shared_ptr here would form a cycle and can re-enter Communicator
+  /// destruction during process shutdown.
+  [[nodiscard]] std::shared_ptr<Communicator> tryCommunicator() const {
+    return communicator_.lock();
+  }
+
+  const std::weak_ptr<Communicator> communicator_;
   std::shared_ptr<EndpointRef> endpointRef_;
 };
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -36,6 +36,8 @@ namespace facebook::velox::ucx_exchange {
 
 // static
 std::once_flag Communicator::onceFlag;
+std::mutex Communicator::instanceMutex_;
+std::mutex Communicator::shutdownMutex_;
 std::shared_ptr<Communicator> Communicator::instancePtr_ = nullptr;
 
 /* static */
@@ -47,17 +49,17 @@ std::shared_ptr<Communicator> Communicator::initAndGet(
     return nullptr;
   }
   std::call_once(onceFlag, [&] {
-    instancePtr_ = std::shared_ptr<Communicator>(new Communicator());
-    instancePtr_->port_ = port;
-    instancePtr_->coordinatorURL_ = coordinatorURL;
+    auto instance = std::shared_ptr<Communicator>(new Communicator());
+    instance->port_ = port;
+    instance->coordinatorURL_ = coordinatorURL;
     // Generate a random unique worker ID for same-process detection.
     // std::random_device reads from /dev/urandom on Linux (non-blocking).
     // A 64-bit random value has negligible collision probability.
     std::random_device rd;
     std::mt19937_64 gen(rd());
     std::uniform_int_distribution<uint64_t> dist;
-    instancePtr_->workerId_ = dist(gen);
-    LOG(INFO) << "Communicator workerId=" << instancePtr_->workerId_;
+    instance->workerId_ = dist(gen);
+    LOG(INFO) << "Communicator workerId=" << instance->workerId_;
     auto logLevel = CudfConfig::getInstance().exchangeLogLevel;
     LOG(INFO) << "ucx-exchange VLOG level set to " << logLevel;
     if (logLevel > 0) {
@@ -68,40 +70,202 @@ std::shared_ptr<Communicator> Communicator::initAndGet(
       }
     }
     if (future) {
-      *future = instancePtr_->promise_.getSemiFuture();
+      *future = instance->promise_.getSemiFuture();
+    }
+    {
+      std::lock_guard<std::mutex> lock(instanceMutex_);
+      instancePtr_ = std::move(instance);
     }
   });
+  auto instance = tryGetInstance();
+  VELOX_CHECK_NOT_NULL(
+      instance,
+      "Communicator was shut down and cannot be reinitialized in this process");
   VELOX_CHECK_EQ(
-      instancePtr_->port_,
+      instance->port_,
       port,
       "Cannot initialize communicator again with different port");
-  return instancePtr_;
+  return instance;
 }
 
 /* static */
 std::shared_ptr<Communicator> Communicator::getInstance() {
+  auto instance = tryGetInstance();
   VELOX_CHECK_NOT_NULL(
-      instancePtr_, "Communicator not initialized. Call init(port) first.");
+      instance, "Communicator not initialized or already shut down.");
+  return instance;
+}
+
+/* static */
+std::shared_ptr<Communicator> Communicator::tryGetInstance() {
+  std::lock_guard<std::mutex> lock(instanceMutex_);
   return instancePtr_;
+}
+
+/* static */
+void Communicator::shutdown() {
+  std::lock_guard<std::mutex> shutdownLock(shutdownMutex_);
+  auto instance = tryGetInstance();
+  if (!instance) {
+    return;
+  }
+  if (!instance->releaseResourcesAfterRun()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(instanceMutex_);
+  if (instancePtr_ == instance) {
+    instancePtr_.reset();
+  }
 }
 
 /* static */ void Communicator::cStyleListenerCallback(
     ucp_conn_request_h conn_request,
     void* arg) {
-  // cast the argument back to our instance variable:
-  Communicator* instance = static_cast<Communicator*>(arg);
-  instance->listenerCallback(conn_request);
+  try {
+    // Cast the argument back to our instance variable. Never let an exception
+    // cross the UCX C callback boundary during terminal cancellation.
+    Communicator* instance = static_cast<Communicator*>(arg);
+    if (instance == nullptr || instance->isShuttingDown()) {
+      return;
+    }
+    instance->listenerCallback(conn_request);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Ignoring UCX listener callback during shutdown: "
+               << e.what();
+  } catch (...) {
+    LOG(ERROR) << "Ignoring unknown UCX listener callback failure during "
+                  "shutdown";
+  }
 }
 
 Communicator::~Communicator() {
+  // Normal owners call shutdown() after joining run(). Keep destruction safe
+  // during partial initialization and static finalization as a last resort.
+  (void)releaseResourcesAfterRun();
+  VLOG(3) << "Communicator destructed";
+}
+
+bool Communicator::releaseResourcesAfterRun() {
+  if (running_.load(std::memory_order_acquire)) {
+    LOG(ERROR) << "Communicator resources cannot be released before the "
+                  "progress thread is stopped and joined";
+    return false;
+  }
+  if (resourcesReleased_.load(std::memory_order_acquire)) {
+    return true;
+  }
+  shuttingDown_.store(true, std::memory_order_release);
+
+  // Stop accepting connections before releasing any element or endpoint. The
+  // worker remains alive until all UCXX-backed children have been released.
   listener_.reset();
-  // Note: worker_->flush() was removed - it only applies to RMA (Remote Memory
-  // Access) operations like ucp_put/ucp_get, which this code doesn't use.
-  // This code only uses tag send/recv and active messages.
-  worker_->progressWorkerEvent(100);
+
+  // Drop every parent-to-child reference while the singleton/local caller
+  // still keeps this Communicator alive. CommElement holds only a weak
+  // back-reference, so clearing these containers cannot re-enter this
+  // destructor.
+  std::set<std::shared_ptr<CommElement>, PtrAddressLess> elements;
+  {
+    std::lock_guard<std::mutex> lock(elemMutex_);
+    elements.swap(elements_);
+    numCommElements_.store(0, std::memory_order_relaxed);
+  }
+  for (const auto& element : elements) {
+    try {
+      element->close();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Ignoring CommElement close failure during terminal UCX "
+                    "shutdown: "
+                 << e.what();
+    } catch (...) {
+      LOG(ERROR) << "Ignoring unknown CommElement close failure during "
+                    "terminal UCX shutdown";
+    }
+  }
+
+  workQueue_.closeAndDrain();
+  deferredEndpointCleanup_.closeAndDrain();
+  elements.clear();
+
+  std::vector<std::shared_ptr<EndpointRef>> pendingEndpoints;
+  pendingEndpoints.swap(pendingEndpointRemoval_);
+  std::map<HostPort, std::shared_ptr<EndpointRef>> endpoints;
+  {
+    std::lock_guard<std::recursive_mutex> lock(endpointsMutex_);
+    endpoints.swap(endpoints_);
+  }
+  std::map<ucp_ep_h, std::shared_ptr<EndpointRef>> acceptedEndpoints;
+  acceptedEndpoints.swap(acceptor_.handleToEndpointRef_);
+
+  // Endpoint installs a close callback whose shared callback argument is its
+  // EndpointRef, while EndpointRef owns Endpoint. Explicitly close every
+  // referenced endpoint to execute and clear that callback, breaking the
+  // ownership cycle; closeBlocking() is idempotent for duplicates.
+  // Do this outside the original maps: closeBlocking() progresses UCX and can
+  // invoke callbacks, but shutdown/status gates turn them into no-ops without
+  // re-entering a container being mutated.
+  auto closeEndpoint = [&](const std::shared_ptr<EndpointRef>& endpoint) {
+    if (!endpoint) {
+      return;
+    }
+    try {
+      if (endpoint->endpoint_ && endpoint->endpoint_->isAlive()) {
+        endpoint->endpoint_->closeBlocking();
+      }
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Ignoring endpoint close failure during terminal UCX "
+                    "shutdown: "
+                 << e.what();
+    } catch (...) {
+      LOG(ERROR) << "Ignoring unknown endpoint close failure during terminal "
+                    "UCX shutdown";
+    }
+  };
+  for (const auto& endpoint : pendingEndpoints) {
+    closeEndpoint(endpoint);
+  }
+  for (const auto& [_, endpoint] : endpoints) {
+    closeEndpoint(endpoint);
+  }
+  for (const auto& [_, endpoint] : acceptedEndpoints) {
+    closeEndpoint(endpoint);
+  }
+  pendingEndpoints.clear();
+  endpoints.clear();
+  acceptedEndpoints.clear();
+
+  if (worker_) {
+    // close() above canceled element-owned requests. Cancel any additional
+    // worker-owned AM/tag requests, then progress their callbacks while all
+    // callback payloads in deferredRequests_ are still alive.
+    try {
+      worker_->cancelInflightRequests(3'000'000'000, 3);
+      for (int attempt = 0; attempt < 3; ++attempt) {
+        worker_->progress();
+      }
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Ignoring worker cancellation failure during terminal "
+                    "UCX shutdown: "
+                 << e.what();
+    } catch (...) {
+      LOG(ERROR) << "Ignoring unknown worker cancellation failure during "
+                    "terminal UCX shutdown";
+    }
+  }
+  const auto incompleteRequests = std::count_if(
+      deferredRequests_.begin(),
+      deferredRequests_.end(),
+      [](const auto& request) { return !request->isCompleted(); });
+  if (incompleteRequests > 0) {
+    LOG(WARNING) << "UCX terminal shutdown retained " << incompleteRequests
+                 << " incomplete request(s) until worker destruction";
+  }
+  deferredRequests_.clear();
+
   worker_.reset();
   context_.reset();
-  VLOG(3) << "Communicator destructed";
+  resourcesReleased_.store(true, std::memory_order_release);
+  return true;
 }
 
 /// @brief Run doesn't return until stop() is called.
@@ -276,6 +440,7 @@ void Communicator::run() {
 
 /// @brief Stops the communicator, called from an outside thread.
 void Communicator::stop() {
+  shuttingDown_.store(true, std::memory_order_release);
   running_.store(false);
   signalWorker();
   // Only log fields that are safe to read from an outside thread.
@@ -287,7 +452,13 @@ void Communicator::stop() {
 }
 
 void Communicator::registerCommElement(std::shared_ptr<CommElement> comms) {
+  if (shuttingDown_.load(std::memory_order_acquire)) {
+    return;
+  }
   std::lock_guard<std::mutex> lock(elemMutex_);
+  if (shuttingDown_.load(std::memory_order_acquire)) {
+    return;
+  }
   auto ret = elements_.insert(comms);
   VELOX_CHECK(ret.second, "CommElement already registered!");
   numCommElements_.fetch_add(1, std::memory_order_relaxed);
@@ -303,7 +474,7 @@ void Communicator::signalWorker() {
 }
 
 void Communicator::addToWorkQueue(std::shared_ptr<CommElement> comms) {
-  if (!comms) {
+  if (!comms || shuttingDown_.load(std::memory_order_acquire)) {
     return;
   }
   workQueue_.push(comms);
@@ -326,6 +497,9 @@ void Communicator::unregister(std::shared_ptr<CommElement> comms) {
 std::shared_ptr<EndpointRef> Communicator::assocEndpointRef(
     std::shared_ptr<CommElement> comms,
     HostPort hostPort) {
+  if (shuttingDown_.load(std::memory_order_acquire)) {
+    return nullptr;
+  }
   std::lock_guard<std::recursive_mutex> lock(endpointsMutex_);
   auto it = endpoints_.find(hostPort);
   if (it != endpoints_.end()) {
@@ -354,7 +528,7 @@ std::shared_ptr<EndpointRef> Communicator::assocEndpointRef(
 void Communicator::removeEndpointRef(std::shared_ptr<EndpointRef> ep) {
   std::lock_guard<std::recursive_mutex> lock(endpointsMutex_);
   VLOG(2) << "[UCX-COMM-REMOVE-ENDPOINT] listenerPort="
-          << Communicator::getInstance()->port_
+          << port_
           << " peer=" << (ep ? ep->getPeerAddress() : "(unknown)")
           << " endpointAlive="
           << (ep && ep->endpoint_ && ep->endpoint_->isAlive());
@@ -385,12 +559,18 @@ void Communicator::deferEndpointCleanup(std::shared_ptr<EndpointRef> ep) {
   VLOG(2) << "[UCX-COMM-DEFER-ENDPOINT-CLEANUP] peer="
           << (ep ? ep->getPeerAddress() : "(unknown)") << " endpointAlive="
           << (ep && ep->endpoint_ && ep->endpoint_->isAlive());
+  if (shuttingDown_.load(std::memory_order_acquire)) {
+    return;
+  }
   deferredEndpointCleanup_.push(ep);
   signalWorker();
 }
 
 void Communicator::deferRequestCleanup(std::shared_ptr<ucxx::Request> request) {
-  if (request) {
+  // Terminal element close() also deposits canceled requests here after the
+  // progress thread has joined. Keep their callback payloads alive until the
+  // finalizer has progressed worker cancellation.
+  if (request && worker_) {
     deferredRequests_.push_back(std::move(request));
   }
 }
@@ -424,6 +604,9 @@ uint16_t Communicator::getListenerPort() const {
 
 /// @brief The callback method that is invoked when a client connects.
 void Communicator::listenerCallback(ucp_conn_request_h conn_request) {
+  if (shuttingDown_.load(std::memory_order_acquire)) {
+    return;
+  }
   char ip_str[INET6_ADDRSTRLEN];
   char port_str[INET6_ADDRSTRLEN];
   ucp_conn_request_attr_t attr{};

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -529,8 +529,7 @@ std::shared_ptr<EndpointRef> Communicator::assocEndpointRef(
 
 void Communicator::removeEndpointRef(std::shared_ptr<EndpointRef> ep) {
   std::lock_guard<std::recursive_mutex> lock(endpointsMutex_);
-  VLOG(2) << "[UCX-COMM-REMOVE-ENDPOINT] listenerPort="
-          << port_
+  VLOG(2) << "[UCX-COMM-REMOVE-ENDPOINT] listenerPort=" << port_
           << " peer=" << (ep ? ep->getPeerAddress() : "(unknown)")
           << " endpointAlive="
           << (ep && ep->endpoint_ && ep->endpoint_->isAlive());
@@ -547,6 +546,14 @@ void Communicator::removeEndpointRef(std::shared_ptr<EndpointRef> ep) {
   for (auto it = endpoints_.begin(); it != endpoints_.end();) {
     if (it->second == ep) {
       it = endpoints_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  for (auto it = acceptor_.handleToEndpointRef_.begin();
+       it != acceptor_.handleToEndpointRef_.end();) {
+    if (it->second == ep) {
+      it = acceptor_.handleToEndpointRef_.erase(it);
     } else {
       ++it;
     }

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -32,6 +32,8 @@
 
 using namespace facebook::velox::cudf_velox;
 
+DEFINE_bool(velox_ucx_exchange, false, "Enable Velox UCX exchange.");
+
 namespace facebook::velox::ucx_exchange {
 
 // static

--- a/velox/experimental/ucx-exchange/Communicator.h
+++ b/velox/experimental/ucx-exchange/Communicator.h
@@ -69,6 +69,15 @@ class Communicator {
   /// @brief Method to get the Communicator reference
   static std::shared_ptr<Communicator> getInstance();
 
+  /// Returns the singleton if it is still live. Callback teardown paths use
+  /// this instead of throwing after shutdown has begun.
+  static std::shared_ptr<Communicator> tryGetInstance();
+
+  /// Releases the singleton after run() has returned and its owner has joined
+  /// the progress thread. This operation is idempotent and cannot be followed
+  /// by reinitialization in the same process.
+  static void shutdown();
+
   /// @brief Destructor.
   ~Communicator();
 
@@ -145,6 +154,10 @@ class Communicator {
     return workerId_;
   }
 
+  bool isShuttingDown() const {
+    return shuttingDown_.load(std::memory_order_acquire);
+  }
+
   /// Returns true when the active UCX context can transfer CUDA memory with
   /// the configured transports. UCXX derives this from both the UCP-supported
   /// memory types and UCX_TLS, so callers can safely choose a device receive
@@ -176,14 +189,21 @@ class Communicator {
       void* arg);
 
   static std::once_flag onceFlag; // Flag for thread-safe initialization
+  static std::mutex instanceMutex_;
+  static std::mutex shutdownMutex_;
   static std::shared_ptr<Communicator> instancePtr_;
+
+  // Called by shutdown() only after the progress thread has returned.
+  bool releaseResourcesAfterRun();
 
   std::shared_ptr<ucxx::Context> context_;
   std::shared_ptr<ucxx::Worker> worker_;
   std::shared_ptr<ucxx::Listener> listener_;
   uint16_t port_;
   std::string coordinatorURL_;
-  std::atomic<bool> running_;
+  std::atomic<bool> running_{false};
+  std::atomic<bool> shuttingDown_{false};
+  std::atomic<bool> resourcesReleased_{false};
   Acceptor acceptor_;
   ContinuePromise promise_{"Communicator::run"};
 

--- a/velox/experimental/ucx-exchange/EndpointRef.cpp
+++ b/velox/experimental/ucx-exchange/EndpointRef.cpp
@@ -44,8 +44,9 @@ void EndpointRef::onClose(ucs_status_t status, std::shared_ptr<void> arg) {
   // The main loop will:
   //   1. Close all communicators registered with this endpoint
   //   2. Clean up the endpoint itself (closeBlocking, etc.)
-  auto c = Communicator::getInstance();
-  c->deferEndpointCleanup(ep);
+  if (auto c = Communicator::tryGetInstance()) {
+    c->deferEndpointCleanup(ep);
+  }
 }
 
 bool EndpointRef::addCommElem(std::shared_ptr<CommElement> commElem) {

--- a/velox/experimental/ucx-exchange/EndpointRef.cpp
+++ b/velox/experimental/ucx-exchange/EndpointRef.cpp
@@ -99,7 +99,11 @@ void EndpointRef::closeAndDrainCommunicators() {
   }
   for (auto& weakElem : localCopy) {
     if (std::shared_ptr<CommElement> spt = weakElem.lock()) {
-      if (dynamic_cast<UcxExchangeServer*>(spt.get()) == nullptr) {
+      if (auto* source = dynamic_cast<UcxExchangeSource*>(spt.get())) {
+        source->closeWithError(
+            "UCX endpoint closed before exchange completed: peer=" +
+            getPeerAddress());
+      } else if (dynamic_cast<UcxExchangeServer*>(spt.get()) == nullptr) {
         spt->close();
       }
     }

--- a/velox/experimental/ucx-exchange/RangePartitionFunction.cpp
+++ b/velox/experimental/ucx-exchange/RangePartitionFunction.cpp
@@ -22,9 +22,8 @@ namespace {
 
 class UcxOnlyRangePartitionFunction final : public core::PartitionFunction {
  public:
-  std::optional<uint32_t> partition(
-      const RowVector&,
-      std::vector<uint32_t>&) override {
+  std::optional<uint32_t> partition(const RowVector&, std::vector<uint32_t>&)
+      override {
     VELOX_FAIL(
         "RANGE_PID is supported only by UcxPartitionedOutput; refusing to "
         "silently substitute hash or round-robin partitioning");

--- a/velox/experimental/ucx-exchange/RangePartitionFunction.cpp
+++ b/velox/experimental/ucx-exchange/RangePartitionFunction.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/ucx-exchange/RangePartitionFunction.h"
+
+#include <sstream>
+
+namespace facebook::velox::ucx_exchange {
+namespace {
+
+class UcxOnlyRangePartitionFunction final : public core::PartitionFunction {
+ public:
+  std::optional<uint32_t> partition(
+      const RowVector&,
+      std::vector<uint32_t>&) override {
+    VELOX_FAIL(
+        "RANGE_PID is supported only by UcxPartitionedOutput; refusing to "
+        "silently substitute hash or round-robin partitioning");
+  }
+};
+
+} // namespace
+
+std::unique_ptr<core::PartitionFunction> RangePartitionFunctionSpec::create(
+    int,
+    bool) const {
+  return std::make_unique<UcxOnlyRangePartitionFunction>();
+}
+
+std::string RangePartitionFunctionSpec::toString() const {
+  std::ostringstream keys;
+  for (size_t i = 0; i < keyChannels_.size(); ++i) {
+    if (i > 0) {
+      keys << ", ";
+    }
+    keys << inputType_->nameOf(keyChannels_[i]);
+  }
+  return fmt::format("RANGE_PID({})", keys.str());
+}
+
+folly::dynamic RangePartitionFunctionSpec::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "RangePartitionFunctionSpec";
+  obj["inputType"] = inputType_->serialize();
+  obj["keyChannels"] = ISerializable::serialize(keyChannels_);
+  obj["boundsJson"] = boundsJson_;
+  return obj;
+}
+
+core::PartitionFunctionSpecPtr RangePartitionFunctionSpec::deserialize(
+    const folly::dynamic& obj,
+    void* context) {
+  return std::make_shared<RangePartitionFunctionSpec>(
+      ISerializable::deserialize<RowType>(obj["inputType"]),
+      ISerializable::deserialize<std::vector<column_index_t>>(
+          obj["keyChannels"], context),
+      obj["boundsJson"].asString());
+}
+
+} // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/RangePartitionFunction.h
+++ b/velox/experimental/ucx-exchange/RangePartitionFunction.h
@@ -38,7 +38,8 @@ class RangePartitionFunctionSpec final : public core::PartitionFunctionSpec {
         keyChannels_(std::move(keyChannels)),
         boundsJson_(std::move(boundsJson)) {
     VELOX_CHECK(!keyChannels_.empty(), "RANGE_PID requires sort-key channels");
-    VELOX_CHECK(!boundsJson_.empty(), "RANGE_PID requires serialized boundaries");
+    VELOX_CHECK(
+        !boundsJson_.empty(), "RANGE_PID requires serialized boundaries");
   }
 
   std::unique_ptr<core::PartitionFunction> create(

--- a/velox/experimental/ucx-exchange/RangePartitionFunction.h
+++ b/velox/experimental/ucx-exchange/RangePartitionFunction.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::ucx_exchange {
+
+/**
+ * An explicit range-partition contract for UCX output.
+ *
+ * The JSON payload contains Spark RangePartitioner boundaries plus ascending
+ * and null-order flags. UcxPartitionedOutput evaluates those boundaries into
+ * an INT32 partition-id column before routing. The ordinary Velox CPU
+ * PartitionedOutput path is intentionally unsupported: using it would make a
+ * RANGE exchange silently change semantics when the GPU adapter is absent.
+ */
+class RangePartitionFunctionSpec final : public core::PartitionFunctionSpec {
+ public:
+  RangePartitionFunctionSpec(
+      RowTypePtr inputType,
+      std::vector<column_index_t> keyChannels,
+      std::string boundsJson)
+      : inputType_(std::move(inputType)),
+        keyChannels_(std::move(keyChannels)),
+        boundsJson_(std::move(boundsJson)) {
+    VELOX_CHECK(!keyChannels_.empty(), "RANGE_PID requires sort-key channels");
+    VELOX_CHECK(!boundsJson_.empty(), "RANGE_PID requires serialized boundaries");
+  }
+
+  std::unique_ptr<core::PartitionFunction> create(
+      int numPartitions,
+      bool localExchange) const override;
+
+  std::string toString() const override;
+
+  folly::dynamic serialize() const override;
+
+  static core::PartitionFunctionSpecPtr deserialize(
+      const folly::dynamic& obj,
+      void* context);
+
+  const RowTypePtr& inputType() const {
+    return inputType_;
+  }
+
+  const std::vector<column_index_t>& keyChannels() const {
+    return keyChannels_;
+  }
+
+  const std::string& boundsJson() const {
+    return boundsJson_;
+  }
+
+ private:
+  const RowTypePtr inputType_;
+  const std::vector<column_index_t> keyChannels_;
+  const std::string boundsJson_;
+};
+
+} // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -256,7 +256,7 @@ void UcxExchangeServer::process() {
   switch (state_) {
     case ServerState::Created:
       setState(ServerState::ReadyToTransfer);
-      communicator_->addToWorkQueue(getSelfPtr());
+      wakeCommunicator();
       break;
     case ServerState::ReadyToTransfer:
       // Count-only / rendezvous push (Presto-style): no consumer credit
@@ -264,7 +264,7 @@ void UcxExchangeServer::process() {
       // rendezvous until the source posts its matching tagRecv
       // (getMetadata/getData), which is the sole flow-control mechanism.
       setState(ServerState::DataRequestReady);
-      communicator_->addToWorkQueue(getSelfPtr());
+      wakeCommunicator();
       break;
     case ServerState::DataRequestReady:
       setState(ServerState::WaitingForDataFromQueue);
@@ -311,10 +311,10 @@ void UcxExchangeServer::process() {
                   "Data pointer exists: Illegal state!");
               self->dataPtr_ = std::move(data);
               self->setState(ServerState::DataReady);
-              self->communicator_->addToWorkQueue(self);
+              self->wakeCommunicator();
             });
       }
-      this->communicator_->addToWorkQueue(getSelfPtr());
+      wakeCommunicator();
       break;
     case ServerState::WaitingForDataFromQueue:
       // Waiting for data is handled by an upcall from the data queue. Nothing
@@ -350,7 +350,7 @@ void UcxExchangeServer::process() {
                     << "] still waiting for source retrieval, polls="
                     << intraNodePollCount_;
           }
-          communicator_->addToWorkQueue(getSelfPtr());
+          wakeCommunicator();
         }
       }
       break;
@@ -397,20 +397,23 @@ void UcxExchangeServer::close() {
   // Move all requests to the Communicator's deferred list so the GPU
   // buffers they reference (via their arg shared_ptr) stay alive until
   // UCX has fully processed any in-flight operations.
-  if (communicator_) {
+  auto communicator = communicator_.lock();
+  if (communicator) {
     if (metaRequest_) {
-      communicator_->deferRequestCleanup(std::move(metaRequest_));
+      communicator->deferRequestCleanup(std::move(metaRequest_));
     }
     if (dataRequest_) {
-      communicator_->deferRequestCleanup(std::move(dataRequest_));
+      communicator->deferRequestCleanup(std::move(dataRequest_));
     }
     for (auto& req : completedRequests_) {
-      communicator_->deferRequestCleanup(std::move(req));
+      communicator->deferRequestCleanup(std::move(req));
     }
     completedRequests_.clear();
   }
 
-  communicator_->unregister(getSelfPtr());
+  if (communicator) {
+    communicator->unregister(getSelfPtr());
+  }
 }
 
 std::string UcxExchangeServer::toString() {
@@ -426,7 +429,17 @@ std::shared_ptr<UcxExchangeServer> UcxExchangeServer::getSelfPtr() {
   return shared_from_this();
 }
 
+void UcxExchangeServer::wakeCommunicator() {
+  if (auto communicator = tryCommunicator()) {
+    communicator->addToWorkQueue(getSelfPtr());
+  }
+}
+
 void UcxExchangeServer::sendData() {
+  auto communicator = tryCommunicator();
+  if (!communicator) {
+    return;
+  }
   std::lock_guard<std::recursive_mutex> lock(dataMutex_);
 
   VLOG(2) << (isIntraNodeTransfer_ ? "[INTRA]" : "[REMOTE]") << " [ExSrv "
@@ -468,7 +481,7 @@ void UcxExchangeServer::sendData() {
       // re-enqueues this server.
       setState(ServerState::WaitingForIntraNodeRetrieve);
       if (intraNodeProducerPollRequeueEnabled()) {
-        communicator_->addToWorkQueue(getSelfPtr());
+        wakeCommunicator();
       }
     } else {
       // Data pointer is null, so no more data will be coming.
@@ -494,12 +507,12 @@ void UcxExchangeServer::sendData() {
       // wakeup re-enqueues this server when that happens.
       setState(ServerState::WaitingForIntraNodeRetrieve);
       if (intraNodeProducerPollRequeueEnabled()) {
-        communicator_->addToWorkQueue(getSelfPtr());
+        wakeCommunicator();
       }
     }
   } else {
     // REMOTE EXCHANGE PATH: Use UCXX for metadata and data transfer
-    const bool useHostStaging = !communicator_->hasCudaTransport();
+    const bool useHostStaging = !communicator->hasCudaTransport();
     std::shared_ptr<DataSendContext> dataCtx;
     if (dataPtr_) {
       const auto hostBytes = static_cast<int64_t>(dataPtr_->gpu_data->size());
@@ -508,7 +521,7 @@ void UcxExchangeServer::sendData() {
         // Keep dataPtr_ and state=DataReady.  Completed UCX callbacks release
         // process-wide credit; requeueing lets this server retry without
         // dequeuing or staging another packed table.
-        communicator_->addToWorkQueue(getSelfPtr());
+        wakeCommunicator();
         return;
       }
     }
@@ -581,7 +594,7 @@ void UcxExchangeServer::sendData() {
                     << metadataTag << std::dec
                     << " status=" << ucs_status_string(status);
             self->setState(ServerState::Done);
-            self->communicator_->addToWorkQueue(self);
+            self->wakeCommunicator();
           }
         },
         metaCtx);
@@ -668,7 +681,7 @@ void UcxExchangeServer::sendData() {
               << partitionKey_.toString();
       queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
       setState(ServerState::Done);
-      communicator_->addToWorkQueue(getSelfPtr());
+      wakeCommunicator();
     }
   }
 }
@@ -712,14 +725,18 @@ void UcxExchangeServer::sendComplete(
             << " bytes=" << bytes_ << " status=" << ucs_status_string(status);
     setState(ServerState::Done);
   }
-  communicator_->addToWorkQueue(getSelfPtr());
+  wakeCommunicator();
 }
 
 std::function<void()> UcxExchangeServer::makeIntraNodeRetrieveWakeup() {
   std::weak_ptr<CommElement> weakSelf = getSelfPtr();
-  auto communicator = communicator_;
-  return [weakSelf, communicator]() {
-    if (auto server = weakSelf.lock()) {
+  auto weakCommunicator = communicator_;
+  return [weakSelf, weakCommunicator]() {
+    if (auto server = weakSelf.lock(); server) {
+      auto communicator = weakCommunicator.lock();
+      if (!communicator) {
+        return;
+      }
       communicator->addToWorkQueue(server);
     }
   };
@@ -759,7 +776,7 @@ void UcxExchangeServer::onIntraNodeRetrieveComplete() {
     this->sequenceNumber_++;
     setState(ServerState::ReadyToTransfer);
   }
-  communicator_->addToWorkQueue(getSelfPtr());
+  wakeCommunicator();
 }
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.h
@@ -88,6 +88,10 @@ class UcxExchangeServer
   /// @return A shared pointer to itself.
   std::shared_ptr<UcxExchangeServer> getSelfPtr();
 
+  /// Re-enqueues this server if the Communicator is still accepting work.
+  /// Safe for UCXX and registry callbacks during shutdown.
+  void wakeCommunicator();
+
   /// @brief Sends metadata and data to the connected receiver.
   void sendData();
 

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -419,6 +419,14 @@ void UcxExchangeSource::close() {
   wakeCommunicator();
 }
 
+void UcxExchangeSource::closeWithError(std::string error) {
+  if (!closed_.load(std::memory_order_acquire) &&
+      getState() != ReceiverState::Done && !atEnd_) {
+    queue_->setError(std::move(error));
+  }
+  close();
+}
+
 void UcxExchangeSource::resumeFromBackpressure() {
   bool expected = true;
   if (backpressureActive_.compare_exchange_strong(

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -250,6 +250,11 @@ std::shared_ptr<UcxExchangeSource> UcxExchangeSource::create(
 }
 
 void UcxExchangeSource::process() {
+  auto communicator = tryCommunicator();
+  if (!communicator) {
+    deliverEndMarker();
+    return;
+  }
   if (closed_) {
     // Driver thread called closed
     cleanUp();
@@ -261,7 +266,7 @@ void UcxExchangeSource::process() {
       // Get the endpoint.
       HostPort hp{host_, port_};
       std::shared_ptr<UcxExchangeSource> selfPtr = getSelfPtr();
-      auto epRef = communicator_->assocEndpointRef(selfPtr, hp);
+      auto epRef = communicator->assocEndpointRef(selfPtr, hp);
       if (epRef) {
         setEndpoint(epRef);
         setStateIf(
@@ -274,7 +279,7 @@ void UcxExchangeSource::process() {
         deliverEndMarker();
         setState(ReceiverState::Done);
       }
-      communicator_->addToWorkQueue(getSelfPtr());
+      wakeCommunicator();
     } break;
     case ReceiverState::WaitingForHandshakeComplete:
       // Waiting for handshake send completion is handled by callback.
@@ -368,12 +373,13 @@ void UcxExchangeSource::cleanUp() {
   // Move all requests to the Communicator's deferred list so the GPU
   // buffers they reference (via their arg shared_ptr) stay alive until
   // UCX has fully processed any in-flight operations.
-  if (communicator_) {
+  auto communicator = communicator_.lock();
+  if (communicator) {
     if (request_) {
-      communicator_->deferRequestCleanup(std::move(request_));
+      communicator->deferRequestCleanup(std::move(request_));
     }
     for (auto& req : completedRequests_) {
-      communicator_->deferRequestCleanup(std::move(req));
+      communicator->deferRequestCleanup(std::move(req));
     }
     completedRequests_.clear();
   }
@@ -382,8 +388,8 @@ void UcxExchangeSource::cleanUp() {
     endpointRef_->removeCommElem(getSelfPtr());
     endpointRef_ = nullptr;
   }
-  if (communicator_) {
-    communicator_->unregister(getSelfPtr());
+  if (communicator) {
+    communicator->unregister(getSelfPtr());
   }
 }
 
@@ -410,7 +416,7 @@ void UcxExchangeSource::close() {
 
   // Let the Communicator progress thread do the actual clean-up.
   setState(ReceiverState::Done);
-  communicator_->addToWorkQueue(getSelfPtr());
+  wakeCommunicator();
 }
 
 void UcxExchangeSource::resumeFromBackpressure() {
@@ -419,7 +425,7 @@ void UcxExchangeSource::resumeFromBackpressure() {
           expected, false, std::memory_order_acq_rel)) {
     VLOG(1) << "[BACKPRESSURE] [ExSrc " << toString()
             << "] resumed by consumer, queueSize=" << queue_->size();
-    communicator_->addToWorkQueue(getSelfPtr());
+    wakeCommunicator();
   }
 }
 
@@ -470,6 +476,12 @@ std::shared_ptr<UcxExchangeSource> UcxExchangeSource::getSelfPtr() {
   return ptr;
 }
 
+void UcxExchangeSource::wakeCommunicator() {
+  if (auto communicator = tryCommunicator()) {
+    communicator->addToWorkQueue(getSelfPtr());
+  }
+}
+
 void UcxExchangeSource::enqueue(
     PackedTableWithStreamPtr data,
     int64_t reservedReceiveBytes) {
@@ -517,6 +529,11 @@ void UcxExchangeSource::setEndpoint(std::shared_ptr<EndpointRef> endpointRef) {
 }
 
 void UcxExchangeSource::sendHandshake() {
+  auto communicator = tryCommunicator();
+  if (!communicator) {
+    deliverEndMarker();
+    return;
+  }
   handshakeRequestBuffer_ = std::make_shared<HandshakeMsg>();
   auto& handshakeReq = handshakeRequestBuffer_;
   handshakeReq->destination = partitionKey_.destination;
@@ -527,7 +544,7 @@ void UcxExchangeSource::sendHandshake() {
       partitionKey_.taskId.c_str(),
       sizeof(handshakeReq->taskId) - 1);
   handshakeReq->taskId[sizeof(handshakeReq->taskId) - 1] = '\0';
-  handshakeReq->workerId = communicator_->getWorkerId();
+  handshakeReq->workerId = communicator->getWorkerId();
 
   VLOG(2) << "[UCX-SOURCE-HANDSHAKE-SEND] localTask=" << taskId_
           << " remoteTask=" << partitionKey_.taskId
@@ -536,7 +553,7 @@ void UcxExchangeSource::sendHandshake() {
 
   // Create the handshake which will register client's existence with the server
   ucxx::AmReceiverCallbackInfo info(
-      communicator_->kAmCallbackOwner, communicator_->kAmCallbackId);
+      communicator->kAmCallbackOwner, communicator->kAmCallbackId);
   // Use weak_ptr to prevent use-after-free if close() is called during callback
   std::weak_ptr<UcxExchangeSource> weak = weak_from_this();
   retireRequest(request_, completedRequests_);
@@ -588,7 +605,7 @@ void UcxExchangeSource::onHandshake(
     queue_->setError(errorMsg);
     deliverEndMarker();
     setState(ReceiverState::Done);
-    communicator_->addToWorkQueue(getSelfPtr());
+    wakeCommunicator();
   } else {
     VLOG(3) << toString() << "+ onHandshake " << ucs_status_string(status)
             << " peer=" << host_ << ":" << port_;
@@ -664,7 +681,7 @@ void UcxExchangeSource::onMetadata(
     queue_->setError(errorMsg);
     deliverEndMarker();
     setState(ReceiverState::Done);
-    communicator_->addToWorkQueue(getSelfPtr());
+    wakeCommunicator();
   } else {
     VELOX_CHECK_NOT_NULL(arg, "Didn't get metadata");
 
@@ -687,7 +704,7 @@ void UcxExchangeSource::onMetadata(
       VLOG(3) << "There is no more data to transfer for " << toString();
       deliverEndMarker();
       setStateIf(ReceiverState::WaitingForMetadata, ReceiverState::Done);
-      communicator_->addToWorkQueue(getSelfPtr());
+      wakeCommunicator();
       // jump out of this function.
       return;
     }
@@ -701,6 +718,10 @@ bool UcxExchangeSource::tryStartDataReceive(
     const std::shared_ptr<DataAndMetadata>& ptr,
     ReceiverState expectedState) {
   if (ptr == nullptr) {
+    return false;
+  }
+  auto communicator = tryCommunicator();
+  if (!communicator) {
     return false;
   }
 
@@ -722,7 +743,7 @@ bool UcxExchangeSource::tryStartDataReceive(
   }
   reservedReceiveBytes_ = ptr->metadata.dataSizeBytes;
 
-  const bool useHostStaging = !communicator_->hasCudaTransport();
+  const bool useHostStaging = !communicator->hasCudaTransport();
   if (useHostStaging && !tryReserveRecvHostBytes(ptr->metadata.dataSizeBytes)) {
     queue_->releaseReservedReceive(reservedReceiveBytes_);
     reservedReceiveBytes_ = 0;
@@ -732,7 +753,7 @@ bool UcxExchangeSource::tryStartDataReceive(
     // Global credit is shared across otherwise unrelated ExchangeQueues, so
     // a dequeue from this queue cannot wake us. Retry from the communicator
     // work loop; completed receives release the process-wide credit below.
-    communicator_->addToWorkQueue(getSelfPtr());
+    wakeCommunicator();
     return false;
   }
   if (useHostStaging) {
@@ -746,7 +767,7 @@ bool UcxExchangeSource::tryStartDataReceive(
     }
     // A different ExchangeQueue may release the process-wide credit. Retry
     // from the communicator loop instead of waiting on this queue's promise.
-    communicator_->addToWorkQueue(getSelfPtr());
+    wakeCommunicator();
     return false;
   }
 
@@ -814,7 +835,7 @@ bool UcxExchangeSource::tryStartDataReceive(
     queue_->setError("Failed to alloc GPU memory");
     deliverEndMarker();
     setState(ReceiverState::Done);
-    communicator_->addToWorkQueue(getSelfPtr());
+    wakeCommunicator();
     return false;
   }
 
@@ -945,7 +966,7 @@ void UcxExchangeSource::onData(ucs_status_t status, std::shared_ptr<void> arg) {
     reservedReceiveBytes_ = 0;
     setStateIf(ReceiverState::WaitingForData, ReceiverState::ReadyToReceive);
   }
-  communicator_->addToWorkQueue(getSelfPtr());
+  wakeCommunicator();
 }
 
 void UcxExchangeSource::receiveHandshakeResponse() {
@@ -1004,7 +1025,7 @@ void UcxExchangeSource::onHandshakeResponse(
     queue_->setError(errorMsg);
     deliverEndMarker();
     setState(ReceiverState::Done);
-    communicator_->addToWorkQueue(getSelfPtr());
+    wakeCommunicator();
     return;
   }
 
@@ -1021,7 +1042,7 @@ void UcxExchangeSource::onHandshakeResponse(
   setStateIf(
       ReceiverState::WaitingForHandshakeResponse,
       ReceiverState::ReadyToReceive);
-  communicator_->addToWorkQueue(getSelfPtr());
+  wakeCommunicator();
 }
 
 void UcxExchangeSource::waitForIntraNodeData() {
@@ -1044,22 +1065,27 @@ void UcxExchangeSource::waitForIntraNodeData() {
     // needs that same thread), livelocking the intra-node transfer. Instead
     // register a one-shot wakeup and go dormant; publish()/cancelTask()
     // re-enqueues this source exactly once when data is available. The weak_ptr
-    // keeps the wakeup safe if the source is destroyed first; the Communicator
-    // outlives its sources, so capturing it by shared_ptr is safe.
+    // keeps the wakeup safe if the source is destroyed first. Capture the
+    // Communicator weakly as well so a dormant waiter cannot extend the
+    // singleton lifetime during executor shutdown.
     auto self = getSelfPtr();
     std::weak_ptr<CommElement> weakSelf = self;
-    auto communicator = communicator_;
+    auto weakCommunicator = communicator_;
     const bool readyNow =
         IntraNodeTransferRegistry::getInstance()->registerWaiter(
-            key, [weakSelf, communicator]() {
-              if (auto source = weakSelf.lock()) {
+            key, [weakSelf, weakCommunicator]() {
+              if (auto source = weakSelf.lock(); source) {
+                auto communicator = weakCommunicator.lock();
+                if (!communicator) {
+                  return;
+                }
                 communicator->addToWorkQueue(source);
               }
             });
     if (readyNow) {
       // Data landed (or the task was cancelled) between poll and register —
       // re-poll once instead of going dormant.
-      communicator_->addToWorkQueue(self);
+      wakeCommunicator();
     }
     return;
   }
@@ -1086,7 +1112,7 @@ void UcxExchangeSource::onIntraNodeData(
     deliverEndMarker();
     setState(ReceiverState::Done);
 
-    communicator_->addToWorkQueue(getSelfPtr());
+    wakeCommunicator();
     return;
   }
 
@@ -1101,7 +1127,7 @@ void UcxExchangeSource::onIntraNodeData(
     queue_->setError(errorMsg);
     deliverEndMarker();
     setState(ReceiverState::Done);
-    communicator_->addToWorkQueue(getSelfPtr());
+    wakeCommunicator();
     return;
   }
 
@@ -1147,7 +1173,7 @@ void UcxExchangeSource::onIntraNodeData(
   this->sequenceNumber_++;
   setStateIf(
       ReceiverState::WaitingForIntraNodeData, ReceiverState::ReadyToReceive);
-  communicator_->addToWorkQueue(getSelfPtr());
+  wakeCommunicator();
 }
 
 bool UcxExchangeSource::setStateIf(

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -100,6 +100,11 @@ class UcxExchangeSource
   /// once it received enough data.
   void close();
 
+  /// Fails a live source because its transport endpoint closed unexpectedly,
+  /// then schedules the ordinary source cleanup. Unlike close(), this records
+  /// an exchange error so a rejected handshake cannot look like an empty input.
+  void closeWithError(std::string error);
+
   /// @brief Marks this source as registered with the exchange queue.
   /// Must be called after addSourceLocked() increments numSources_ for this
   /// source. Without this, deliverEndMarker() will not enqueue the nullptr

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.h
@@ -198,6 +198,10 @@ class UcxExchangeSource
   /// @return A shared pointer to itself.
   std::shared_ptr<UcxExchangeSource> getSelfPtr();
 
+  /// Re-enqueues this source if the Communicator is still accepting work.
+  /// Safe for UCXX and registry callbacks during shutdown.
+  void wakeCommunicator();
+
   // Put the received data into the exchange queue.
   void enqueue(PackedTableWithStreamPtr data, int64_t reservedReceiveBytes = 0);
 

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/experimental/ucx-exchange/UcxPartitionedOutput.h"
 #include <fmt/format.h>
+#include <folly/json.h>
 #include <algorithm>
 #include <cstdlib>
 #include "velox/core/PlanNode.h"
@@ -23,13 +24,16 @@
 #include "velox/exec/Operator.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
+#include "velox/experimental/ucx-exchange/RangePartitionFunction.h"
 
 #include <cudf/concatenate.hpp>
 #include <cudf/contiguous_split.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/detail/utilities/stream_pool.hpp>
 #include <cudf/partitioning.hpp>
+#include <cudf/search.hpp>
 
 using namespace facebook::velox::cudf_velox;
 using facebook::velox::exec::Task;
@@ -48,6 +52,121 @@ int64_t targetRowsPerUcxChunk(const core::QueryConfig& queryConfig) {
     }
   }
   return queryConfig.ucxPartitionedOutputBatchRows();
+}
+
+RowVectorPtr buildRangeBoundaryVector(
+    const std::string& boundsJson,
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    memory::MemoryPool* pool,
+    std::vector<cudf::order>& orders,
+    std::vector<cudf::null_order>& nullOrders) {
+  const auto descriptor = folly::parseJson(boundsJson);
+  VELOX_CHECK_EQ(
+      descriptor["version"].asInt(), 1, "Unsupported RANGE_PID descriptor version");
+  const auto& keys = descriptor["keys"];
+  const auto& bounds = descriptor["bounds"];
+  VELOX_CHECK(keys.isArray(), "RANGE_PID keys must be an array");
+  VELOX_CHECK(bounds.isArray(), "RANGE_PID bounds must be an array");
+  VELOX_CHECK_EQ(
+      keys.size(), keyChannels.size(), "RANGE_PID key metadata/channel mismatch");
+
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  names.reserve(keyChannels.size());
+  types.reserve(keyChannels.size());
+  orders.clear();
+  nullOrders.clear();
+  for (size_t key = 0; key < keyChannels.size(); ++key) {
+    const auto channel = keyChannels[key];
+    VELOX_CHECK_LT(channel, inputType->size(), "RANGE_PID key channel out of bounds");
+    names.push_back(inputType->nameOf(channel));
+    types.push_back(inputType->childAt(channel));
+    orders.push_back(
+        keys[key]["ascending"].asBool() ? cudf::order::ASCENDING
+                                         : cudf::order::DESCENDING);
+    nullOrders.push_back(
+        keys[key]["nullsFirst"].asBool() ? cudf::null_order::BEFORE
+                                          : cudf::null_order::AFTER);
+  }
+
+  auto boundaryType = ROW(std::move(names), std::move(types));
+  auto vector = std::dynamic_pointer_cast<RowVector>(
+      BaseVector::create(boundaryType, bounds.size(), pool));
+  VELOX_CHECK_NOT_NULL(vector);
+
+  for (size_t row = 0; row < bounds.size(); ++row) {
+    VELOX_CHECK(bounds[row].isArray(), "RANGE_PID boundary must be an array");
+    VELOX_CHECK_EQ(
+        bounds[row].size(), keyChannels.size(), "RANGE_PID boundary width mismatch");
+    for (size_t key = 0; key < keyChannels.size(); ++key) {
+      const auto& encoded = bounds[row][key];
+      auto child = vector->childAt(key);
+      if (encoded["isNull"].asBool()) {
+        child->setNull(row, true);
+        continue;
+      }
+
+      const auto& value = encoded["value"];
+      const auto& type = boundaryType->childAt(key);
+      if (type->isDate()) {
+        child->asFlatVector<int32_t>()->set(row, value.asInt());
+      } else if (type->isTimestamp()) {
+        child->asFlatVector<Timestamp>()->set(
+            row, Timestamp::fromMicros(value.asInt()));
+      } else {
+        switch (type->kind()) {
+          case TypeKind::BOOLEAN:
+            child->asFlatVector<bool>()->set(row, value.asBool());
+            break;
+          case TypeKind::TINYINT:
+            child->asFlatVector<int8_t>()->set(row, value.asInt());
+            break;
+          case TypeKind::SMALLINT:
+            child->asFlatVector<int16_t>()->set(row, value.asInt());
+            break;
+          case TypeKind::INTEGER:
+            child->asFlatVector<int32_t>()->set(row, value.asInt());
+            break;
+          case TypeKind::BIGINT:
+            child->asFlatVector<int64_t>()->set(row, value.asInt());
+            break;
+          case TypeKind::REAL:
+            child->asFlatVector<float>()->set(
+                row, static_cast<float>(value.asDouble()));
+            break;
+          case TypeKind::DOUBLE:
+            child->asFlatVector<double>()->set(row, value.asDouble());
+            break;
+          case TypeKind::VARCHAR: {
+            const auto stringValue = value.asString();
+            child->asFlatVector<StringView>()->set(row, StringView(stringValue));
+            break;
+          }
+          default:
+            VELOX_UNSUPPORTED(
+                "RANGE_PID D1 does not support native key type {}",
+                type->toString());
+        }
+      }
+    }
+  }
+  return vector;
+}
+
+void normalizePartitionOffsets(
+    std::vector<cudf::size_type>& offsets,
+    size_t numPartitions) {
+  VELOX_CHECK(
+      offsets.size() == numPartitions || offsets.size() == numPartitions + 1,
+      "Unexpected libcudf partition offset count {} for {} partitions",
+      offsets.size(),
+      numPartitions);
+  VELOX_CHECK_EQ(offsets.front(), 0);
+  offsets.erase(offsets.begin());
+  if (offsets.size() == numPartitions) {
+    offsets.pop_back();
+  }
 }
 } // namespace
 
@@ -196,7 +315,9 @@ void UcxPartitionedOutput::flushPending() {
     // Partition + enqueue (identical to previous addInput logic).
     auto queueManager = sharedQueueManager();
     if (numPartitions_ > 1) {
-      if (partitionKeyIndices_.size() > 0 || spec_ == "gather") {
+      if (!rangeBoundsJson_.empty()) {
+        rangePartition(tableView, stream);
+      } else if (partitionKeyIndices_.size() > 0 || spec_ == "gather") {
         hashPartition(tableView, stream);
       } else {
         equalPartition(tableView, stream);
@@ -310,6 +431,17 @@ void UcxPartitionedOutput::initPartitionKeys(
   // Get partition function specification string
   spec_ = planNode->partitionFunctionSpec().toString();
 
+  if (auto* rangeFunctionSpec =
+          dynamic_cast<const RangePartitionFunctionSpec*>(
+              &planNode->partitionFunctionSpec())) {
+    partitionKeyIndices_ = rangeFunctionSpec->keyChannels();
+    rangeBoundsJson_ = rangeFunctionSpec->boundsJson();
+    VELOX_CHECK(
+        !partitionKeyIndices_.empty() && !rangeBoundsJson_.empty(),
+        "RANGE_PID requires both keys and Spark boundaries");
+    return;
+  }
+
   // Only parse keys if it's a hash function
   if (spec_.find("HASH(") != std::string::npos) {
     // Extract keys between HASH( and )
@@ -370,6 +502,63 @@ void UcxPartitionedOutput::hashPartition(
   partitionOffsets.erase(partitionOffsets.begin());
   partitionOffsets.pop_back();
 
+  splitAndEnqueue(partitionedTable->view(), partitionOffsets, stream);
+}
+
+void UcxPartitionedOutput::rangePartition(
+    cudf::table_view tableView,
+    rmm::cuda_stream_view stream) {
+  VELOX_CHECK(!rangeBoundsJson_.empty(), "RANGE_PID descriptor is missing");
+  VELOX_CHECK(!partitionKeyIndices_.empty(), "RANGE_PID keys are missing");
+
+  if (!rangeBoundaries_) {
+    auto boundaryVector = buildRangeBoundaryVector(
+        rangeBoundsJson_,
+        outputType_,
+        partitionKeyIndices_,
+        pool(),
+        rangeOrders_,
+        rangeNullOrders_);
+    rangeBoundaries_ = cudf_velox::with_arrow::toCudfTable(
+        boundaryVector,
+        pool(),
+        stream,
+        cudf::get_current_device_resource_ref());
+    VELOX_CHECK_LT(
+        rangeBoundaries_->num_rows(),
+        numPartitions_,
+        "RANGE_PID boundary count must be smaller than requested partitions");
+  }
+
+  std::vector<cudf::size_type> rangeKeyIndices;
+  rangeKeyIndices.reserve(partitionKeyIndices_.size());
+  for (const auto index : partitionKeyIndices_) {
+    rangeKeyIndices.push_back(static_cast<cudf::size_type>(index));
+  }
+  const auto keyTable = tableView.select(rangeKeyIndices);
+  auto partitionIds = cudf::lower_bound(
+      rangeBoundaries_->view(),
+      keyTable,
+      rangeOrders_,
+      rangeNullOrders_,
+      stream,
+      cudf::get_current_device_resource_ref());
+  VELOX_CHECK(
+      partitionIds->size() == tableView.num_rows(),
+      "RANGE_PID must produce exactly one id per input row");
+  VELOX_CHECK(
+      partitionIds->type().id() == cudf::type_id::INT32,
+      "RANGE_PID must produce an INT32 partition map");
+
+  // libcudf::partition groups by the explicit INT32 map. No hash function is
+  // involved; the returned table is routed directly to destination queues.
+  auto [partitionedTable, partitionOffsets] = cudf::partition(
+      tableView,
+      partitionIds->view(),
+      numPartitions_,
+      stream,
+      cudf::get_current_device_resource_ref());
+  normalizePartitionOffsets(partitionOffsets, numPartitions_);
   splitAndEnqueue(partitionedTable->view(), partitionOffsets, stream);
 }
 

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -63,13 +63,17 @@ RowVectorPtr buildRangeBoundaryVector(
     std::vector<cudf::null_order>& nullOrders) {
   const auto descriptor = folly::parseJson(boundsJson);
   VELOX_CHECK_EQ(
-      descriptor["version"].asInt(), 1, "Unsupported RANGE_PID descriptor version");
+      descriptor["version"].asInt(),
+      1,
+      "Unsupported RANGE_PID descriptor version");
   const auto& keys = descriptor["keys"];
   const auto& bounds = descriptor["bounds"];
   VELOX_CHECK(keys.isArray(), "RANGE_PID keys must be an array");
   VELOX_CHECK(bounds.isArray(), "RANGE_PID bounds must be an array");
   VELOX_CHECK_EQ(
-      keys.size(), keyChannels.size(), "RANGE_PID key metadata/channel mismatch");
+      keys.size(),
+      keyChannels.size(),
+      "RANGE_PID key metadata/channel mismatch");
 
   std::vector<std::string> names;
   std::vector<TypePtr> types;
@@ -79,15 +83,16 @@ RowVectorPtr buildRangeBoundaryVector(
   nullOrders.clear();
   for (size_t key = 0; key < keyChannels.size(); ++key) {
     const auto channel = keyChannels[key];
-    VELOX_CHECK_LT(channel, inputType->size(), "RANGE_PID key channel out of bounds");
+    VELOX_CHECK_LT(
+        channel, inputType->size(), "RANGE_PID key channel out of bounds");
     names.push_back(inputType->nameOf(channel));
     types.push_back(inputType->childAt(channel));
     orders.push_back(
         keys[key]["ascending"].asBool() ? cudf::order::ASCENDING
-                                         : cudf::order::DESCENDING);
+                                        : cudf::order::DESCENDING);
     nullOrders.push_back(
         keys[key]["nullsFirst"].asBool() ? cudf::null_order::BEFORE
-                                          : cudf::null_order::AFTER);
+                                         : cudf::null_order::AFTER);
   }
 
   auto boundaryType = ROW(std::move(names), std::move(types));
@@ -98,7 +103,9 @@ RowVectorPtr buildRangeBoundaryVector(
   for (size_t row = 0; row < bounds.size(); ++row) {
     VELOX_CHECK(bounds[row].isArray(), "RANGE_PID boundary must be an array");
     VELOX_CHECK_EQ(
-        bounds[row].size(), keyChannels.size(), "RANGE_PID boundary width mismatch");
+        bounds[row].size(),
+        keyChannels.size(),
+        "RANGE_PID boundary width mismatch");
     for (size_t key = 0; key < keyChannels.size(); ++key) {
       const auto& encoded = bounds[row][key];
       auto child = vector->childAt(key);
@@ -140,7 +147,8 @@ RowVectorPtr buildRangeBoundaryVector(
             break;
           case TypeKind::VARCHAR: {
             const auto stringValue = value.asString();
-            child->asFlatVector<StringView>()->set(row, StringView(stringValue));
+            child->asFlatVector<StringView>()->set(
+                row, StringView(stringValue));
             break;
           }
           default:
@@ -431,9 +439,8 @@ void UcxPartitionedOutput::initPartitionKeys(
   // Get partition function specification string
   spec_ = planNode->partitionFunctionSpec().toString();
 
-  if (auto* rangeFunctionSpec =
-          dynamic_cast<const RangePartitionFunctionSpec*>(
-              &planNode->partitionFunctionSpec())) {
+  if (auto* rangeFunctionSpec = dynamic_cast<const RangePartitionFunctionSpec*>(
+          &planNode->partitionFunctionSpec())) {
     partitionKeyIndices_ = rangeFunctionSpec->keyChannels();
     rangeBoundsJson_ = rangeFunctionSpec->boundsJson();
     VELOX_CHECK(

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
@@ -74,6 +74,10 @@ class UcxPartitionedOutput : public exec::Operator,
   // function using the given stream.
   void hashPartition(cudf::table_view tableView, rmm::cuda_stream_view stream);
 
+  // Computes a Spark-compatible INT32 partition id from serialized range
+  // boundaries, then routes rows by that explicit id.
+  void rangePartition(cudf::table_view tableView, rmm::cuda_stream_view stream);
+
   // Splits the cudf table view into equal sizes. This is used when
   // RoundRobin partitioning is requested but round robin on a
   // row-by-row basis is not meaningful for UCX exchange.
@@ -89,6 +93,10 @@ class UcxPartitionedOutput : public exec::Operator,
 
   const std::weak_ptr<UcxOutputQueueManager> queueManager_;
   std::vector<column_index_t> partitionKeyIndices_;
+  std::string rangeBoundsJson_;
+  std::unique_ptr<cudf::table> rangeBoundaries_;
+  std::vector<cudf::order> rangeOrders_;
+  std::vector<cudf::null_order> rangeNullOrders_;
   const size_t numPartitions_;
 
   const int pipelineId_;

--- a/velox/experimental/ucx-exchange/WorkQueue.h
+++ b/velox/experimental/ucx-exchange/WorkQueue.h
@@ -29,10 +29,15 @@ class WorkQueue {
   WorkQueue(const WorkQueue&) = delete;
   WorkQueue& operator=(const WorkQueue&) = delete;
 
-  // push always succeeds; never blocks
-  void push(std::shared_ptr<T> item) {
+  // Push never blocks. It returns false after terminal shutdown has closed the
+  // queue, preventing a check-then-push race with closeAndDrain().
+  bool push(std::shared_ptr<T> item) {
     std::lock_guard<std::mutex> lock(mutex_);
+    if (closed_) {
+      return false;
+    }
     queue_.emplace_back(std::move(item));
+    return true;
   }
 
   // pop never blocks; returns nullptr if empty
@@ -47,16 +52,25 @@ class WorkQueue {
     return item;
   }
 
-  // remove an element from the queue.
+  // Remove all copies of an element from the queue. Work items can be queued
+  // repeatedly, so removing only the first leaves a hidden owning reference.
   bool erase(std::shared_ptr<T> item) {
-    bool erased = false;
     std::lock_guard<std::mutex> lock(mutex_);
-    auto it = std::find(queue_.begin(), queue_.end(), item);
-    if (it != queue_.end()) {
-      queue_.erase(it);
-      erased = true;
+    const auto oldSize = queue_.size();
+    queue_.remove(item);
+    return queue_.size() != oldSize;
+  }
+
+  // Permanently close the queue and remove every queued reference. Swap under
+  // the mutex and release shared_ptrs after unlocking so item destruction
+  // cannot re-enter this queue while its mutex is held.
+  void closeAndDrain() {
+    std::list<std::shared_ptr<T>> items;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      closed_ = true;
+      items.swap(queue_);
     }
-    return erased;
   }
 
   // helpers
@@ -73,4 +87,5 @@ class WorkQueue {
  private:
   mutable std::mutex mutex_;
   std::list<std::shared_ptr<T>> queue_;
+  bool closed_{false};
 };

--- a/velox/experimental/ucx-exchange/tests/CMakeLists.txt
+++ b/velox/experimental/ucx-exchange/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   ucx_exchange_test
   UcxOutputQueueManagerTest.cpp
+  RangePartitionFunctionTest.cpp
   UcxExchangeTest.cpp
   IntraNodeTransferRegistryTest.cpp
   Main.cpp

--- a/velox/experimental/ucx-exchange/tests/Main.cpp
+++ b/velox/experimental/ucx-exchange/tests/Main.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/common/process/ThreadDebugInfo.h"
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/ucx-exchange/Communicator.h"
+#include "velox/type/Type.h"
 
 #include <folly/Unit.h>
 #include <folly/init/Init.h>
@@ -32,6 +34,8 @@ int main(int argc, char** argv) {
   // Signal handler required for ThreadDebugInfoTest
   facebook::velox::process::addDefaultFatalSignalHandler();
   folly::Init init(&argc, &argv, false);
+  FLAGS_velox_ucx_exchange = true;
+  facebook::velox::Type::registerSerDe();
   facebook::velox::cudf_velox::CudfConfig::getInstance().exchangeLogLevel =
       FLAGS_exchange_log_level;
   return RUN_ALL_TESTS();

--- a/velox/experimental/ucx-exchange/tests/RangePartitionFunctionTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/RangePartitionFunctionTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/experimental/ucx-exchange/RangePartitionFunction.h"
+
+namespace facebook::velox::ucx_exchange {
+namespace {
+
+constexpr auto kBounds = R"json({
+  "version": 1,
+  "keys": [{"sparkType":"int","ascending":true,"nullsFirst":true}],
+  "bounds": [[{"isNull":false,"value":10}]]
+})json";
+
+TEST(RangePartitionFunctionSpecTest, explicitPidIdentityAndSerde) {
+  auto rowType = ROW({"k", "payload"}, {INTEGER(), VARCHAR()});
+  auto spec = std::make_shared<RangePartitionFunctionSpec>(
+      rowType, std::vector<column_index_t>{0}, kBounds);
+
+  EXPECT_EQ(spec->toString(), "RANGE_PID(k)");
+  EXPECT_EQ(spec->keyChannels(), std::vector<column_index_t>({0}));
+  EXPECT_EQ(spec->boundsJson(), kBounds);
+
+  auto copy = RangePartitionFunctionSpec::deserialize(spec->serialize(), nullptr);
+  EXPECT_EQ(copy->toString(), "RANGE_PID(k)");
+}
+
+TEST(RangePartitionFunctionSpecTest, ordinaryCpuPathFailsInsteadOfHashing) {
+  auto spec = std::make_shared<RangePartitionFunctionSpec>(
+      ROW({"k"}, {INTEGER()}), std::vector<column_index_t>{0}, kBounds);
+  auto function = spec->create(2, false);
+  std::vector<uint32_t> partitions;
+  auto input = RowVector(nullptr, ROW({"k"}, {INTEGER()}), nullptr, 0, {});
+
+  EXPECT_THROW(function->partition(input, partitions), VeloxRuntimeError);
+}
+
+} // namespace
+} // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/tests/RangePartitionFunctionTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/RangePartitionFunctionTest.cpp
@@ -36,7 +36,8 @@ TEST(RangePartitionFunctionSpecTest, explicitPidIdentityAndSerde) {
   EXPECT_EQ(spec->keyChannels(), std::vector<column_index_t>({0}));
   EXPECT_EQ(spec->boundsJson(), kBounds);
 
-  auto copy = RangePartitionFunctionSpec::deserialize(spec->serialize(), nullptr);
+  auto copy =
+      RangePartitionFunctionSpec::deserialize(spec->serialize(), nullptr);
   EXPECT_EQ(copy->toString(), "RANGE_PID(k)");
 }
 

--- a/velox/experimental/ucx-exchange/tests/SinkDriverMock.cpp
+++ b/velox/experimental/ucx-exchange/tests/SinkDriverMock.cpp
@@ -55,18 +55,19 @@ SinkDriverMock::SinkDriverMock(
   }
 }
 
-void SinkDriverMock::updateDataValidity(const cudf::table_view& tab) {
+void SinkDriverMock::updateDataValidity(
+    const cudf::table_view& tab,
+    uint64_t startRow) {
   if (!referenceData_) {
     return; // No reference data to check against
   }
 
   auto stream = rmm::cuda_stream_default;
 
-  // Use the polymorphic verifyTable method
-  // Note: For chunk-based verification, we use startRow=0 since each chunk
-  // contains rows that should match the reference data from the beginning.
-  // This assumes the test sends the same data pattern in each chunk.
-  bool valid = referenceData_->verifyTable(tab, 0, tab.num_rows(), stream);
+  // Output chunks may be bounded slices of a larger input table. Validate each
+  // slice at its logical position in the received stream.
+  bool valid =
+      referenceData_->verifyTable(tab, startRow, tab.num_rows(), stream);
 
   if (!valid) {
     dataValidFlag_ = false;
@@ -95,11 +96,12 @@ void SinkDriverMock::receiveAllData(UcxExchange* hybridExchange) {
             std::dynamic_pointer_cast<facebook::velox::cudf_velox::CudfVector>(
                 res);
         numBytes_.fetch_add(cudfRes->estimateFlatSize());
-        numRows_ += cudfRes->getTableView().num_rows();
+        const auto rows = cudfRes->getTableView().num_rows();
+        const auto startRow = numRows_.fetch_add(rows);
         numChunksReceived_.fetch_add(1);
         // If we have Reference data check the received data is the same
         if (referenceData_)
-          updateDataValidity(cudfRes->getTableView());
+          updateDataValidity(cudfRes->getTableView(), startRow);
       }
     }
     if (hybridExchange->isFinished()) {

--- a/velox/experimental/ucx-exchange/tests/SinkDriverMock.h
+++ b/velox/experimental/ucx-exchange/tests/SinkDriverMock.h
@@ -86,7 +86,8 @@ class SinkDriverMock {
   /// @brief checks if the received table corresponds to that sent, sets
   /// dataValidFlag_=false if not
   /// @param tab
-  void updateDataValidity(const cudf::table_view& tab);
+  /// @param startRow the logical row offset in the received stream
+  void updateDataValidity(const cudf::table_view& tab, uint64_t startRow);
 
   std::atomic<bool> dataValidFlag_{true};
   std::shared_ptr<facebook::velox::exec::Task> task_;

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -86,7 +86,7 @@ static std::vector<ExchangeTestParams> generateTestParams() {
       {"MultiPartition", 1, 1, 4, 100, 1000, TableType::NARROW},
       // Test with multiple partitions and multiple drivers
       {"MultiPartitionDrivers", 4, 4, 4, 25, 1000, TableType::NARROW},
-      // Wide table tests with all data types including STRUCT
+      // Wide table tests with numeric types shared by Velox and cuDF.
       // Single partition wide table (no hash partitioning)
       {"WideTableSingle", 1, 1, 1, 100, 1000, TableType::WIDE},
       // Multi-partition wide table (uses hash partitioning)

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -177,9 +177,13 @@ class UcxExchangeTest : public testing::TestWithParam<ExchangeTestParams> {
 
   static void TearDownTestCase() {
     communicator_->stop();
-    communicator_.reset();
     communicatorThread_->join();
     communicatorThread_.reset();
+    Communicator::shutdown();
+    // The explicit finalizer is intentionally idempotent because Spark's
+    // plugin shutdown and JVM shutdown hook can both invoke native teardown.
+    Communicator::shutdown();
+    communicator_.reset();
   }
 
   void SetUp() override {

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -767,9 +767,12 @@ TEST_P(UcxExchangeTest, realPartitionedOutputDataIntegrityTest) {
 
     // Pass the partitioned reference data for this partition (may be nullptr
     // for wide multi-partition)
+    // Ordered row-wise validation requires a single consumer. Multi-consumer
+    // exchange parallelism is covered by the non-order-sensitive tests.
+    const auto sinkDriverCount = canVerifyDataIntegrity ? 1 : p.numDstDrivers;
     auto sinkDriver = std::make_shared<SinkDriverMock>(
         sinkTask,
-        p.numDstDrivers,
+        sinkDriverCount,
         canVerifyDataIntegrity ? partitionedDataToVerify[partitionId]
                                : nullptr);
 
@@ -797,6 +800,9 @@ TEST_P(UcxExchangeTest, realPartitionedOutputDataIntegrityTest) {
   }
   VLOG(3) << "All sink tasks done.";
 
+  // Release the source task even if a following assertion fails.
+  queueManager_->removeTask(srcTaskId);
+
   // Verify total row count
   size_t expectedTotalRows = p.numChunks * p.numRowsPerChunk * numSrcDrivers;
   size_t totalReceivedRows = 0;
@@ -823,9 +829,6 @@ TEST_P(UcxExchangeTest, realPartitionedOutputDataIntegrityTest) {
     VLOG(3)
         << "Data integrity verification skipped for wide table with multi-partition";
   }
-
-  // Cleanup
-  queueManager_->removeTask(srcTaskId);
 
   VLOG(3) << "- UcxExchangeTest::realPartitionedOutputDataIntegrityTest";
 }
@@ -1246,10 +1249,11 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
     queueManager_->removeTask(srcTaskId);
   }
 
-  // --- Scenario 3: Large chunks (>= threshold) should NOT be accumulated ---
+  // --- Scenario 3: Large chunks are flushed immediately and bounded ---
   // 5 chunks × 20,000 rows = 100,000 total rows.
   // Each chunk exceeds kTargetRowsPerChunk, so each addInput triggers an
-  // immediate flush via the single-input fast path. Expected: 5 output chunks.
+  // immediate flush. The outbound path still limits every output chunk to the
+  // target row count, so each input becomes two output chunks.
   {
     const int numChunks = 5;
     const int numRowsPerChunk = 20000;
@@ -1297,15 +1301,17 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
     EXPECT_TRUE(sinkDriver->dataIsValid())
         << "Large-chunk scenario data must match reference";
 
+    const auto chunksPerInput =
+        (numRowsPerChunk + kTargetRows - 1) / kTargetRows;
+    const auto expectedOutputChunks = numChunks * chunksPerInput;
+
     VLOG(0) << "batchAccumulationTest scenario 3: sent " << numChunks
             << " chunks of " << numRowsPerChunk << " rows, received "
             << sinkDriver->numChunksReceived() << " chunks (expected "
-            << numChunks << ")";
+            << expectedOutputChunks << ")";
 
-    // Large chunks should pass through without accumulation — each addInput
-    // immediately flushes because pendingRows >= kTargetRowsPerChunk.
-    EXPECT_EQ(sinkDriver->numChunksReceived(), static_cast<uint64_t>(numChunks))
-        << "Large chunks should not be accumulated";
+    EXPECT_EQ(sinkDriver->numChunksReceived(), expectedOutputChunks)
+        << "Large inputs should be flushed immediately in bounded slices";
 
     queueManager_->removeTask(srcTaskId);
   }

--- a/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
@@ -369,10 +369,6 @@ void WideTestTable::initialize(size_t numRows) {
   int16Data_.resize(numRows);
   int32Data_.resize(numRows);
   int64Data_.resize(numRows);
-  uint8Data_.resize(numRows);
-  uint16Data_.resize(numRows);
-  uint32Data_.resize(numRows);
-  uint64Data_.resize(numRows);
   float32Data_.resize(numRows);
   float64Data_.resize(numRows);
   boolData_.resize(numRows);
@@ -385,10 +381,6 @@ void WideTestTable::initialize(size_t numRows) {
     int16Data_[i] = static_cast<int16_t>(randInt % 32768);
     int32Data_[i] = static_cast<int32_t>(randInt);
     int64Data_[i] = randInt;
-    uint8Data_[i] = static_cast<uint8_t>(std::abs(randInt) % 256);
-    uint16Data_[i] = static_cast<uint16_t>(std::abs(randInt) % 65536);
-    uint32Data_[i] = static_cast<uint32_t>(std::abs(randInt));
-    uint64Data_[i] = static_cast<uint64_t>(std::abs(randInt));
     float32Data_[i] = static_cast<float>(randDouble);
     float64Data_[i] = randDouble;
     boolData_[i] = boolDist(gen);
@@ -404,10 +396,6 @@ void WideTestTable::addNumericColumns(
   columns.push_back(makeNumericColumn(int16Data_, stream));
   columns.push_back(makeNumericColumn(int32Data_, stream));
   columns.push_back(makeNumericColumn(int64Data_, stream));
-  columns.push_back(makeNumericColumn(uint8Data_, stream));
-  columns.push_back(makeNumericColumn(uint16Data_, stream));
-  columns.push_back(makeNumericColumn(uint32Data_, stream));
-  columns.push_back(makeNumericColumn(uint64Data_, stream));
   columns.push_back(makeNumericColumn(float32Data_, stream));
   columns.push_back(makeNumericColumn(float64Data_, stream));
   columns.push_back(makeNumericColumn(boolData_, stream));
@@ -425,18 +413,14 @@ bool WideTestTable::verifyNumericColumns(
     size_t startRow,
     size_t numRows,
     rmm::cuda_stream_view stream) {
-  // Verify numeric columns (columns 0-10)
+  // Verify numeric columns (columns 0-6).
   auto rxInt8 = getColVector<int8_t>(table.column(0), numRows, stream);
   auto rxInt16 = getColVector<int16_t>(table.column(1), numRows, stream);
   auto rxInt32 = getColVector<int32_t>(table.column(2), numRows, stream);
   auto rxInt64 = getColVector<int64_t>(table.column(3), numRows, stream);
-  auto rxUint8 = getColVector<uint8_t>(table.column(4), numRows, stream);
-  auto rxUint16 = getColVector<uint16_t>(table.column(5), numRows, stream);
-  auto rxUint32 = getColVector<uint32_t>(table.column(6), numRows, stream);
-  auto rxUint64 = getColVector<uint64_t>(table.column(7), numRows, stream);
-  auto rxFloat32 = getColVector<float>(table.column(8), numRows, stream);
-  auto rxFloat64 = getColVector<double>(table.column(9), numRows, stream);
-  auto rxBool = getColVector<int8_t>(table.column(10), numRows, stream);
+  auto rxFloat32 = getColVector<float>(table.column(4), numRows, stream);
+  auto rxFloat64 = getColVector<double>(table.column(5), numRows, stream);
+  auto rxBool = getColVector<int8_t>(table.column(6), numRows, stream);
 
   // Use modular indexing because batch accumulation in UcxPartitionedOutput
   // may concatenate multiple identical chunks into one larger table, causing
@@ -446,10 +430,6 @@ bool WideTestTable::verifyNumericColumns(
 
     if (rxInt8[i] != int8Data_[srcIdx] || rxInt16[i] != int16Data_[srcIdx] ||
         rxInt32[i] != int32Data_[srcIdx] || rxInt64[i] != int64Data_[srcIdx] ||
-        rxUint8[i] != uint8Data_[srcIdx] ||
-        rxUint16[i] != uint16Data_[srcIdx] ||
-        rxUint32[i] != uint32Data_[srcIdx] ||
-        rxUint64[i] != uint64Data_[srcIdx] ||
         rxFloat32[i] != float32Data_[srcIdx] ||
         rxFloat64[i] != float64Data_[srcIdx] ||
         rxBool[i] != boolData_[srcIdx]) {
@@ -465,8 +445,8 @@ bool WideTestTable::verifyTable(
     size_t startRow,
     size_t numRows,
     rmm::cuda_stream_view stream) {
-  if (table.num_columns() != 11) {
-    VLOG(0) << "WideTestTable::verifyTable: expected 11 columns, got "
+  if (table.num_columns() != 7) {
+    VLOG(0) << "WideTestTable::verifyTable: expected 7 columns, got "
             << table.num_columns();
     return false;
   }
@@ -529,8 +509,8 @@ bool WideComplexTestTable::verifyTable(
     size_t startRow,
     size_t numRows,
     rmm::cuda_stream_view stream) {
-  if (table.num_columns() != 13) {
-    VLOG(0) << "WideComplexTestTable::verifyTable: expected 13 columns, got "
+  if (table.num_columns() != 9) {
+    VLOG(0) << "WideComplexTestTable::verifyTable: expected 9 columns, got "
             << table.num_columns();
     return false;
   }
@@ -540,11 +520,11 @@ bool WideComplexTestTable::verifyTable(
     return false;
   }
 
-  // Verify string column (column 11)
-  auto rxStrings = getStringCol(table.column(11), numRows, stream);
+  // Verify string column (column 7)
+  auto rxStrings = getStringCol(table.column(7), numRows, stream);
 
-  // Verify struct column children (column 12)
-  cudf::structs_column_view structView{table.column(12)};
+  // Verify struct column children (column 8)
+  cudf::structs_column_view structView{table.column(8)};
   auto rxStructField1 =
       getColVector<int64_t>(structView.child(0), numRows, stream);
   auto rxStructField2 =

--- a/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
@@ -398,7 +398,18 @@ void WideTestTable::addNumericColumns(
   columns.push_back(makeNumericColumn(int64Data_, stream));
   columns.push_back(makeNumericColumn(float32Data_, stream));
   columns.push_back(makeNumericColumn(float64Data_, stream));
-  columns.push_back(makeNumericColumn(boolData_, stream));
+  auto boolColumn = cudf::make_fixed_width_column(
+      cudf::data_type{cudf::type_id::BOOL8},
+      static_cast<cudf::size_type>(boolData_.size()),
+      cudf::mask_state::UNALLOCATED,
+      stream);
+  cudaMemcpyAsync(
+      boolColumn->mutable_view().data<bool>(),
+      boolData_.data(),
+      boolData_.size() * sizeof(int8_t),
+      cudaMemcpyHostToDevice,
+      stream.value());
+  columns.push_back(std::move(boolColumn));
 }
 
 std::unique_ptr<cudf::table> WideTestTable::makeTable(

--- a/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxTestData.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<cudf::column> BaseTableGenerator::makeNumericColumn(
 
   // Allocate a device buffer of the correct size
   rmm::device_buffer data(
-      numRows * sizeof(T), stream, rmm::mr::get_current_device_resource());
+      numRows * sizeof(T), stream, rmm::mr::get_current_device_resource_ref());
 
   // Copy host -> device
   cudaMemcpyAsync(
@@ -135,7 +135,7 @@ std::unique_ptr<cudf::column> BaseTableGenerator::makeStringsColumn(
   rmm::device_buffer charsBuffer(
       totalBytes,
       cudf::get_default_stream(),
-      rmm::mr::get_current_device_resource());
+      rmm::mr::get_current_device_resource_ref());
 
   std::vector<char> hostConcat;
   hostConcat.reserve(totalBytes);

--- a/velox/experimental/ucx-exchange/tests/UcxTestData.h
+++ b/velox/experimental/ucx-exchange/tests/UcxTestData.h
@@ -184,16 +184,13 @@ class UcxTestData : public BaseTableGenerator {
 /// WideComplexTestTable for those.
 class WideTestTable : public BaseTableGenerator {
  public:
-  // Column names for the wide table (numeric types only)
+  // Column names for numeric types shared by Velox and cuDF. cuDF unsigned
+  // integers are excluded because Velox has no matching logical types.
   inline static const std::vector<std::string> kColumnNames = {
       "int8_col", // INT8
       "int16_col", // INT16
       "int32_col", // INT32
       "int64_col", // INT64
-      "uint8_col", // UINT8
-      "uint16_col", // UINT16
-      "uint32_col", // UINT32
-      "uint64_col", // UINT64
       "float32_col", // FLOAT32
       "float64_col", // FLOAT64
       "bool_col" // BOOL8
@@ -205,10 +202,6 @@ class WideTestTable : public BaseTableGenerator {
       SMALLINT(), // INT16
       INTEGER(), // INT32
       BIGINT(), // INT64
-      TINYINT(), // UINT8 (mapped to TINYINT)
-      SMALLINT(), // UINT16 (mapped to SMALLINT)
-      INTEGER(), // UINT32 (mapped to INTEGER)
-      BIGINT(), // UINT64 (mapped to BIGINT)
       REAL(), // FLOAT32
       DOUBLE(), // FLOAT64
       BOOLEAN()}; // BOOL8
@@ -260,10 +253,6 @@ class WideTestTable : public BaseTableGenerator {
   std::vector<int16_t> int16Data_;
   std::vector<int32_t> int32Data_;
   std::vector<int64_t> int64Data_;
-  std::vector<uint8_t> uint8Data_;
-  std::vector<uint16_t> uint16Data_;
-  std::vector<uint32_t> uint32Data_;
-  std::vector<uint64_t> uint64Data_;
   std::vector<float> float32Data_;
   std::vector<double> float64Data_;
   std::vector<int8_t> boolData_; // stored as int8_t for BOOL8
@@ -282,10 +271,6 @@ class WideComplexTestTable : public WideTestTable {
       "int16_col", // INT16
       "int32_col", // INT32
       "int64_col", // INT64
-      "uint8_col", // UINT8
-      "uint16_col", // UINT16
-      "uint32_col", // UINT32
-      "uint64_col", // UINT64
       "float32_col", // FLOAT32
       "float64_col", // FLOAT64
       "bool_col", // BOOL8
@@ -299,10 +284,6 @@ class WideComplexTestTable : public WideTestTable {
       SMALLINT(), // INT16
       INTEGER(), // INT32
       BIGINT(), // INT64
-      TINYINT(), // UINT8 (mapped to TINYINT)
-      SMALLINT(), // UINT16 (mapped to SMALLINT)
-      INTEGER(), // UINT32 (mapped to INTEGER)
-      BIGINT(), // UINT64 (mapped to BIGINT)
       REAL(), // FLOAT32
       DOUBLE(), // FLOAT64
       BOOLEAN(), // BOOL8

--- a/velox/experimental/ucx-exchange/tests/UcxTestHelpers.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxTestHelpers.cpp
@@ -180,8 +180,8 @@ template <typename T>
 std::unique_ptr<cudf::column> make_numeric_column_from_vector(
     const std::vector<T>& host_values,
     rmm::cuda_stream_view stream = cudf::get_default_stream(),
-    rmm::mr::device_memory_resource* mr =
-        rmm::mr::get_current_device_resource()) {
+    rmm::device_async_resource_ref mr =
+        rmm::mr::get_current_device_resource_ref()) {
   size_t num_rows = host_values.size();
 
   // Allocate a device buffer of the correct size
@@ -208,8 +208,8 @@ std::unique_ptr<cudf::column> make_numeric_column_from_vector(
 rmm::device_buffer make_chars_buffer_from_host(
     const std::vector<std::string>& host_strings,
     rmm::cuda_stream_view stream = cudf::get_default_stream(),
-    rmm::mr::device_memory_resource* mr =
-        rmm::mr::get_current_device_resource()) {
+    rmm::device_async_resource_ref mr =
+        rmm::mr::get_current_device_resource_ref()) {
   // Compute total bytes needed
   size_t total_bytes = 0;
   for (auto const& s : host_strings)


### PR DESCRIPTION
 ## Summary

  This PR improves cuDF and UCX reliability for distributed MPP execution. It focuses on exchange lifecycle safety, bounded output processing, join
  ownership, aggregation support, and spill cleanup.

  It is the Velox-side companion to the spark-gluten MPP reliability PR.

  ## Key changes

  ### UCX exchange reliability

  - Move ownership of the UCX exchange enable flag into Velox.
  - Improve communicator, endpoint, and exchange-source lifecycle handling.
  - Keep receive and output buffers alive until asynchronous UCX operations complete.
  - Bound partitioned-output slices to avoid oversized output batches.
  - Improve peer readiness, progress, shutdown, and error propagation.
  - Initialize exchange and type serialization consistently.
  - Add native RANGE partition-function support.

  ### cuDF operator reliability

  - Retain the nested-loop join bridge until operator shutdown completes.
  - Preserve correct probe-side ownership and schema handling.
  - Use the task spill directory for `TopNRowNumber`.
  - Clean up Top-N spill state on normal completion and early failure.
  - Add grouped `collect_list` support.
  - Reject unsupported constant collection aggregates explicitly.

  ### Test coverage

  Add or extend coverage for:

  - bounded UCX output slices
  - wide-column and boolean exchange data
  - exchange and type-serde initialization
  - RANGE partitioning
  - nested-loop join bridge lifetime
  - grouped `collect_list`
  - constant collection-aggregate rejection
  - Top-N spill-directory selection
  - Top-N spill cleanup on completion and failure

  ## Validation

  The changes were exercised through the companion spark-gluten integration using 23 unchanged production-style workloads.

  Across iterative validation runs:

  - 12 distinct jobs completed successfully at least once.
  - Three jobs were verified on the clean fully-MPP query-data path.
  - Nine additional jobs completed with a Spark RANGE pre-stage and remain classified as hybrid MPP.
  - OOM-related workloads remain outside the scope of this PR.

  These results are aggregated across validation runs and do not represent a single clean 12/23 run on the final commit.

  ## Out of scope

  - Spark plan-conversion and boundary-repair logic
  - Application-specific UDF implementations
  - Workload-query modifications or query-specific workarounds
  - OOM tuning and hardware-capacity issues
