### PR TITLE
feat(cudf): Improve bounded batching, aggregation, and UCX exchange

### DIFF
--- a/.github/workflows/sync-facebookincubator-main.yml
+++ b/.github/workflows/sync-facebookincubator-main.yml
@@ -1,11 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Sync facebookincubator main
 
 on:
   schedule:
     # Run daily at 03:17 UTC (12:17 JST). Avoid the top of the hour,
     # when scheduled workflows are more likely to be delayed.
-    - cron: '17 3 * * *'
-  workflow_dispatch:
+    - cron: 17 3 * * *
+  workflow_dispatch: {}
 
 permissions: {}
 

--- a/.github/workflows/sync-facebookincubator-main.yml
+++ b/.github/workflows/sync-facebookincubator-main.yml
@@ -1,0 +1,31 @@
+name: Sync facebookincubator main
+
+on:
+  schedule:
+    # Run daily at 03:17 UTC (12:17 JST). Avoid the top of the hour,
+    # when scheduled workflows are more likely to be delayed.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: sync-facebookincubator-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Fast-forward main from upstream
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Sync main from facebookincubator/velox
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/merge-upstream" \
+            -f branch=main

--- a/velox/common/file/LocalFile.cpp
+++ b/velox/common/file/LocalFile.cpp
@@ -432,8 +432,7 @@ void LocalWriteFile::append(std::unique_ptr<folly::IOBuf> data) {
   uint64_t totalBytesWritten{0};
   for (auto rangeIter = data->begin(); rangeIter != data->end(); ++rangeIter) {
     const auto bytesToWrite = rangeIter->size();
-    const auto bytesWritten =
-        writeFully(fd_, rangeIter->data(), bytesToWrite);
+    const auto bytesWritten = writeFully(fd_, rangeIter->data(), bytesToWrite);
     totalBytesWritten += bytesWritten;
   }
   const auto totalBytesToWrite = data->computeChainDataLength();

--- a/velox/common/file/LocalFile.cpp
+++ b/velox/common/file/LocalFile.cpp
@@ -88,6 +88,26 @@ FOLLY_ALWAYS_INLINE void checkNotClosed(bool closed) {
   VELOX_CHECK(!closed, "file is closed");
 }
 
+uint64_t writeFully(int32_t fd, const void* data, uint64_t size) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  uint64_t totalWritten = 0;
+  while (totalWritten < size) {
+    ssize_t written;
+    do {
+      written = ::write(fd, bytes + totalWritten, size - totalWritten);
+    } while (written < 0 && errno == EINTR);
+    VELOX_CHECK_GT(
+        written,
+        0,
+        "write failure after {} of {} bytes: {}",
+        totalWritten,
+        size,
+        folly::errnoStr(errno));
+    totalWritten += static_cast<uint64_t>(written);
+  }
+  return totalWritten;
+}
+
 #ifdef STATX_DIOALIGN
 bool isPowerOfTwo(uint64_t value) {
   return value != 0 && (value & (value - 1)) == 0;
@@ -403,14 +423,7 @@ LocalWriteFile::~LocalWriteFile() {
 
 void LocalWriteFile::append(std::string_view data) {
   checkNotClosed(closed_);
-  const uint64_t bytesWritten = ::write(fd_, data.data(), data.size());
-  VELOX_CHECK_EQ(
-      bytesWritten,
-      data.size(),
-      "fwrite failure in LocalWriteFile::append, {} vs {}: {}",
-      bytesWritten,
-      data.size(),
-      folly::errnoStr(errno));
+  const auto bytesWritten = writeFully(fd_, data.data(), data.size());
   size_ += bytesWritten;
 }
 
@@ -419,16 +432,9 @@ void LocalWriteFile::append(std::unique_ptr<folly::IOBuf> data) {
   uint64_t totalBytesWritten{0};
   for (auto rangeIter = data->begin(); rangeIter != data->end(); ++rangeIter) {
     const auto bytesToWrite = rangeIter->size();
-    const uint64_t bytesWritten =
-        ::write(fd_, rangeIter->data(), rangeIter->size());
+    const auto bytesWritten =
+        writeFully(fd_, rangeIter->data(), bytesToWrite);
     totalBytesWritten += bytesWritten;
-    if (bytesWritten != bytesToWrite) {
-      VELOX_FAIL(
-          "fwrite failure in LocalWriteFile::append, {} vs {}: {}",
-          bytesWritten,
-          bytesToWrite,
-          folly::errnoStr(errno));
-    }
   }
   const auto totalBytesToWrite = data->computeChainDataLength();
   VELOX_CHECK_EQ(

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -72,7 +72,8 @@ HiveIcebergSplit::HiveIcebergSplit(
     std::vector<IcebergDeleteFile> deletes,
     const std::unordered_map<std::string, std::string>& infoColumns,
     std::optional<FileProperties> properties,
-    int64_t dataSequenceNumber)
+    int64_t dataSequenceNumber,
+    std::vector<IcebergCoalescedFile> coalescedFiles)
     : HiveConnectorSplit(
           connectorId,
           filePath,
@@ -91,6 +92,7 @@ HiveIcebergSplit::HiveIcebergSplit(
           std::nullopt,
           std::nullopt),
       deleteFiles(std::move(deletes)),
+      coalescedFiles(std::move(coalescedFiles)),
       dataSequenceNumber(dataSequenceNumber) {}
 
 std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -27,8 +27,21 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
+/// An additional whole data file that can be decoded together with the
+/// primary file of an Iceberg split. Multi-file splits are produced only for
+/// the cuDF Iceberg connector; CPU readers continue to receive one file per
+/// split.
+struct IcebergCoalescedFile {
+  std::string filePath;
+  uint64_t length;
+};
+
 struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
   std::vector<IcebergDeleteFile> deleteFiles;
+
+  /// Additional whole files with the same partition and metadata constants.
+  /// Delete-bearing and byte-range splits must never be coalesced.
+  std::vector<IcebergCoalescedFile> coalescedFiles;
 
   /// Data sequence number of the base data file in this split. Per the Iceberg
   /// spec (V2+), an equality delete file should only apply to data files whose
@@ -69,7 +82,8 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       std::vector<IcebergDeleteFile> deletes = {},
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       std::optional<FileProperties> fileProperties = std::nullopt,
-      int64_t dataSequenceNumber = 0);
+      int64_t dataSequenceNumber = 0,
+      std::vector<IcebergCoalescedFile> coalescedFiles = {});
 };
 
 /// Builds Iceberg splits with named parameters.

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -93,6 +93,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kMaxPartitionedOutputBufferSize);
     VELOX_REGISTER_QUERY_CONFIG(kMaxOutputBufferSize);
     VELOX_REGISTER_QUERY_CONFIG(kUcxPartitionedOutputBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kUcxPartitionedOutputBatchBytes);
 
     // Output batch.
     VELOX_REGISTER_QUERY_CONFIG(kPreferredOutputBatchBytes);

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -93,6 +93,9 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kMaxPartitionedOutputBufferSize);
     VELOX_REGISTER_QUERY_CONFIG(kMaxOutputBufferSize);
     VELOX_REGISTER_QUERY_CONFIG(kUcxPartitionedOutputBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kUcxHashPartitionInputBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kUcxHashPartitionWindowRows);
+    VELOX_REGISTER_QUERY_CONFIG(kCudfAsyncQueryEndTrimBytes);
     VELOX_REGISTER_QUERY_CONFIG(kUcxPartitionedOutputBatchBytes);
 
     // Output batch.

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -351,6 +351,17 @@ class QueryConfig {
       10'000,
       "Target rows per CudfPartitionedOutput exchange chunk.")
 
+  /// Target bytes to accumulate before flushing CudfPartitionedOutput and the
+  /// maximum approximate payload bytes per destination chunk. Set to 0 to
+  /// disable byte-based accumulation and chunking.
+  VELOX_QUERY_CONFIG(
+      kUcxPartitionedOutputBatchBytes,
+      ucxPartitionedOutputBatchBytes,
+      "cudf.partitioned_output_batch_bytes",
+      uint64_t,
+      0,
+      "Target bytes per CudfPartitionedOutput exchange chunk.")
+
   VELOX_QUERY_CONFIG(
       kMaxPartialAggregationMemory,
       maxPartialAggregationMemoryUsage,

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -351,6 +351,42 @@ class QueryConfig {
       10'000,
       "Target rows per CudfPartitionedOutput exchange chunk.")
 
+  /// Maximum input rows for one libcudf hash_partition call in UCX output.
+  /// Zero keeps the normal single-call path. This is query-scoped so a query
+  /// that needs the libcudf safety bound does not regress every other query.
+  VELOX_QUERY_CONFIG(
+      kUcxHashPartitionInputBatchRows,
+      ucxHashPartitionInputBatchRows,
+      "cudf.hash_partition_input_batch_rows",
+      int64_t,
+      0,
+      "Maximum input rows per UCX hash_partition call; 0 disables slicing.")
+
+  /// Maximum source rows whose safely sliced hash results are recombined at
+  /// once. Zero derives the window from cudf.partitioned_output_batch_rows.
+  VELOX_QUERY_CONFIG(
+      kUcxHashPartitionWindowRows,
+      ucxHashPartitionWindowRows,
+      "cudf.hash_partition_window_rows",
+      int64_t,
+      0,
+      "Maximum source rows per sliced UCX hash recombination window; 0 uses "
+      "the partitioned-output batch row setting.")
+
+  /// Query-boundary cudaMallocAsync trim policy. Values >= 0 trim unused pool
+  /// memory to the requested retained bytes; -1 explicitly disables trim for
+  /// this query; -2 preserves the executor-environment fallback. This allows
+  /// benchmark hot iterations to reuse the pool while retaining deterministic
+  /// release before a following high-peak query.
+  VELOX_QUERY_CONFIG(
+      kCudfAsyncQueryEndTrimBytes,
+      cudfAsyncQueryEndTrimBytes,
+      "cudf.async_query_end_trim_bytes",
+      int64_t,
+      -2,
+      "cudaMallocAsync bytes to retain at query end; -1 disables and -2 uses "
+      "the executor environment fallback.")
+
   /// Target bytes to accumulate before flushing CudfPartitionedOutput and the
   /// maximum approximate payload bytes per destination chunk. Set to 0 to
   /// disable byte-based accumulation and chunking.

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -11,6 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if(VELOX_ENABLE_CUDF)
+  # Task owns output-queue initialization. Without this definition the cuDF
+  # UcxPartitionedOutput operator runs without a registered output queue.
+  set_source_files_properties(
+    Task.cpp TARGET_DIRECTORY velox PROPERTIES COMPILE_DEFINITIONS VELOX_ENABLE_CUDF)
+  set_property(
+    SOURCE Task.cpp
+    TARGET_DIRECTORY velox
+    APPEND
+    PROPERTY INCLUDE_DIRECTORIES
+             "${CMAKE_BINARY_DIR}/_deps/cccl-src/libcudacxx/include"
+             "${CMAKE_BINARY_DIR}/_deps/cccl-src/thrust"
+             "${CMAKE_BINARY_DIR}/_deps/cccl-src/cub"
+             "${CUDAToolkit_INCLUDE_DIRS}")
+endif()
+
 velox_add_library(
   velox_exec
   AddressableNonNullValueList.cpp

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -19,16 +19,6 @@ if(VELOX_ENABLE_CUDF)
     TARGET_DIRECTORY velox
     PROPERTIES COMPILE_DEFINITIONS VELOX_ENABLE_CUDF
   )
-  set_property(
-    SOURCE Task.cpp TARGET_DIRECTORY velox
-    APPEND
-    PROPERTY
-      INCLUDE_DIRECTORIES
-        "${CMAKE_BINARY_DIR}/_deps/cccl-src/libcudacxx/include"
-        "${CMAKE_BINARY_DIR}/_deps/cccl-src/thrust"
-        "${CMAKE_BINARY_DIR}/_deps/cccl-src/cub"
-        "${CUDAToolkit_INCLUDE_DIRS}"
-  )
 endif()
 
 velox_add_library(

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -15,16 +15,20 @@ if(VELOX_ENABLE_CUDF)
   # Task owns output-queue initialization. Without this definition the cuDF
   # UcxPartitionedOutput operator runs without a registered output queue.
   set_source_files_properties(
-    Task.cpp TARGET_DIRECTORY velox PROPERTIES COMPILE_DEFINITIONS VELOX_ENABLE_CUDF)
-  set_property(
-    SOURCE Task.cpp
+    Task.cpp
     TARGET_DIRECTORY velox
+    PROPERTIES COMPILE_DEFINITIONS VELOX_ENABLE_CUDF
+  )
+  set_property(
+    SOURCE Task.cpp TARGET_DIRECTORY velox
     APPEND
-    PROPERTY INCLUDE_DIRECTORIES
-             "${CMAKE_BINARY_DIR}/_deps/cccl-src/libcudacxx/include"
-             "${CMAKE_BINARY_DIR}/_deps/cccl-src/thrust"
-             "${CMAKE_BINARY_DIR}/_deps/cccl-src/cub"
-             "${CUDAToolkit_INCLUDE_DIRS}")
+    PROPERTY
+      INCLUDE_DIRECTORIES
+        "${CMAKE_BINARY_DIR}/_deps/cccl-src/libcudacxx/include"
+        "${CMAKE_BINARY_DIR}/_deps/cccl-src/thrust"
+        "${CMAKE_BINARY_DIR}/_deps/cccl-src/cub"
+        "${CUDAToolkit_INCLUDE_DIRS}"
+  )
 endif()
 
 velox_add_library(
@@ -258,6 +262,18 @@ velox_link_libraries(
   velox_test_util
   velox_vector
 )
+
+if(VELOX_ENABLE_CUDF)
+  # Task.cpp owns the UCX output-queue lifecycle when cuDF exchange is enabled.
+  # The CMake option does not automatically define a C++ preprocessor macro;
+  # without this definition the guarded initialize/update/remove paths are
+  # silently omitted from production builds.
+  velox_compile_definitions(velox_exec PRIVATE VELOX_ENABLE_CUDF)
+  # Task.cpp includes the cuDF-backed queue manager under the same guard.
+  # Propagate cuDF's CCCL include directories (including <cuda/version>) to
+  # this target without exposing them to velox_exec consumers.
+  velox_link_libraries(velox_exec PRIVATE cudf::cudf)
+endif()
 
 if(VELOX_ENABLE_GEO)
   velox_compile_definitions(velox_exec PRIVATE VELOX_ENABLE_GEO)

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -42,11 +42,6 @@
 #include "velox/exec/TableScan.h"
 #include "velox/exec/Task.h"
 
-#ifdef VELOX_ENABLE_CUDF
-#include <velox/experimental/ucx-exchange/UcxOutputQueueManager.h>
-#include "velox/experimental/cudf/CudfConfig.h"
-#endif
-
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
@@ -107,6 +102,24 @@ splitListenerFactories() {
   static folly::Synchronized<std::vector<std::shared_ptr<SplitListenerFactory>>>
       kListenerFactories;
   return kListenerFactories;
+}
+
+folly::Synchronized<std::shared_ptr<PartitionedOutputBufferManager>>&
+partitionedOutputBufferManagerRegistry() {
+  static folly::Synchronized<std::shared_ptr<PartitionedOutputBufferManager>>
+      kManager;
+  return kManager;
+}
+
+std::shared_ptr<PartitionedOutputBufferManager>
+getRegisteredPartitionedOutputBufferManager(
+    const core::PartitionedOutputNode& node,
+    const core::QueryConfig& queryConfig) {
+  auto manager = partitionedOutputBufferManagerRegistry().withRLock(
+      [](const auto& registered) { return registered; });
+  return manager != nullptr && manager->supports(node, queryConfig)
+      ? std::move(manager)
+      : nullptr;
 }
 
 std::string errorMessageImpl(const std::exception_ptr& exception) {
@@ -213,7 +226,6 @@ std::string makeUuid() {
   return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
 }
 
-#ifdef VELOX_ENABLE_CUDF
 bool isUcxExchangePlanNode(
     const core::PlanNode* planNode,
     const core::PlanNodeId& planNodeId) {
@@ -234,7 +246,6 @@ bool isUcxExchangePlanNode(
   }
   return false;
 }
-#endif
 
 // Returns true if an operator is a hash join operator given 'operatorType'.
 bool isHashJoinOperator(const std::string& operatorType) {
@@ -307,6 +318,31 @@ void noMoreSplitsForStore(
 }
 
 } // namespace
+
+bool registerPartitionedOutputBufferManager(
+    const std::shared_ptr<PartitionedOutputBufferManager>& manager) {
+  VELOX_CHECK_NOT_NULL(manager);
+  return partitionedOutputBufferManagerRegistry().withWLock(
+      [&](auto& registered) {
+        if (registered != nullptr) {
+          return false;
+        }
+        registered = manager;
+        return true;
+      });
+}
+
+bool unregisterPartitionedOutputBufferManager(
+    const std::shared_ptr<PartitionedOutputBufferManager>& manager) {
+  return partitionedOutputBufferManagerRegistry().withWLock(
+      [&](auto& registered) {
+        if (registered != manager) {
+          return false;
+        }
+        registered.reset();
+        return true;
+      });
+}
 
 std::string executionModeString(Task::ExecutionMode mode) {
   switch (mode) {
@@ -1304,11 +1340,14 @@ void Task::createAndStartDrivers(uint32_t concurrentSplitGroups) {
 }
 
 void Task::initializePartitionOutput() {
-  VELOX_CHECK(
-      isRunningLocked(),
-      "Task {} has already been terminated before start: {}",
-      taskId_,
-      errorMessageLocked());
+  {
+    std::lock_guard<std::timed_mutex> l(mutex_);
+    VELOX_CHECK(
+        isRunningLocked(),
+        "Task {} has already been terminated before start: {}",
+        taskId_,
+        errorMessageLocked());
+  }
 
   auto bufferManager = bufferManager_.lock();
   VELOX_CHECK_NOT_NULL(
@@ -1317,6 +1356,8 @@ void Task::initializePartitionOutput() {
       "PartitionedOutputBufferManager was already destructed");
   std::shared_ptr<const core::PartitionedOutputNode> partitionedOutputNode{
       nullptr};
+  std::shared_ptr<PartitionedOutputBufferManager>
+      partitionedOutputBufferManager;
   int numOutputDrivers{0};
   {
     std::unique_lock<std::timed_mutex> l(mutex_);
@@ -1337,6 +1378,9 @@ void Task::initializePartitionOutput() {
         if (partitionedOutputNode != nullptr) {
           numDriversInPartitionedOutput_ = factory->numDrivers;
           groupedPartitionedOutput_ = factory->groupedExecution;
+          partitionedOutputBufferManager =
+              getRegisteredPartitionedOutputBufferManager(
+                  *partitionedOutputNode, queryCtx_->queryConfig());
           numOutputDrivers = factory->groupedExecution
               ? factory->numDrivers * planFragment_.numSplitGroups
               : factory->numDrivers;
@@ -1366,18 +1410,36 @@ void Task::initializePartitionOutput() {
         partitionedOutputNode->kind(),
         partitionedOutputNode->numPartitions(),
         numOutputDrivers);
-#ifdef VELOX_ENABLE_CUDF
-    if (velox::cudf_velox::CudfConfig::getInstance().enabled &&
-        velox::cudf_velox::CudfConfig::getInstance().exchange) {
-      auto queueMgr = facebook::velox::ucx_exchange::UcxOutputQueueManager::
-          getInstanceRef();
-      queueMgr->initializeTask(
-          shared_from_this(),
-          partitionedOutputNode->kind(),
-          partitionedOutputNode->numPartitions(),
-          numOutputDrivers);
+    if (partitionedOutputBufferManager != nullptr) {
+      try {
+        partitionedOutputBufferManager->initializeTask(
+            shared_from_this(),
+            partitionedOutputNode->kind(),
+            partitionedOutputNode->numPartitions(),
+            numOutputDrivers);
+      } catch (...) {
+        try {
+          partitionedOutputBufferManager->removeTask(taskId_);
+        } catch (...) {
+          LOG(ERROR) << "Failed to clean up partitioned output after "
+                        "initialization failed for task "
+                     << taskId_;
+        }
+        throw;
+      }
+
+      bool keepManager{false};
+      {
+        std::lock_guard<std::timed_mutex> l(mutex_);
+        if (isRunningLocked()) {
+          partitionedOutputBufferManager_ = partitionedOutputBufferManager;
+          keepManager = true;
+        }
+      }
+      if (!keepManager) {
+        partitionedOutputBufferManager->removeTask(taskId_);
+      }
     }
-#endif
   }
 }
 
@@ -1906,6 +1968,9 @@ void Task::noMoreSplits(const core::PlanNodeId& planNodeId) {
   std::vector<ContinuePromise> splitPromises;
   bool allFinished;
   std::shared_ptr<ExchangeClient> exchangeClient;
+  std::shared_ptr<PartitionedOutputBufferManager>
+      partitionedOutputBufferManager;
+  std::optional<uint32_t> numPartitionedOutputDrivers;
   {
     std::lock_guard<std::timed_mutex> l(mutex_);
 
@@ -1946,11 +2011,20 @@ void Task::noMoreSplits(const core::PlanNodeId& planNodeId) {
       }
     }
 
-    allFinished = checkNoMoreSplitGroupsLocked();
+    allFinished = checkNoMoreSplitGroupsLocked(numPartitionedOutputDrivers);
+
+    if (numPartitionedOutputDrivers.has_value()) {
+      partitionedOutputBufferManager = partitionedOutputBufferManager_;
+    }
 
     if (!isRunningLocked()) {
       exchangeClient = getExchangeClientLocked(planNodeId);
     }
+  }
+
+  if (partitionedOutputBufferManager != nullptr) {
+    partitionedOutputBufferManager->updateNumDrivers(
+        taskId_, numPartitionedOutputDrivers.value());
   }
 
   for (auto& promise : splitPromises) {
@@ -2160,7 +2234,8 @@ void Task::dropInputLocked(
   }
 }
 
-bool Task::checkNoMoreSplitGroupsLocked() {
+bool Task::checkNoMoreSplitGroupsLocked(
+    std::optional<uint32_t>& numPartitionedOutputDrivers) {
   if (isUngroupedExecution()) {
     return false;
   }
@@ -2178,9 +2253,11 @@ bool Task::checkNoMoreSplitGroupsLocked() {
     numTotalDrivers_ = seenSplitGroups_.size() * numDriversPerSplitGroup_ +
         numDriversUngrouped_;
     if (groupedPartitionedOutput_) {
+      const auto numOutputDrivers =
+          numDriversInPartitionedOutput_ * seenSplitGroups_.size();
       auto bufferManager = bufferManager_.lock();
-      bufferManager->updateNumDrivers(
-          taskId(), numDriversInPartitionedOutput_ * seenSplitGroups_.size());
+      bufferManager->updateNumDrivers(taskId(), numOutputDrivers);
+      numPartitionedOutputDrivers = numOutputDrivers;
     }
 
     return checkIfFinishedLocked();
@@ -2386,6 +2463,8 @@ bool Task::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
       bufferManager,
       "Unable to initialize task. "
       "DefaultOutputBufferManager was already destructed");
+  std::shared_ptr<PartitionedOutputBufferManager>
+      partitionedOutputBufferManager;
   {
     std::lock_guard<std::timed_mutex> l(mutex_);
     if (noMoreOutputBuffers_) {
@@ -2395,17 +2474,14 @@ bool Task::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
     if (noMoreBuffers) {
       noMoreOutputBuffers_ = true;
     }
+    partitionedOutputBufferManager = partitionedOutputBufferManager_;
   }
   auto result =
       bufferManager->updateOutputBuffers(taskId_, numBuffers, noMoreBuffers);
-#ifdef VELOX_ENABLE_CUDF
-  if (velox::cudf_velox::CudfConfig::getInstance().enabled &&
-      velox::cudf_velox::CudfConfig::getInstance().exchange) {
-    auto queueMgr =
-        facebook::velox::ucx_exchange::UcxOutputQueueManager::getInstanceRef();
-    queueMgr->updateOutputBuffers(taskId_, numBuffers, noMoreBuffers);
+  if (partitionedOutputBufferManager != nullptr) {
+    partitionedOutputBufferManager->updateOutputBuffers(
+        taskId_, numBuffers, noMoreBuffers);
   }
-#endif
   return result;
 }
 
@@ -2831,11 +2907,9 @@ ContinueFuture Task::terminate(TaskState terminalState) {
 
       // Process remaining remote splits.
       if (getExchangeClientLocked(nodeId) != nullptr) {
-#ifdef VELOX_ENABLE_CUDF
         if (isUcxExchangePlanNode(planFragment_.planNode.get(), nodeId)) {
           continue;
         }
-#endif
         std::vector<exec::Split> splits;
         for (auto& [groupId, store] : state.groupSplitsStores) {
           if (!store) {
@@ -2904,6 +2978,13 @@ ContinueFuture Task::terminate(TaskState terminalState) {
 
 void Task::maybeRemoveFromOutputBufferManager() {
   if (hasPartitionedOutput()) {
+    std::shared_ptr<PartitionedOutputBufferManager>
+        partitionedOutputBufferManager;
+    {
+      std::lock_guard<std::timed_mutex> l(mutex_);
+      partitionedOutputBufferManager =
+          std::move(partitionedOutputBufferManager_);
+    }
     if (auto bufferManager = bufferManager_.lock()) {
       // Capture output buffer stats before deleting the buffer.
       {
@@ -2915,23 +2996,30 @@ void Task::maybeRemoveFromOutputBufferManager() {
       }
       bufferManager->removeTask(taskId_);
     }
-#ifdef VELOX_ENABLE_CUDF
-    if (velox::cudf_velox::CudfConfig::getInstance().enabled &&
-        velox::cudf_velox::CudfConfig::getInstance().exchange) {
-      // Capture output queue stats before deleting the queue.
-      auto queueMgr = facebook::velox::ucx_exchange::UcxOutputQueueManager::
-          getInstanceRef();
-      // Capture output buffer stats before deleting the buffer.
-      {
-        std::lock_guard<std::timed_mutex> l(mutex_);
-        auto optStats = queueMgr->stats(taskId_);
+    if (partitionedOutputBufferManager != nullptr) {
+      try {
+        auto optStats = partitionedOutputBufferManager->stats(taskId_);
         if (optStats.has_value() && optStats.value().totalPagesSent > 0) {
+          std::lock_guard<std::timed_mutex> l(mutex_);
           taskStats_.outputBufferStats = optStats;
         }
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to collect partitioned output stats for task "
+                   << taskId_ << ": " << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Failed to collect partitioned output stats for task "
+                   << taskId_ << ": unknown exception";
       }
-      queueMgr->removeTask(taskId_);
+      try {
+        partitionedOutputBufferManager->removeTask(taskId_);
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to remove partitioned output for task " << taskId_
+                   << ": " << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Failed to remove partitioned output for task " << taskId_
+                   << ": unknown exception";
+      }
     }
-#endif
   }
 }
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -33,6 +33,45 @@
 namespace facebook::velox::exec {
 
 class DefaultOutputBufferManager;
+class Task;
+
+/// Extension point for non-default partitioned-output transports. A Task
+/// selects one registered manager at output initialization and retains it for
+/// the lifetime of that output.
+class PartitionedOutputBufferManager {
+ public:
+  virtual ~PartitionedOutputBufferManager() = default;
+
+  virtual bool supports(
+      const core::PartitionedOutputNode& node,
+      const core::QueryConfig& queryConfig) const = 0;
+
+  virtual void initializeTask(
+      std::shared_ptr<Task> task,
+      core::PartitionedOutputNode::Kind kind,
+      int numPartitions,
+      int numOutputDrivers) = 0;
+
+  virtual void updateOutputBuffers(
+      const std::string& taskId,
+      int numBuffers,
+      bool noMoreBuffers) = 0;
+
+  virtual void updateNumDrivers(
+      const std::string& taskId,
+      uint32_t numOutputDrivers) = 0;
+
+  virtual std::optional<OutputBuffer::Stats> stats(
+      const std::string& taskId) = 0;
+
+  virtual void removeTask(const std::string& taskId) = 0;
+};
+
+bool registerPartitionedOutputBufferManager(
+    const std::shared_ptr<PartitionedOutputBufferManager>& manager);
+
+bool unregisterPartitionedOutputBufferManager(
+    const std::shared_ptr<PartitionedOutputBufferManager>& manager);
 
 class HashJoinBridge;
 class IndexLookupJoinBridge;
@@ -1079,7 +1118,8 @@ class Task : public std::enable_shared_from_this<Task> {
   // kRunning state, but no more split groups are commit and all drivers
   // finished processing and all output has been consumed. In other words,
   // returns true if task should transition to kFinished state.
-  bool checkNoMoreSplitGroupsLocked();
+  bool checkNoMoreSplitGroupsLocked(
+      std::optional<uint32_t>& numPartitionedOutputDrivers);
 
   // Notifies listeners that the task is now complete.
   void onTaskCompletion();
@@ -1401,6 +1441,8 @@ class Task : public std::enable_shared_from_this<Task> {
   // Execution mode. In this case we will need to update the number of output
   // drivers in the end. False otherwise.
   bool groupedPartitionedOutput_{false};
+  std::shared_ptr<PartitionedOutputBufferManager>
+      partitionedOutputBufferManager_;
   // The number of splits groups we run concurrently.
   uint32_t concurrentSplitGroups_{1};
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/Task.h"
+#include <folly/ScopeGuard.h>
 #include "folly/synchronization/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
@@ -565,6 +566,174 @@ class TaskTest : public HiveConnectorTestBase {
     return {task, results};
   }
 };
+
+namespace {
+
+struct TestOutputManagerState {
+  std::atomic_int supportsCalls{0};
+  std::atomic_int initializeCalls{0};
+  std::atomic_int updateBuffersCalls{0};
+  std::atomic_int updateDriversCalls{0};
+  std::atomic_int statsCalls{0};
+  std::atomic_int removeCalls{0};
+  std::atomic_int initialDrivers{0};
+  std::atomic_int lastDrivers{0};
+  std::atomic_int lastBuffers{0};
+  std::atomic_int sequence{0};
+  std::atomic_int statsSequence{0};
+  std::atomic_int removeSequence{0};
+  std::atomic_bool noMoreBuffers{false};
+};
+
+class TestOutputManager final : public PartitionedOutputBufferManager {
+ public:
+  explicit TestOutputManager(std::shared_ptr<TestOutputManagerState> state)
+      : state_(std::move(state)) {}
+
+  bool supports(const core::PartitionedOutputNode&, const core::QueryConfig&)
+      const override {
+    ++state_->supportsCalls;
+    return true;
+  }
+
+  void initializeTask(
+      std::shared_ptr<Task>,
+      core::PartitionedOutputNode::Kind,
+      int,
+      int numOutputDrivers) override {
+    ++state_->initializeCalls;
+    state_->initialDrivers = numOutputDrivers;
+  }
+
+  void updateOutputBuffers(
+      const std::string&,
+      int numBuffers,
+      bool noMoreBuffers) override {
+    ++state_->updateBuffersCalls;
+    state_->lastBuffers = numBuffers;
+    state_->noMoreBuffers = noMoreBuffers;
+  }
+
+  void updateNumDrivers(const std::string&, uint32_t numOutputDrivers)
+      override {
+    ++state_->updateDriversCalls;
+    state_->lastDrivers = numOutputDrivers;
+  }
+
+  std::optional<OutputBuffer::Stats> stats(const std::string&) override {
+    ++state_->statsCalls;
+    state_->statsSequence = ++state_->sequence;
+    return OutputBuffer::Stats(
+        core::PartitionedOutputNode::Kind::kBroadcast,
+        true,
+        true,
+        true,
+        0,
+        0,
+        123,
+        456,
+        7,
+        0,
+        0,
+        {});
+  }
+
+  void removeTask(const std::string&) override {
+    ++state_->removeCalls;
+    state_->removeSequence = ++state_->sequence;
+  }
+
+ private:
+  const std::shared_ptr<TestOutputManagerState> state_;
+};
+
+} // namespace
+
+TEST_F(TaskTest, partitionedOutputManagerLifecycle) {
+  auto state = std::make_shared<TestOutputManagerState>();
+  auto manager = std::make_shared<TestOutputManager>(state);
+  ASSERT_TRUE(registerPartitionedOutputBufferManager(manager));
+  ASSERT_FALSE(registerPartitionedOutputBufferManager(manager));
+  auto unregister = folly::makeGuard(
+      [&]() { unregisterPartitionedOutputBufferManager(manager); });
+
+  auto plan = PlanBuilder()
+                  .tableScan(ROW({"c0"}, {BIGINT()}))
+                  .partitionedOutputBroadcast()
+                  .planFragment();
+  auto task = Task::create(
+      "partitioned-output-manager-lifecycle",
+      std::move(plan),
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel,
+      Consumer{});
+  task->start(2, 1);
+
+  EXPECT_EQ(state->supportsCalls, 1);
+  EXPECT_EQ(state->initializeCalls, 1);
+  EXPECT_EQ(state->initialDrivers, 2);
+  EXPECT_TRUE(task->updateOutputBuffers(3, true));
+  EXPECT_EQ(state->updateBuffersCalls, 1);
+  EXPECT_EQ(state->lastBuffers, 3);
+  EXPECT_TRUE(state->noMoreBuffers);
+
+  task->requestAbort().wait();
+  EXPECT_EQ(state->statsCalls, 1);
+  EXPECT_EQ(state->removeCalls, 1);
+  EXPECT_LT(state->statsSequence, state->removeSequence);
+  const auto stats = task->taskStats().outputBufferStats;
+  ASSERT_TRUE(stats.has_value());
+  EXPECT_EQ(stats->totalBytesSent, 123);
+  EXPECT_EQ(stats->totalRowsSent, 456);
+  EXPECT_EQ(stats->totalPagesSent, 7);
+
+  task->requestAbort().wait();
+  EXPECT_EQ(state->removeCalls, 1);
+  EXPECT_TRUE(unregisterPartitionedOutputBufferManager(manager));
+  unregister.dismiss();
+  EXPECT_FALSE(unregisterPartitionedOutputBufferManager(manager));
+}
+
+TEST_F(TaskTest, groupedPartitionedOutputUpdatesManagerDriverCount) {
+  auto state = std::make_shared<TestOutputManagerState>();
+  auto manager = std::make_shared<TestOutputManager>(state);
+  ASSERT_TRUE(registerPartitionedOutputBufferManager(manager));
+  auto unregister = folly::makeGuard(
+      [&]() { unregisterPartitionedOutputBufferManager(manager); });
+
+  auto data = makeRowVector({makeFlatVector<int64_t>({1})});
+  auto file = TempFilePath::create();
+  writeToFile(file->getPath(), data);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .partitionedOutput({}, 1)
+                  .planFragment();
+  plan.executionStrategy = core::ExecutionStrategy::kGrouped;
+  plan.groupedExecutionLeafNodeIds.emplace(scanNodeId);
+  plan.numSplitGroups = 4;
+  auto task = Task::create(
+      "grouped-partitioned-output-manager",
+      std::move(plan),
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel,
+      Consumer{});
+  task->start(2, 1);
+  EXPECT_EQ(state->initialDrivers, 8);
+
+  task->addSplit(
+      scanNodeId, exec::Split(makeHiveConnectorSplit(file->getPath()), 3));
+  task->noMoreSplitsForGroup(scanNodeId, 3);
+  task->noMoreSplits(scanNodeId);
+
+  EXPECT_GE(state->updateDriversCalls, 1);
+  EXPECT_EQ(state->lastDrivers, 2);
+  task->requestAbort().wait();
+}
 
 TEST_F(TaskTest, toJson) {
   auto plan = PlanBuilder()

--- a/velox/experimental/cudf/CMakeLists.txt
+++ b/velox/experimental/cudf/CMakeLists.txt
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Velox cuDF targets link NVTX directly. Do not rely on cuDF or RMM to expose
+# their directory-scoped imported target to this directory.
+find_package(nvtx3 REQUIRED)
+
 add_subdirectory(connectors)
 add_subdirectory(exec)
 add_subdirectory(expression)

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -45,6 +45,8 @@ struct CudfConfig {
   static constexpr const char* kCudfLogFallback{"cudf.log_fallback"};
   static constexpr const char* kCudfBatchSizeMinThreshold{
       "cudf.batch_size_min_threshold"};
+  static constexpr const char* kCudfBatchSizeMinThresholdBytes{
+      "cudf.batch_size_min_threshold_bytes"};
   static constexpr const char* kCudfBatchSizeMaxThreshold{
       "cudf.batch_size_max_threshold"};
   static constexpr const char* kCudfConcatOptimizationEnabled{
@@ -168,6 +170,11 @@ struct CudfConfig {
   /// Minimum rows to accumulate before GPU-side concatenation in
   /// `CudfBatchConcat` (default 100k).
   int32_t batchSizeMinThreshold{100000};
+
+  /// Target bytes to accumulate before GPU-side concatenation. Zero disables
+  /// the byte threshold. When both row and byte thresholds are configured,
+  /// reaching either one flushes the batch.
+  uint64_t batchSizeMinThresholdBytes{0};
 
   /// Maximum rows allowed in a concatenated batch (user configurable).
   /// When not set, cuDF's own `size_type::max()` is used.

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -47,6 +47,8 @@ struct CudfConfig {
       "cudf.batch_size_min_threshold"};
   static constexpr const char* kCudfExchangeBatchSizeMinThreshold{
       "cudf.exchange_batch_size_min_threshold"};
+  static constexpr const char* kCudfExchangeBatchSizeMinThresholdBytes{
+      "cudf.exchange_batch_size_min_threshold_bytes"};
   static constexpr const char* kCudfBatchSizeMinThresholdBytes{
       "cudf.batch_size_min_threshold_bytes"};
   static constexpr const char* kCudfBatchSizeMaxThreshold{
@@ -186,6 +188,10 @@ struct CudfConfig {
   /// this below the aggregation target because a fragment can buffer several
   /// inbound exchanges concurrently while its join builds are still live.
   int32_t exchangeBatchSizeMinThreshold{32000000};
+
+  /// Target bytes to accumulate immediately after a UCX Exchange. Zero
+  /// disables the exchange-specific byte threshold.
+  uint64_t exchangeBatchSizeMinThresholdBytes{0};
 
   /// Target bytes to accumulate before GPU-side concatenation. Zero disables
   /// the byte threshold. When both row and byte thresholds are configured,

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -45,6 +45,8 @@ struct CudfConfig {
   static constexpr const char* kCudfLogFallback{"cudf.log_fallback"};
   static constexpr const char* kCudfBatchSizeMinThreshold{
       "cudf.batch_size_min_threshold"};
+  static constexpr const char* kCudfExchangeBatchSizeMinThreshold{
+      "cudf.exchange_batch_size_min_threshold"};
   static constexpr const char* kCudfBatchSizeMinThresholdBytes{
       "cudf.batch_size_min_threshold_bytes"};
   static constexpr const char* kCudfBatchSizeMaxThreshold{
@@ -59,6 +61,12 @@ struct CudfConfig {
       "cudf.order_by_merge_fan_in"};
   static constexpr const char* kCudfWindowSortedRunBytes{
       "cudf.window.sorted_run_bytes"};
+  static constexpr const char* kCudfOrderByOutputChunkBytes{
+      "cudf.order_by_output_chunk_bytes"};
+  static constexpr const char* kCudfOrderByMaxOutputRows{
+      "cudf.order_by_max_output_rows"};
+  static constexpr const char* kCudfExchangeConcatOptimizationEnabled{
+      "cudf.exchange_concat_optimization_enabled"};
   static constexpr const char* kCudfTimestampUnit{"cudf.timestamp_unit"};
   // The value could be either spark or presto.
   static constexpr const char* kCudfFunctionEngine{"cudf.function_engine"};
@@ -107,7 +115,7 @@ struct CudfConfig {
   std::string memoryResource{"async"};
 
   /// The initial percent of GPU memory to allocate for pool or arena memory
-  /// resources.
+  /// resources, and the retained-memory release threshold for async.
   int32_t memoryPercent{50};
 
   /// Memory resource for output vectors. When set to a value different from
@@ -142,8 +150,7 @@ struct CudfConfig {
   /// Whether to log a reason for falling back to Velox CPU execution.
   bool logFallback{true};
 
-  /// Whether to insert CudfBatchConcat operators before supported Cudf
-  /// operators.
+  /// Whether to insert CudfBatchConcat before supported Cudf operators.
   /// This can improve performance by reducing the number of cuda kernel
   /// launches on addInput of certain operators by collecting a minimum number
   /// of rows before concatenating and passing on to the next operator.
@@ -167,9 +174,18 @@ struct CudfConfig {
   /// independently sorted run.
   uint64_t windowSortedRunBytes{3ULL << 30};
 
+  /// Maximum bytes and rows returned by one OrderBy output batch.
+  uint64_t orderByOutputChunkBytes{32ULL << 20};
+  int32_t orderByMaxOutputRows{262144};
+
   /// Minimum rows to accumulate before GPU-side concatenation in
   /// `CudfBatchConcat` (default 100k).
   int32_t batchSizeMinThreshold{100000};
+
+  /// Target rows for CudfBatchConcat immediately after a UCX Exchange. Keep
+  /// this below the aggregation target because a fragment can buffer several
+  /// inbound exchanges concurrently while its join builds are still live.
+  int32_t exchangeBatchSizeMinThreshold{32000000};
 
   /// Target bytes to accumulate before GPU-side concatenation. Zero disables
   /// the byte threshold. When both row and byte thresholds are configured,
@@ -202,6 +218,12 @@ struct CudfConfig {
 
   /// VLOG level for ucx-exchange source files.
   int32_t exchangeLogLevel{0};
+
+  /// Whether to insert CudfBatchConcat immediately after ordinary UCX
+  /// Exchange sources. Keep this independent from aggregation-side concat.
+  /// This field is intentionally appended so incremental builds that reuse
+  /// stable UCX objects preserve the offsets of every pre-existing field.
+  bool exchangeConcatOptimizationEnabled{true};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.cpp
@@ -35,7 +35,8 @@ std::string stripFilePrefix(const std::string& targetPath) {
 } // namespace
 
 std::string CudfHiveConnectorSplit::toString() const {
-  return fmt::format("CudfHive: {}", filePath);
+  return fmt::format(
+      "CudfHive: {} ({} files)", filePath, 1 + coalescedFiles.size());
 }
 
 std::string CudfHiveConnectorSplit::getFileName() const {
@@ -44,7 +45,14 @@ std::string CudfHiveConnectorSplit::getFileName() const {
 }
 
 uint64_t CudfHiveConnectorSplit::size() const {
-  return length;
+  if (length == std::numeric_limits<uint64_t>::max()) {
+    return length;
+  }
+  uint64_t total = length;
+  for (const auto& file : coalescedFiles) {
+    total += file.length;
+  }
+  return total;
 }
 
 CudfHiveConnectorSplit::CudfHiveConnectorSplit(
@@ -53,13 +61,15 @@ CudfHiveConnectorSplit::CudfHiveConnectorSplit(
     uint64_t _start,
     uint64_t _length,
     int64_t _splitWeight,
-    const std::unordered_map<std::string, std::string>& _infoColumns)
+    const std::unordered_map<std::string, std::string>& _infoColumns,
+    std::vector<CudfCoalescedFile> _coalescedFiles)
     : facebook::velox::connector::ConnectorSplit(connectorId, _splitWeight),
       filePath(stripFilePrefix(_filePath)),
       start(_start),
       length(_length),
       cudfSourceInfo(std::make_unique<cudf::io::source_info>(filePath)),
-      infoColumns(_infoColumns) {}
+      infoColumns(_infoColumns),
+      coalescedFiles(std::move(_coalescedFiles)) {}
 
 // static
 std::shared_ptr<CudfHiveConnectorSplit> CudfHiveConnectorSplit::create(
@@ -75,8 +85,23 @@ std::shared_ptr<CudfHiveConnectorSplit> CudfHiveConnectorSplit::create(
     infoColumns[key.asString()] = value.asString();
   }
 
+  std::vector<CudfCoalescedFile> coalescedFiles;
+  if (obj.count("coalescedFiles")) {
+    for (const auto& file : obj["coalescedFiles"]) {
+      coalescedFiles.push_back(
+          {file["filePath"].asString(),
+           static_cast<uint64_t>(file["length"].asInt())});
+    }
+  }
+
   return std::make_shared<CudfHiveConnectorSplit>(
-      connectorId, filePath, start, length, splitWeight, infoColumns);
+      connectorId,
+      filePath,
+      start,
+      length,
+      splitWeight,
+      infoColumns,
+      std::move(coalescedFiles));
 }
 
 folly::dynamic CudfHiveConnectorSplit::serialize() const {
@@ -92,6 +117,14 @@ folly::dynamic CudfHiveConnectorSplit::serialize() const {
     infoColumnsObj[key] = value;
   }
   obj["infoColumns"] = infoColumnsObj;
+
+  folly::dynamic coalescedFilesObj = folly::dynamic::array;
+  for (const auto& file : coalescedFiles) {
+    coalescedFilesObj.push_back(
+        folly::dynamic::object("filePath", file.filePath)(
+            "length", static_cast<int64_t>(file.length)));
+  }
+  obj["coalescedFiles"] = std::move(coalescedFilesObj);
 
   return obj;
 }

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
@@ -28,8 +28,14 @@ struct source_info;
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace facebook::velox::cudf_velox::connector::hive {
+
+struct CudfCoalescedFile {
+  std::string filePath;
+  uint64_t length;
+};
 
 struct CudfHiveConnectorSplit
     : public facebook::velox::connector::ConnectorSplit {
@@ -44,13 +50,17 @@ struct CudfHiveConnectorSplit
   /// associated with the CudfHiveConnectorSplit.
   std::unordered_map<std::string, std::string> infoColumns = {};
 
+  /// Additional whole Parquet files decoded by the same cuDF reader.
+  std::vector<CudfCoalescedFile> coalescedFiles;
+
   CudfHiveConnectorSplit(
       const std::string& connectorId,
       const std::string& _filePath,
       uint64_t _start = 0,
       uint64_t _length = std::numeric_limits<uint64_t>::max(),
       int64_t _splitWeight = 0,
-      const std::unordered_map<std::string, std::string>& _infoColumns = {});
+      const std::unordered_map<std::string, std::string>& _infoColumns = {},
+      std::vector<CudfCoalescedFile> _coalescedFiles = {});
 
   std::string toString() const override;
   std::string getFileName() const;

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -384,8 +384,7 @@ std::unordered_map<std::string, RuntimeMetric>
 CudfHiveDataSource::getRuntimeStats() {
   auto result = runtimeStats_.toRuntimeMetricMap();
   if (numFilesCoalesced_ > 0) {
-    result.emplace(
-        "numFilesCoalesced", RuntimeMetric(numFilesCoalesced_));
+    result.emplace("numFilesCoalesced", RuntimeMetric(numFilesCoalesced_));
   }
   result.insert({
       {std::string(connector::hive::HiveDataSource::kTotalScanTime),

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -292,6 +292,10 @@ void CudfHiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   cudfSplitReader_ = createCudfSplitReader();
   cudfSplitReader_->prepareSplit(runtimeStats_);
+  numFilesCoalesced_ += split_->coalescedFiles.size();
+  for (const auto& file : split_->coalescedFiles) {
+    completedBytes_ += file.length;
+  }
 
   // TODO: `completedBytes_` should be updated in `next()` as we read more and
   // more table bytes
@@ -379,6 +383,10 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
 std::unordered_map<std::string, RuntimeMetric>
 CudfHiveDataSource::getRuntimeStats() {
   auto result = runtimeStats_.toRuntimeMetricMap();
+  if (numFilesCoalesced_ > 0) {
+    result.emplace(
+        "numFilesCoalesced", RuntimeMetric(numFilesCoalesced_));
+  }
   result.insert({
       {std::string(connector::hive::HiveDataSource::kTotalScanTime),
        RuntimeMetric(

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
@@ -125,6 +125,7 @@ class CudfHiveDataSource : public DataSource, public NvtxHelper {
 
   size_t completedRows_{0};
   size_t completedBytes_{0};
+  int64_t numFilesCoalesced_{0};
 
   dwio::common::RuntimeStatistics runtimeStats_;
 

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -59,8 +59,8 @@ std::size_t multiFileChunkReadLimit(
   // scans turns a split containing thousands of small files into hundreds of
   // tiny decode calls. Keep the safety bound, but do not shrink the reader
   // below its 256 MiB multi-file default.
-  return facebook::velox::cudf_velox::connector::hive::
-      multiFileChunkReadLimit(configuredLimit, batchTarget);
+  return facebook::velox::cudf_velox::connector::hive::multiFileChunkReadLimit(
+      configuredLimit, batchTarget);
 }
 
 } // namespace
@@ -260,7 +260,6 @@ void CudfSplitReader::setupCudfDataSource() {
 
 std::shared_ptr<cudf::io::datasource> CudfSplitReader::createCudfDataSource(
     const std::string& filePath) {
-
   const auto useBufferedInput = cudfHiveConfig_->useBufferedInputSession(
       connectorQueryCtx_->sessionProperties());
 
@@ -275,8 +274,7 @@ std::shared_ptr<cudf::io::datasource> CudfSplitReader::createCudfDataSource(
 
   // Use KvikIO data source if we don't want to use the BufferedInput source
   if (not useBufferedInput) {
-    VLOG(1) << fmt::format(
-        "Using KvikIO data source for file: {}", filePath);
+    VLOG(1) << fmt::format("Using KvikIO data source for file: {}", filePath);
     return std::move(
         cudf::io::make_datasources(cudf::io::source_info{filePath}).front());
   }

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -219,6 +219,7 @@ void CudfSplitReader::resetSplit() {
   exptSplitReader_.reset();
   hybridScanState_.reset();
   dataSource_.reset();
+  coalescedDataSources_.clear();
   fileMetaData_.clear();
 }
 
@@ -231,32 +232,40 @@ void CudfSplitReader::setupCudfDataSource() {
     return;
   }
 
+  dataSource_ = createCudfDataSource(split_->filePath);
+  coalescedDataSources_.reserve(split_->coalescedFiles.size());
+  for (const auto& file : split_->coalescedFiles) {
+    coalescedDataSources_.push_back(createCudfDataSource(file.filePath));
+  }
+}
+
+std::shared_ptr<cudf::io::datasource> CudfSplitReader::createCudfDataSource(
+    const std::string& filePath) {
+
   const auto useBufferedInput = cudfHiveConfig_->useBufferedInputSession(
       connectorQueryCtx_->sessionProperties());
 
   VELOX_CHECK(
-      not isAbfsPath(split_->filePath) or useBufferedInput,
+      not isAbfsPath(filePath) or useBufferedInput,
       "ABFS blobs require buffered input data source. "
       "Set the session property '{}' (or connector property '{}') to 'true'. "
       "Blob Path: {}.",
       CudfHiveConfig::kUseBufferedInputSession,
       CudfHiveConfig::kUseBufferedInput,
-      split_->filePath);
+      filePath);
 
   // Use KvikIO data source if we don't want to use the BufferedInput source
   if (not useBufferedInput) {
     VLOG(1) << fmt::format(
-        "Using KvikIO data source for file: {}", split_->filePath);
-    dataSource_ = std::move(
-        cudf::io::make_datasources(cudf::io::source_info{split_->filePath})
-            .front());
-    return;
+        "Using KvikIO data source for file: {}", filePath);
+    return std::move(
+        cudf::io::make_datasources(cudf::io::source_info{filePath}).front());
   }
 
   auto fileHandleCachePtr = FileHandleCachedPtr{};
   try {
     const auto fileHandleKey = FileHandleKey{
-        .filename = split_->filePath,
+        .filename = filePath,
         .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
     auto fileProperties = FileProperties{};
     fileHandleCachePtr = fileHandleFactory_->generate(
@@ -264,23 +273,21 @@ void CudfSplitReader::setupCudfDataSource() {
     VELOX_CHECK_NOT_NULL(fileHandleCachePtr.get());
   } catch (const VeloxRuntimeError& e) {
     // ABFS blobs can not fall back to KvikIO. Throw the original error.
-    if (isAbfsPath(split_->filePath)) {
+    if (isAbfsPath(filePath)) {
       VELOX_USER_FAIL(
           "Failed to generate file handle cache for ABFS blob. Ensure "
           "registerAbfsFileSystem() and registerAzureClientProvider() have "
           "been called and the connector config provides Azure credentials. "
           "Blob path: {}. Error: {}.",
-          split_->filePath,
+          filePath,
           e.what());
     }
 
     LOG(WARNING) << fmt::format(
         "Failed to generate file handle cache for file. Falling back to KvikIO. Path: {}",
-        split_->filePath);
-    dataSource_ = std::move(
-        cudf::io::make_datasources(cudf::io::source_info{split_->filePath})
-            .front());
-    return;
+        filePath);
+    return std::move(
+        cudf::io::make_datasources(cudf::io::source_info{filePath}).front());
   }
 
   // Here we keep adding new entries to CacheTTLController when new
@@ -301,23 +308,32 @@ void CudfSplitReader::setupCudfDataSource() {
           executor_);
   if (not bufferedInput) {
     // ABFS blobs can not fall back to KvikIO
-    if (isAbfsPath(split_->filePath)) {
+    if (isAbfsPath(filePath)) {
       VELOX_USER_FAIL(
           "Failed to create buffered input data source for the ABFS blob. Ensure that the registered "
           "BufferedInputBuilder is ABFS-aware. Blob path: {}.",
-          split_->filePath);
+          filePath);
     }
 
     LOG(WARNING) << fmt::format(
         "Failed to create buffered input data source for file. Falling back to the KvikIO. Path: {}",
-        split_->filePath);
-    dataSource_ = std::move(
-        cudf::io::make_datasources(cudf::io::source_info{split_->filePath})
-            .front());
-    return;
+        filePath);
+    return std::move(
+        cudf::io::make_datasources(cudf::io::source_info{filePath}).front());
   }
-  dataSource_ =
-      std::make_unique<BufferedInputDataSource>(std::move(bufferedInput));
+  return std::make_unique<BufferedInputDataSource>(std::move(bufferedInput));
+}
+
+std::vector<std::unique_ptr<cudf::io::datasource>>
+CudfSplitReader::makeDataSourceViews() {
+  VELOX_CHECK_NOT_NULL(dataSource_);
+  std::vector<std::unique_ptr<cudf::io::datasource>> sources;
+  sources.reserve(1 + coalescedDataSources_.size());
+  sources.push_back(cudf::io::datasource::create(dataSource_.get()));
+  for (const auto& source : coalescedDataSources_) {
+    sources.push_back(cudf::io::datasource::create(source.get()));
+  }
+  return sources;
 }
 
 void CudfSplitReader::setupReaderOptions() {
@@ -337,10 +353,14 @@ void CudfSplitReader::setupReaderOptions() {
           .build();
 
   // Set skip_bytes and num_bytes if available
-  if (split_->start != 0) {
+  // cuDF only supports byte bounds for a single source. Multi-file splits are
+  // admitted only after Gluten verifies that every Iceberg task covers the
+  // complete file, so read each source without per-file bounds here.
+  if (split_->coalescedFiles.empty() && split_->start != 0) {
     readerOptions_.set_skip_bytes(split_->start);
   }
-  if (split_->size() != std::numeric_limits<uint64_t>::max()) {
+  if (split_->coalescedFiles.empty() &&
+      split_->size() != std::numeric_limits<uint64_t>::max()) {
     readerOptions_.set_num_bytes(split_->size());
   }
 
@@ -372,8 +392,7 @@ void CudfSplitReader::fileMetaDatas() {
       "CudfSplitReader does not have a datasource. Call setupCudfDataSource() first");
 
   // Wrap the existing datasource without transferring ownership.
-  std::vector<std::unique_ptr<cudf::io::datasource>> sources;
-  sources.push_back(cudf::io::datasource::create(dataSource_.get()));
+  auto sources = makeDataSourceViews();
   fileMetaData_ = cudf::io::read_parquet_footers(sources);
   VELOX_CHECK_GE(
       fileMetaData_.size(),
@@ -388,8 +407,7 @@ void CudfSplitReader::createCudfReader() {
   // Setup reader options
   setupReaderOptions();
 
-  std::vector<std::unique_ptr<cudf::io::datasource>> sources;
-  sources.push_back(cudf::io::datasource::create(dataSource_.get()));
+  auto sources = makeDataSourceViews();
 
   // Create a parquet reader
   splitReader_ = std::make_unique<cudf::io::chunked_parquet_reader>(

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/connectors/hive/CudfSplitReader.h"
 #include "velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h"
@@ -45,6 +46,24 @@
 #include <memory>
 
 namespace facebook::velox::cudf_velox::connector::hive {
+
+namespace {
+
+std::size_t multiFileChunkReadLimit(
+    std::size_t configuredLimit,
+    const config::ConfigBase* session) {
+  const auto batchTarget = session->get<uint64_t>(
+      CudfConfig::kCudfBatchSizeMinThresholdBytes,
+      CudfConfig::getInstance().batchSizeMinThresholdBytes);
+  // The compute batch threshold is commonly 8 MiB. Reusing it directly for
+  // scans turns a split containing thousands of small files into hundreds of
+  // tiny decode calls. Keep the safety bound, but do not shrink the reader
+  // below its 256 MiB multi-file default.
+  return facebook::velox::cudf_velox::connector::hive::
+      multiFileChunkReadLimit(configuredLimit, batchTarget);
+}
+
+} // namespace
 
 using namespace facebook::velox::connector;
 using namespace facebook::velox::connector::hive;
@@ -409,10 +428,20 @@ void CudfSplitReader::createCudfReader() {
 
   auto sources = makeDataSourceViews();
 
+  auto chunkReadLimit = cudfHiveConfig_->maxChunkReadLimitSession(
+      connectorQueryCtx_->sessionProperties());
+  if (!split_->coalescedFiles.empty()) {
+    // An unbounded reader is safe for one physical file, but a coalesced split
+    // can contain many files. Decoding all of them into one table bypasses the
+    // downstream byte thresholds and makes a single scan batch consume most
+    // of the GPU before aggregation can apply backpressure.
+    chunkReadLimit = multiFileChunkReadLimit(
+        chunkReadLimit, connectorQueryCtx_->sessionProperties());
+  }
+
   // Create a parquet reader
   splitReader_ = std::make_unique<cudf::io::chunked_parquet_reader>(
-      cudfHiveConfig_->maxChunkReadLimitSession(
-          connectorQueryCtx_->sessionProperties()),
+      chunkReadLimit,
       cudfHiveConfig_->maxPassReadLimitSession(
           connectorQueryCtx_->sessionProperties()),
       std::move(sources),

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -95,6 +95,13 @@ class CudfSplitReader : public NvtxHelper {
   // Setup the cuDF data source
   void setupCudfDataSource();
 
+  // Create a data source for one physical file.
+  std::shared_ptr<cudf::io::datasource> createCudfDataSource(
+      const std::string& filePath);
+
+  // Return non-owning wrappers for every source in this split.
+  std::vector<std::unique_ptr<cudf::io::datasource>> makeDataSourceViews();
+
   // Read file metadatas.
   void fileMetaDatas();
 
@@ -135,6 +142,7 @@ class CudfSplitReader : public NvtxHelper {
 
   // cuDF split reader stuff.
   std::shared_ptr<cudf::io::datasource> dataSource_;
+  std::vector<std::shared_ptr<cudf::io::datasource>> coalescedDataSources_;
   cudf::io::parquet_reader_options readerOptions_;
   CudfParquetReaderPtr splitReader_;
   CudfHybridScanReaderPtr exptSplitReader_;

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h
@@ -31,9 +31,21 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <algorithm>
 #include <vector>
 
 namespace facebook::velox::cudf_velox::connector::hive {
+
+constexpr std::size_t kDefaultMultiFileChunkReadLimit = 256UL << 20;
+
+inline std::size_t multiFileChunkReadLimit(
+    std::size_t configuredLimit,
+    std::size_t batchTarget) {
+  if (configuredLimit > 0) {
+    return configuredLimit;
+  }
+  return std::max(batchTarget, kDefaultMultiFileChunkReadLimit);
+}
 
 // ---------------- Internal helper ----------------
 // A cudf::io::datasource that serves bytes via Velox BufferedInput so that

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
@@ -29,6 +29,13 @@ namespace velox_connector = ::facebook::velox::connector;
 namespace velox_hive = ::facebook::velox::connector::hive;
 namespace velox_iceberg = ::facebook::velox::connector::hive::iceberg;
 
+namespace {
+std::string stripFilePrefix(const std::string& path) {
+  constexpr std::string_view prefix{"file:"};
+  return path.rfind(prefix, 0) == 0 ? path.substr(prefix.size()) : path;
+}
+} // namespace
+
 CudfIcebergDataSource::CudfIcebergDataSource(
     const RowTypePtr& outputType,
     const velox_connector::ConnectorTableHandlePtr& tableHandle,
@@ -68,6 +75,12 @@ void CudfIcebergDataSource::convertSplit(
 
   // Convert `ConnectorSplit` to `CudfHiveConnectorSplit`
   CudfHiveDataSource::convertSplit(split);
+
+  split_->coalescedFiles.reserve(icebergSplit_->coalescedFiles.size());
+  for (const auto& file : icebergSplit_->coalescedFiles) {
+    split_->coalescedFiles.push_back(
+        {stripFilePrefix(file.filePath), file.length});
+  }
 }
 
 std::unique_ptr<CudfSplitReader>

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -163,21 +163,23 @@ void CudfIcebergSplitReader::prepareSplit(
     if (!schemasMatch) {
       VLOG(1) << "Falling back to single-file cuDF readers for an Iceberg "
                  "multi-file split with schema evolution";
-      fallbackSplits_.push_back(std::make_shared<CudfHiveConnectorSplit>(
-          split_->connectorId,
-          split_->filePath,
-          split_->start,
-          split_->length,
-          split_->splitWeight,
-          split_->infoColumns));
+      fallbackSplits_.push_back(
+          std::make_shared<CudfHiveConnectorSplit>(
+              split_->connectorId,
+              split_->filePath,
+              split_->start,
+              split_->length,
+              split_->splitWeight,
+              split_->infoColumns));
       for (const auto& file : split_->coalescedFiles) {
-        fallbackSplits_.push_back(std::make_shared<CudfHiveConnectorSplit>(
-            split_->connectorId,
-            file.filePath,
-            0,
-            file.length,
-            split_->splitWeight,
-            split_->infoColumns));
+        fallbackSplits_.push_back(
+            std::make_shared<CudfHiveConnectorSplit>(
+                split_->connectorId,
+                file.filePath,
+                0,
+                file.length,
+                split_->splitWeight,
+                split_->infoColumns));
       }
       split_ = fallbackSplits_.front();
       fallbackSplits_.pop_front();

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -194,6 +194,9 @@ void CudfIcebergSplitReader::prepareSplit(
 
   // Create the cuDF reader
   if (useExperimentalCudfReader()) {
+    VELOX_CHECK(
+        split_->coalescedFiles.empty(),
+        "Iceberg multi-file scan is not supported by the experimental cuDF reader");
     createExperimentalReader();
   } else {
     createCudfReader();
@@ -617,12 +620,20 @@ void CudfIcebergSplitReader::cacheSchemaFromMetadata() {
 
   VELOX_CHECK_EQ(
       fileMetaData_.size(),
-      1,
-      "Expected a single parquet footer for Iceberg data file");
+      1 + split_->coalescedFiles.size(),
+      "Expected one parquet footer per Iceberg data file");
   const auto& meta = fileMetaData_.front();
   VELOX_CHECK(not meta.schema.empty(), "Parquet footer schema is empty");
   VELOX_CHECK_GE(meta.num_rows, 0, "Parquet footer reports negative row count");
-  fileRowCount_ = static_cast<std::size_t>(meta.num_rows);
+  fileRowCount_ = 0;
+  for (const auto& fileMeta : fileMetaData_) {
+    VELOX_CHECK_GE(
+        fileMeta.num_rows, 0, "Parquet footer reports negative row count");
+    VELOX_CHECK(
+        fileMeta.schema == meta.schema,
+        "Iceberg multi-file scan requires identical physical Parquet schemas");
+    fileRowCount_ += static_cast<std::size_t>(fileMeta.num_rows);
+  }
 
   const auto& root = meta.schema.front();
   fileColumnNames_.clear();

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -46,7 +46,9 @@
 #include <folly/Conv.h>
 #include <folly/lang/Bits.h>
 
+#include <algorithm>
 #include <cstring>
+#include <deque>
 #include <limits>
 #include <unordered_set>
 
@@ -140,18 +142,57 @@ CudfIcebergSplitReader::CudfIcebergSplitReader(
     readColumnNames_.insert(
         readColumnNames_.begin() + insertAt, nested.begin(), nested.end());
   }
+  initialReadColumnNames_ = readColumnNames_;
 }
 
 void CudfIcebergSplitReader::prepareSplit(
     dwio::common::RuntimeStatistics& runtimeStats) {
-  // Reset the split
+  fallbackSplits_.clear();
+  runtimeStats_ = &runtimeStats;
+
   resetSplit();
-
-  // Get a stream
   stream_ = cudfGlobalStreamPool().get_stream();
-
-  // Read file metadata and cache schema information
   cacheSchemaFromMetadata();
+
+  if (fileMetaData_.size() > 1) {
+    const auto& primarySchema = fileMetaData_.front().schema;
+    const bool schemasMatch = std::all_of(
+        fileMetaData_.begin() + 1,
+        fileMetaData_.end(),
+        [&](const auto& metadata) { return metadata.schema == primarySchema; });
+    if (!schemasMatch) {
+      VLOG(1) << "Falling back to single-file cuDF readers for an Iceberg "
+                 "multi-file split with schema evolution";
+      fallbackSplits_.push_back(std::make_shared<CudfHiveConnectorSplit>(
+          split_->connectorId,
+          split_->filePath,
+          split_->start,
+          split_->length,
+          split_->splitWeight,
+          split_->infoColumns));
+      for (const auto& file : split_->coalescedFiles) {
+        fallbackSplits_.push_back(std::make_shared<CudfHiveConnectorSplit>(
+            split_->connectorId,
+            file.filePath,
+            0,
+            file.length,
+            split_->splitWeight,
+            split_->infoColumns));
+      }
+      split_ = fallbackSplits_.front();
+      fallbackSplits_.pop_front();
+      resetSplit();
+      cacheSchemaFromMetadata();
+    }
+  }
+
+  prepareCurrentSplit(runtimeStats, true);
+}
+
+void CudfIcebergSplitReader::prepareCurrentSplit(
+    dwio::common::RuntimeStatistics& runtimeStats,
+    bool countProcessedSplit) {
+  readColumnNames_ = initialReadColumnNames_;
 
   // Must setup delete file readers before reader construction so that it
   // can correctly determine the memory resource to construct the cuDF reader.
@@ -185,7 +226,9 @@ void CudfIcebergSplitReader::prepareSplit(
                "column references and/or positional deletes.";
   }
 
-  runtimeStats.processedSplits++;
+  if (countProcessedSplit) {
+    runtimeStats.processedSplits++;
+  }
 
   // No need to create a cuDF reader for injected-only projection.
   if (noColumnsToRead_) {
@@ -201,6 +244,19 @@ void CudfIcebergSplitReader::prepareSplit(
   } else {
     createCudfReader();
   }
+}
+
+bool CudfIcebergSplitReader::prepareNextFallbackSplit() {
+  if (fallbackSplits_.empty()) {
+    return false;
+  }
+  VELOX_CHECK_NOT_NULL(runtimeStats_);
+  split_ = fallbackSplits_.front();
+  fallbackSplits_.pop_front();
+  resetSplit();
+  cacheSchemaFromMetadata();
+  prepareCurrentSplit(*runtimeStats_, false);
+  return true;
 }
 
 void CudfIcebergSplitReader::resetSplit() {
@@ -237,24 +293,29 @@ CudfIcebergSplitReader::determineCudfMemoryResource() {
 std::optional<std::unique_ptr<cudf::table>>
 CudfIcebergSplitReader::readNextChunk() {
   std::unique_ptr<cudf::table> cudfTable;
-  if (noColumnsToRead_) {
-    if (syntheticTableProduced_) {
+  while (!cudfTable) {
+    if (noColumnsToRead_) {
+      if (!syntheticTableProduced_) {
+        VELOX_CHECK_LE(
+            fileRowCount_,
+            std::numeric_limits<cudf::size_type>::max(),
+            "File row count exceeds max cudf::size_type value");
+        syntheticTableProduced_ = true;
+        cudfTable = std::make_unique<cudf::table>(
+            std::vector<std::unique_ptr<cudf::column>>{});
+        break;
+      }
+    } else {
+      // Read the next table chunk from the cuDF reader.
+      auto chunkOpt = CudfSplitReader::readNextChunk();
+      if (chunkOpt.has_value()) {
+        cudfTable = std::move(chunkOpt.value());
+        break;
+      }
+    }
+    if (!prepareNextFallbackSplit()) {
       return std::nullopt;
     }
-    VELOX_CHECK_LE(
-        fileRowCount_,
-        std::numeric_limits<cudf::size_type>::max(),
-        "File row count exceeds max cudf::size_type value");
-    syntheticTableProduced_ = true;
-    cudfTable = std::make_unique<cudf::table>(
-        std::vector<std::unique_ptr<cudf::column>>{});
-  } else {
-    // Read the next table chunk from the cuDF reader
-    auto chunkOpt = CudfSplitReader::readNextChunk();
-    if (not chunkOpt.has_value()) {
-      return std::nullopt;
-    }
-    cudfTable = std::move(chunkOpt.value());
   }
 
   // Number of table rows before deletes.
@@ -629,9 +690,6 @@ void CudfIcebergSplitReader::cacheSchemaFromMetadata() {
   for (const auto& fileMeta : fileMetaData_) {
     VELOX_CHECK_GE(
         fileMeta.num_rows, 0, "Parquet footer reports negative row count");
-    VELOX_CHECK(
-        fileMeta.schema == meta.schema,
-        "Iceberg multi-file scan requires identical physical Parquet schemas");
     fileRowCount_ += static_cast<std::size_t>(fileMeta.num_rows);
   }
 

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
@@ -25,6 +25,7 @@
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/hive/iceberg/PositionalDeleteFileReader.h"
 
+#include <deque>
 #include <list>
 #include <optional>
 #include <string>
@@ -106,6 +107,15 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // Read metadata and cache `fileRowCount_` and `fileColumnNames_`
   void cacheSchemaFromMetadata();
 
+  // Prepare the current physical split. Schema-evolved files that cannot
+  // share one cuDF reader are queued and prepared one at a time.
+  void prepareCurrentSplit(
+      dwio::common::RuntimeStatistics& runtimeStats,
+      bool countProcessedSplit);
+
+  // Advance to the next single-file fallback split, if any.
+  bool prepareNextFallbackSplit();
+
   // Adapts the data file schema to match the table schema expected by the
   // query. Classifies each output and filter-only column into one of:
   //
@@ -166,6 +176,10 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // are expanded into nested parquet selector paths.
   std::vector<std::string> logicalReadColumnNames_;
   std::vector<std::string> outputReadColumnNames_;
+  std::vector<std::string> initialReadColumnNames_;
+
+  std::deque<std::shared_ptr<CudfHiveConnectorSplit>> fallbackSplits_;
+  dwio::common::RuntimeStatistics* runtimeStats_{nullptr};
 
   // cuDF-accelerated reader for Iceberg V3 deletion vector (Puffin-encoded
   // roaring bitmaps).

--- a/velox/experimental/cudf/exec/CudfAggregation.h
+++ b/velox/experimental/cudf/exec/CudfAggregation.h
@@ -119,7 +119,9 @@ bool isCountFunctionName(std::string_view kind);
 bool hasOnlyConstantArguments(const core::CallTypedExpr& call);
 
 // Returns true if the aggregation node contains companion aggregates
-// (e.g. _merge, _partial, _merge_extract suffixes), which disables streaming.
+// (e.g. _merge, _partial, _merge_extract suffixes). Kept for callers that need
+// to inspect the external plan shape; CudfGroupby streaming supports companion
+// aggregates by forcing its internal compaction step to kIntermediate.
 bool hasCompanionAggregates(
     std::vector<core::AggregationNode::Aggregate> const& aggregates);
 

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -122,6 +122,25 @@ CudfBatchConcat::CudfBatchConcat(
     std::shared_ptr<const core::PlanNode> planNode,
     RowTypePtr outputType,
     int32_t targetRows)
+    : CudfBatchConcat(
+          operatorId,
+          driverCtx,
+          std::move(planNode),
+          std::move(outputType),
+          targetRows,
+          concatThreshold(
+              driverCtx,
+              CudfConfig::kCudfBatchSizeMinThresholdBytes,
+              "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_BYTES",
+              CudfConfig::getInstance().batchSizeMinThresholdBytes)) {}
+
+CudfBatchConcat::CudfBatchConcat(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::PlanNode> planNode,
+    RowTypePtr outputType,
+    int32_t targetRows,
+    uint64_t targetBytes)
     : CudfOperatorBase(
           operatorId,
           driverCtx,
@@ -135,11 +154,7 @@ CudfBatchConcat::CudfBatchConcat(
       driverCtx_(driverCtx),
       aggregationStep_(getAggregationStep(planNode)),
       targetRows_(checkedConcatTargetRows(targetRows)),
-      targetBytes_(concatThreshold(
-          driverCtx,
-          CudfConfig::kCudfBatchSizeMinThresholdBytes,
-          "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_BYTES",
-          CudfConfig::getInstance().batchSizeMinThresholdBytes)) {
+      targetBytes_(targetBytes) {
   if (logConcatConfig()) {
     LOG(WARNING) << "CudfBatchConcat configured targetRows=" << targetRows_
                  << ", targetBytes=" << targetBytes_;

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -20,10 +20,35 @@
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
+#include <cstdlib>
+#include <string_view>
 #include <utility>
 
 namespace facebook::velox::cudf_velox {
 namespace {
+
+uint64_t concatThresholdFromEnv(const char* name, uint64_t fallback) {
+  if (const char* value = std::getenv(name)) {
+    try {
+      return std::stoull(value);
+    } catch (...) {
+    }
+  }
+  return fallback;
+}
+
+uint64_t concatThreshold(
+    exec::DriverCtx* driverCtx,
+    const char* configKey,
+    const char* envName,
+    uint64_t fallback) {
+  // Prefer the per-query value.  The process-wide CudfConfig is initialized
+  // before registration, but a long-lived executor can subsequently execute
+  // queries with different batch targets.
+  const auto configured =
+      driverCtx->queryConfig().get<uint64_t>(configKey, fallback);
+  return concatThresholdFromEnv(envName, configured);
+}
 
 RowTypePtr getConcatOutputType(
     const std::shared_ptr<const core::PlanNode>& planNode) {
@@ -32,6 +57,19 @@ RowTypePtr getConcatOutputType(
       1,
       "CudfBatchConcat expects a single-source plan node");
   return planNode->sources()[0]->outputType();
+}
+
+std::string getAggregationStep(
+    const std::shared_ptr<const core::PlanNode>& planNode) {
+  const auto aggregation =
+      std::dynamic_pointer_cast<const core::AggregationNode>(planNode);
+  return aggregation ? fmt::format("{}", aggregation->step()) : "UNKNOWN";
+}
+
+bool logConcatConfig() {
+  const auto* value = std::getenv("GLUTEN_CUDF_BATCH_CONCAT_LOG_CONFIG");
+  return value != nullptr && std::string_view(value) != "0" &&
+      std::string_view(value) != "false";
 }
 
 } // namespace
@@ -51,7 +89,28 @@ CudfBatchConcat::CudfBatchConcat(
           std::nullopt,
           planNode),
       driverCtx_(driverCtx),
-      targetRows_(CudfConfig::getInstance().batchSizeMinThreshold) {}
+      aggregationStep_(getAggregationStep(planNode)),
+      targetRows_(concatThreshold(
+          driverCtx,
+          CudfConfig::kCudfBatchSizeMinThreshold,
+          "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_ROWS",
+          CudfConfig::getInstance().batchSizeMinThreshold)),
+      targetBytes_(concatThreshold(
+          driverCtx,
+          CudfConfig::kCudfBatchSizeMinThresholdBytes,
+          "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_BYTES",
+          CudfConfig::getInstance().batchSizeMinThresholdBytes)) {
+  if (logConcatConfig()) {
+    LOG(WARNING) << "CudfBatchConcat configured targetRows=" << targetRows_
+                 << ", targetBytes=" << targetBytes_;
+  }
+}
+
+bool CudfBatchConcat::needsInput() const {
+  return !noMoreInput_ && outputQueue_.empty() &&
+      currentNumRows_ < targetRows_ &&
+      (targetBytes_ == 0 || currentNumBytes_ < targetBytes_);
+}
 
 void CudfBatchConcat::doAddInput(RowVectorPtr input) {
   auto cudfVector = std::dynamic_pointer_cast<CudfVector>(input);
@@ -62,8 +121,38 @@ void CudfBatchConcat::doAddInput(RowVectorPtr input) {
   }
 
   // Push input cudf table to buffer
+  ++inputBatches_;
+  totalInputRows_ += cudfVector->size();
+  totalInputBytes_ += cudfVector->estimateFlatSize();
   currentNumRows_ += cudfVector->size();
+  currentNumBytes_ += cudfVector->estimateFlatSize();
   buffer_.push_back(std::move(cudfVector));
+
+  // Enforce the bound here as well as in needsInput(). Source pipelines may
+  // have already scheduled another input before the driver observes the
+  // updated needsInput() result. Keeping a ready output in outputQueue_ makes
+  // the backpressure explicit and prevents scan batches from accumulating up
+  // to device capacity. Avoid a redundant D2D concatenate for one large input.
+  if (currentNumRows_ >= targetRows_ ||
+      (targetBytes_ != 0 && currentNumBytes_ >= targetBytes_)) {
+    if (buffer_.size() == 1) {
+      outputQueue_.push(std::move(buffer_.front()));
+      buffer_.clear();
+    } else {
+      const auto outputStream = buffer_.front()->stream();
+      auto outputVectors = getConcatenatedCudfVectorsBatched(
+          pool(),
+          std::exchange(buffer_, {}),
+          outputType_,
+          outputStream,
+          get_output_mr());
+      for (auto& output : outputVectors) {
+        outputQueue_.push(std::move(output));
+      }
+    }
+    currentNumRows_ = 0;
+    currentNumBytes_ = 0;
+  }
 }
 
 RowVectorPtr CudfBatchConcat::doGetOutput() {
@@ -71,11 +160,15 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
   if (!outputQueue_.empty()) {
     auto output = std::move(outputQueue_.front());
     outputQueue_.pop();
+    ++outputBatches_;
     return output;
   }
 
   // Merge tables if there are enough rows
-  if (!buffer_.empty() && (currentNumRows_ >= targetRows_ || noMoreInput_)) {
+  if (!buffer_.empty() &&
+      (currentNumRows_ >= targetRows_ ||
+       (targetBytes_ != 0 && currentNumBytes_ >= targetBytes_) ||
+       noMoreInput_)) {
     // Use stream from existing buffer vectors
     const auto outputStream = buffer_[0]->stream();
     auto outputVectors = getConcatenatedCudfVectorsBatched(
@@ -86,6 +179,7 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
         get_output_mr());
 
     currentNumRows_ = 0;
+    currentNumBytes_ = 0;
     VELOX_CHECK_GT(outputVectors.size(), 0);
 
     for (auto it = outputVectors.begin(); it + 1 != outputVectors.end(); ++it) {
@@ -97,8 +191,11 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
     auto& last = outputVectors.back();
     auto rowCount = last->size();
 
-    if (!noMoreInput_ && rowCount < targetRows_) {
+    const auto lastBytes = last->estimateFlatSize();
+    if (!noMoreInput_ && rowCount < targetRows_ &&
+        (targetBytes_ == 0 || lastBytes < targetBytes_)) {
       currentNumRows_ = rowCount;
+      currentNumBytes_ = lastBytes;
       buffer_.push_back(std::move(last));
     } else {
       outputQueue_.push(std::move(last));
@@ -108,6 +205,7 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
     if (!outputQueue_.empty()) {
       auto output = std::move(outputQueue_.front());
       outputQueue_.pop();
+      ++outputBatches_;
       return output;
     }
   }
@@ -116,7 +214,18 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
 }
 
 bool CudfBatchConcat::isFinished() {
-  return noMoreInput_ && buffer_.empty() && outputQueue_.empty();
+  const bool finished =
+      noMoreInput_ && buffer_.empty() && outputQueue_.empty();
+  if (finished && !summaryLogged_ && logConcatConfig()) {
+    summaryLogged_ = true;
+    LOG(WARNING) << "CudfBatchConcat summary planNode=" << planNodeId()
+                 << ", step=" << aggregationStep_
+                 << ", inputBatches=" << inputBatches_
+                 << ", outputBatches=" << outputBatches_
+                 << ", inputRows=" << totalInputRows_
+                 << ", inputBytes=" << totalInputBytes_;
+  }
+  return finished;
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -21,6 +21,7 @@
 #include "velox/experimental/cudf/exec/Utilities.h"
 
 #include <cstdlib>
+#include <limits>
 #include <string_view>
 #include <utility>
 
@@ -59,6 +60,25 @@ RowTypePtr getConcatOutputType(
   return planNode->sources()[0]->outputType();
 }
 
+size_t checkedConcatTargetRows(int32_t targetRows) {
+  VELOX_CHECK_GT(
+      targetRows, 0, "CudfBatchConcat target row count must be positive");
+  return static_cast<size_t>(targetRows);
+}
+
+int32_t queryConcatTargetRows(exec::DriverCtx* driverCtx) {
+  const auto targetRows = concatThreshold(
+      driverCtx,
+      CudfConfig::kCudfBatchSizeMinThreshold,
+      "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_ROWS",
+      CudfConfig::getInstance().batchSizeMinThreshold);
+  VELOX_CHECK_LE(
+      targetRows,
+      static_cast<uint64_t>(std::numeric_limits<int32_t>::max()),
+      "CudfBatchConcat target row count exceeds INT32_MAX");
+  return static_cast<int32_t>(targetRows);
+}
+
 std::string getAggregationStep(
     const std::shared_ptr<const core::PlanNode>& planNode) {
   const auto aggregation =
@@ -78,10 +98,34 @@ CudfBatchConcat::CudfBatchConcat(
     int32_t operatorId,
     exec::DriverCtx* driverCtx,
     std::shared_ptr<const core::PlanNode> planNode)
+    : CudfBatchConcat(
+          operatorId,
+          driverCtx,
+          planNode,
+          getConcatOutputType(planNode)) {}
+
+CudfBatchConcat::CudfBatchConcat(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::PlanNode> planNode,
+    RowTypePtr outputType)
+    : CudfBatchConcat(
+          operatorId,
+          driverCtx,
+          planNode,
+          std::move(outputType),
+          queryConcatTargetRows(driverCtx)) {}
+
+CudfBatchConcat::CudfBatchConcat(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::PlanNode> planNode,
+    RowTypePtr outputType,
+    int32_t targetRows)
     : CudfOperatorBase(
           operatorId,
           driverCtx,
-          getConcatOutputType(planNode),
+          std::move(outputType),
           planNode->id(),
           "CudfBatchConcat",
           nvtx3::rgb{211, 211, 211}, /* LightGrey */
@@ -90,11 +134,7 @@ CudfBatchConcat::CudfBatchConcat(
           planNode),
       driverCtx_(driverCtx),
       aggregationStep_(getAggregationStep(planNode)),
-      targetRows_(concatThreshold(
-          driverCtx,
-          CudfConfig::kCudfBatchSizeMinThreshold,
-          "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_ROWS",
-          CudfConfig::getInstance().batchSizeMinThreshold)),
+      targetRows_(checkedConcatTargetRows(targetRows)),
       targetBytes_(concatThreshold(
           driverCtx,
           CudfConfig::kCudfBatchSizeMinThresholdBytes,
@@ -169,6 +209,18 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
       (currentNumRows_ >= targetRows_ ||
        (targetBytes_ != 0 && currentNumBytes_ >= targetBytes_) ||
        noMoreInput_)) {
+    // Preserve the zero-copy Exchange fast path when a single received batch
+    // already satisfies the target (or is the final tail batch). CudfVector
+    // carries its producing stream, so downstream operators can consume it
+    // directly without rebinding allocation ownership to another stream.
+    if (buffer_.size() == 1) {
+      auto output = std::move(buffer_.front());
+      buffer_.clear();
+      currentNumRows_ = 0;
+      currentNumBytes_ = 0;
+      ++outputBatches_;
+      return output;
+    }
     // Use stream from existing buffer vectors
     const auto outputStream = buffer_[0]->stream();
     auto outputVectors = getConcatenatedCudfVectorsBatched(
@@ -214,8 +266,7 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
 }
 
 bool CudfBatchConcat::isFinished() {
-  const bool finished =
-      noMoreInput_ && buffer_.empty() && outputQueue_.empty();
+  const bool finished = noMoreInput_ && buffer_.empty() && outputQueue_.empty();
   if (finished && !summaryLogged_ && logConcatConfig()) {
     summaryLogged_ = true;
     LOG(WARNING) << "CudfBatchConcat summary planNode=" << planNodeId()

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -47,6 +47,14 @@ class CudfBatchConcat : public CudfOperatorBase {
       RowTypePtr outputType,
       int32_t targetRows);
 
+  CudfBatchConcat(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const core::PlanNode> planNode,
+      RowTypePtr outputType,
+      int32_t targetRows,
+      uint64_t targetBytes);
+
   bool needsInput() const override;
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -23,6 +23,7 @@
 #include "velox/exec/Operator.h"
 
 #include <queue>
+#include <string>
 
 namespace facebook::velox::cudf_velox {
 
@@ -33,10 +34,7 @@ class CudfBatchConcat : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::PlanNode> planNode);
 
-  bool needsInput() const override {
-    return !noMoreInput_ && outputQueue_.empty() &&
-        currentNumRows_ < targetRows_;
-  }
+  bool needsInput() const override;
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
     return exec::BlockingReason::kNotBlocked;
@@ -50,10 +48,18 @@ class CudfBatchConcat : public CudfOperatorBase {
 
  private:
   exec::DriverCtx* const driverCtx_;
+  const std::string aggregationStep_;
   std::vector<CudfVectorPtr> buffer_;
   std::queue<CudfVectorPtr> outputQueue_;
+  uint64_t totalInputRows_{0};
+  uint64_t totalInputBytes_{0};
+  uint64_t inputBatches_{0};
+  uint64_t outputBatches_{0};
   size_t currentNumRows_{0};
+  uint64_t currentNumBytes_{0};
   const size_t targetRows_{0};
+  const uint64_t targetBytes_{0};
+  bool summaryLogged_{false};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -34,6 +34,19 @@ class CudfBatchConcat : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::PlanNode> planNode);
 
+  CudfBatchConcat(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const core::PlanNode> planNode,
+      RowTypePtr outputType);
+
+  CudfBatchConcat(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const core::PlanNode> planNode,
+      RowTypePtr outputType,
+      int32_t targetRows);
+
   bool needsInput() const override;
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -1093,13 +1093,23 @@ void CudfGroupby::initialize() {
       aggregationNode_->step(),
       outputType_,
       aggregationInput.constants);
-  // The old blanket companion-aggregate guard forced every input batch into
-  // inputs_ until noMoreInput(). Large MPP final aggregates consequently
-  // retained several GiB of materialized exchange pages per
-  // executor. Companion suffixes describe the external Spark plan step; for
-  // streaming compaction we explicitly force the internal intermediate step
-  // below, so these aggregates can be compacted incrementally as well.
-  streamingEnabled_ = true;
+  // Companion names encode their effective aggregation step. Streaming is
+  // safe when that step agrees with the plan node: each input batch can then
+  // be compacted using the intermediate aggregators and finalized normally.
+  // Mixed companion plans intentionally keep the legacy path because forcing
+  // e.g. count_partial in a single-step node through an intermediate merge
+  // would count partial rows instead of merging their states. Empty grouping
+  // keys also keep the legacy path because cuDF's groupby primitive requires
+  // a key column; global aggregation is handled correctly by the old path.
+  streamingEnabled_ = !aggregationNode_->groupingKeys().empty() &&
+      std::all_of(
+          aggregationNode_->aggregates().begin(),
+          aggregationNode_->aggregates().end(),
+          [&](const auto& aggregate) {
+            return getCompanionStep(
+                       aggregate.call->name(), aggregationNode_->step()) ==
+                aggregationNode_->step();
+          });
 
   if (deviceMemoryDiagnosticsEnabled()) {
     for (const auto& aggregate : aggregationNode_->aggregates()) {
@@ -1178,6 +1188,12 @@ void CudfGroupby::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
       bufferedResultType_,
       inputTableStream,
       get_output_mr());
+
+  // An all-null key batch with ignoreNullKeys enabled has no partial state to
+  // merge. Preserve any state accumulated from earlier batches.
+  if (!groupbyOnInput) {
+    return;
+  }
 
   // If we already have partial output, concatenate the new results with it.
   if (bufferedResult_) {
@@ -1645,6 +1661,12 @@ void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
       bufferedResultType_,
       inputTableStream,
       get_output_mr());
+
+  // An all-null key batch with ignoreNullKeys enabled has no partial state to
+  // merge. Preserve any state accumulated from earlier batches.
+  if (!groupbyOnInput) {
+    return;
+  }
 
   if (bufferedResult_) {
     auto partialOutputStream = bufferedResult_->stream();

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -40,7 +40,9 @@
 #include <cudf/reduction.hpp>
 #include <cudf/unary.hpp>
 
+#include <cstdlib>
 #include <limits>
+#include <mutex>
 
 namespace {
 
@@ -75,6 +77,55 @@ constexpr const char* kFinalStreamingOutputRows =
     "cudfFinalStreamingOutputRows";
 constexpr const char* kFinalStreamingFallbackProbeColumnsReleased =
     "cudfFinalStreamingFallbackProbeColumnsReleased";
+constexpr const char* kIntermediateAggregationInputRuns =
+    "cudfIntermediateAggregationInputRuns";
+constexpr const char* kIntermediateAggregationRunMerges =
+    "cudfIntermediateAggregationRunMerges";
+constexpr const char* kIntermediateAggregationFinalizeMerges =
+    "cudfIntermediateAggregationFinalizeMerges";
+constexpr const char* kIntermediateAggregationMergeRows =
+    "cudfIntermediateAggregationMergeRows";
+constexpr const char* kIntermediateAggregationMergeBytes =
+    "cudfIntermediateAggregationMergeBytes";
+constexpr const char* kIntermediateAggregationMaxLevel =
+    "cudfIntermediateAggregationMaxLevel";
+constexpr const char* kIntermediateAggregationSerializedMerges =
+    "cudfIntermediateAggregationSerializedMerges";
+
+bool serializeLargeIntermediateAggregationMergesEnabled() {
+  static const bool enabled = [] {
+    const auto* value = std::getenv("GLUTEN_CUDF_SERIALIZE_LARGE_FINAL_AGG");
+    if (value == nullptr) {
+      return false;
+    }
+    const std::string_view setting{value};
+    return !setting.empty() && setting != "0" && setting != "false" &&
+        setting != "off" && setting != "no";
+  }();
+  return enabled;
+}
+
+uint64_t largeIntermediateAggregationSerializeBytes() {
+  static const uint64_t threshold = []() -> uint64_t {
+    constexpr uint64_t kDefaultThreshold = 8ULL << 30;
+    const auto* value =
+        std::getenv("GLUTEN_CUDF_LARGE_FINAL_AGG_SERIALIZE_BYTES");
+    if (value == nullptr || *value == '\0') {
+      return kDefaultThreshold;
+    }
+    char* end = nullptr;
+    const auto parsed = std::strtoull(value, &end, 10);
+    return end != value && *end == '\0' && parsed > 0
+        ? static_cast<uint64_t>(parsed)
+        : kDefaultThreshold;
+  }();
+  return threshold;
+}
+
+std::mutex& largeIntermediateAggregationMutex() {
+  static std::mutex mutex;
+  return mutex;
+}
 
 size_t aggregationRunLevel(uint64_t representedRows) {
   VELOX_CHECK_GT(representedRows, 0);
@@ -1167,9 +1218,7 @@ void CudfGroupby::initialize() {
 }
 
 void CudfGroupby::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
-  // For every input, we'll do a groupby and compact results with the existing
-  // intermediate groupby results.
-
+  const auto representedRows = static_cast<uint64_t>(tbl->size());
   auto inputTableStream = tbl->stream();
   // Use getTableView() to avoid expensive materialization for packed_table.
   // tbl stays alive during this function call, keeping the view valid.
@@ -1189,38 +1238,9 @@ void CudfGroupby::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
       inputTableStream,
       get_output_mr());
 
-  // An all-null key batch with ignoreNullKeys enabled has no partial state to
-  // merge. Preserve any state accumulated from earlier batches.
-  if (!groupbyOnInput) {
-    return;
-  }
-
-  // If we already have partial output, concatenate the new results with it.
-  if (bufferedResult_) {
-    auto partialOutputStream = bufferedResult_->stream();
-    std::vector<CudfVectorPtr> tablesToConcat;
-    tablesToConcat.push_back(std::exchange(bufferedResult_, nullptr));
-    tablesToConcat.push_back(std::move(groupbyOnInput));
-    auto concatenatedTable = getConcatenatedTable(
-        std::move(tablesToConcat),
-        bufferedResultType_,
-        partialOutputStream,
-        get_temp_mr());
-
-    // Now we have to groupby again but this time with intermediate aggregators.
-    // Keep concatenatedTable alive while we use its view.
-    auto compactedOutput = doGroupByAggregation(
-        concatenatedTable->view(),
-        groupingKeyOutputChannels_,
-        intermediateAggregators_,
-        bufferedResultType_,
-        partialOutputStream,
-        get_output_mr());
-    bufferedResult_ = compactedOutput;
-  } else {
-    // First time processing, just store the result of the input batch's groupby
-    // This means we're storing the stream from the first batch.
-    bufferedResult_ = groupbyOnInput;
+  if (groupbyOnInput) {
+    addIntermediateAggregationRun(
+        IntermediateAggregationRun{std::move(groupbyOnInput), representedRows});
   }
 }
 
@@ -1645,6 +1665,7 @@ CudfVectorPtr CudfGroupby::finalizeStreamingFinalAggregation() {
 }
 
 void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
+  const auto representedRows = static_cast<uint64_t>(tbl->size());
   auto inputTableStream = tbl->stream();
   auto preparedInput = prepareAggregationInput(
       tbl->getTableView(),
@@ -1662,34 +1683,181 @@ void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
       inputTableStream,
       get_output_mr());
 
-  // An all-null key batch with ignoreNullKeys enabled has no partial state to
-  // merge. Preserve any state accumulated from earlier batches.
-  if (!groupbyOnInput) {
-    return;
+  if (groupbyOnInput) {
+    addIntermediateAggregationRun(
+        IntermediateAggregationRun{std::move(groupbyOnInput), representedRows});
+  }
+}
+
+void CudfGroupby::addIntermediateAggregationRun(
+    IntermediateAggregationRun run) {
+  VELOX_CHECK_NOT_NULL(run.data);
+  VELOX_CHECK_GT(run.representedRows, 0);
+  ++intermediateInputRunCount_;
+
+  auto level = aggregationRunLevel(run.representedRows);
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationInputRuns, RuntimeCounter(1));
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationMaxLevel,
+        RuntimeCounter(static_cast<int64_t>(level)));
   }
 
-  if (bufferedResult_) {
-    auto partialOutputStream = bufferedResult_->stream();
-    std::vector<CudfVectorPtr> tablesToConcat;
-    tablesToConcat.push_back(std::exchange(bufferedResult_, nullptr));
-    tablesToConcat.push_back(std::move(groupbyOnInput));
-    auto concatenatedTable = getConcatenatedTable(
-        std::move(tablesToConcat),
-        bufferedResultType_,
-        partialOutputStream,
-        get_temp_mr());
+  for (;;) {
+    if (intermediateRunLevels_.size() <= level) {
+      intermediateRunLevels_.resize(level + 1);
+    }
+    if (!intermediateRunLevels_[level].has_value()) {
+      intermediateBufferedBytes_ += run.data->estimateFlatSize();
+      intermediateRunLevels_[level] = std::move(run);
+      return;
+    }
 
-    auto compactedOutput = doGroupByAggregation(
-        concatenatedTable->view(),
-        groupingKeyOutputChannels_,
-        intermediateAggregators_,
-        bufferedResultType_,
-        partialOutputStream,
-        get_output_mr());
-    bufferedResult_ = compactedOutput;
-  } else {
-    bufferedResult_ = groupbyOnInput;
+    auto peer = std::move(*intermediateRunLevels_[level]);
+    intermediateRunLevels_[level].reset();
+    const auto peerBytes = peer.data->estimateFlatSize();
+    VELOX_CHECK_GE(intermediateBufferedBytes_, peerBytes);
+    intermediateBufferedBytes_ -= peerBytes;
+
+    const auto representedRows =
+        addRepresentedRows(peer.representedRows, run.representedRows);
+    auto outputLevel = aggregationRunLevel(representedRows);
+    outputLevel = std::max(outputLevel, level + 1);
+    run = mergeIntermediateAggregationRuns(
+        std::move(peer), std::move(run), outputLevel, false);
+    level = outputLevel;
   }
+}
+
+CudfGroupby::IntermediateAggregationRun
+CudfGroupby::mergeIntermediateAggregationRuns(
+    IntermediateAggregationRun left,
+    IntermediateAggregationRun right,
+    size_t outputLevel,
+    bool finalizing) {
+  VELOX_CHECK_NOT_NULL(left.data);
+  VELOX_CHECK_NOT_NULL(right.data);
+  VELOX_CHECK(left.data->stream().value() == stateStream_.value());
+  VELOX_CHECK(right.data->stream().value() == stateStream_.value());
+
+  const auto inputRows = static_cast<int64_t>(left.data->size()) +
+      static_cast<int64_t>(right.data->size());
+  const auto inputBytes =
+      left.data->estimateFlatSize() + right.data->estimateFlatSize();
+  VELOX_CHECK_LE(
+      inputBytes, static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+  const auto representedRows =
+      addRepresentedRows(left.representedRows, right.representedRows);
+  // The pre-rebase MPP path deliberately serialized very large merge kernels
+  // within an executor. Four local aggregation drivers otherwise launch
+  // multi-GiB concatenate and groupby operations concurrently on the same
+  // GPU, increasing both peak memory and Q18 latency. Retain that behavior for
+  // PARTIAL/SINGLE runs while leaving the new FINAL streaming state untouched.
+  const bool serializeLargeMerge =
+      serializeLargeIntermediateAggregationMergesEnabled() &&
+      inputBytes >= largeIntermediateAggregationSerializeBytes();
+  std::unique_lock<std::mutex> largeMergeLock;
+  if (serializeLargeMerge) {
+    largeMergeLock =
+        std::unique_lock<std::mutex>{largeIntermediateAggregationMutex()};
+    stateStream_.synchronize();
+  }
+
+  std::vector<CudfVectorPtr> inputs;
+  inputs.reserve(2);
+  inputs.push_back(std::move(left.data));
+  inputs.push_back(std::move(right.data));
+  auto concatenated = getConcatenatedTable(
+      std::move(inputs), bufferedResultType_, stateStream_, get_temp_mr());
+  auto output = doGroupByAggregation(
+      concatenated->view(),
+      groupingKeyOutputChannels_,
+      intermediateAggregators_,
+      bufferedResultType_,
+      stateStream_,
+      get_output_mr());
+  VELOX_CHECK_NOT_NULL(output);
+  if (serializeLargeMerge) {
+    // Complete the merge and release its temporary concatenation before the
+    // next local driver enters the large-merge section.
+    concatenated.reset();
+    stateStream_.synchronize();
+  }
+
+  ++intermediateRunMergeCount_;
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationRunMerges, RuntimeCounter(1));
+    if (finalizing) {
+      lockedStats->addRuntimeStat(
+          kIntermediateAggregationFinalizeMerges, RuntimeCounter(1));
+    }
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationMergeRows, RuntimeCounter(inputRows));
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationMergeBytes,
+        RuntimeCounter(static_cast<int64_t>(inputBytes)));
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationMaxLevel,
+        RuntimeCounter(static_cast<int64_t>(outputLevel)));
+    if (serializeLargeMerge) {
+      lockedStats->addRuntimeStat(
+          kIntermediateAggregationSerializedMerges, RuntimeCounter(1));
+    }
+  }
+
+  if (deviceMemoryDiagnosticsEnabled() &&
+      (finalizing || intermediateRunMergeCount_ == 1 ||
+       intermediateRunMergeCount_ % 64 == 0)) {
+    logDeviceMemorySnapshot(
+        fmt::format(
+            "operator=CudfGroupby node={} state=intermediate_run.merge "
+            "phase={} level={} merge={} inputRows={} inputBytes={} "
+            "outputRows={} outputBytes={} representedRows={}",
+            diagnosticNodeId_,
+            finalizing ? "finalize" : "online",
+            outputLevel,
+            intermediateRunMergeCount_,
+            inputRows,
+            inputBytes,
+            output->size(),
+            output->estimateFlatSize(),
+            representedRows));
+  }
+
+  return IntermediateAggregationRun{std::move(output), representedRows};
+}
+
+CudfVectorPtr CudfGroupby::drainIntermediateAggregationRuns() {
+  std::optional<IntermediateAggregationRun> carry;
+  for (auto& level : intermediateRunLevels_) {
+    if (!level.has_value()) {
+      continue;
+    }
+    auto run = std::move(*level);
+    level.reset();
+    if (!carry.has_value()) {
+      carry = std::move(run);
+      continue;
+    }
+    const auto representedRows =
+        addRepresentedRows(carry->representedRows, run.representedRows);
+    carry = mergeIntermediateAggregationRuns(
+        std::move(*carry),
+        std::move(run),
+        aggregationRunLevel(representedRows),
+        true);
+  }
+  intermediateRunLevels_.clear();
+  intermediateBufferedBytes_ = 0;
+
+  if (!carry.has_value()) {
+    return nullptr;
+  }
+  return std::move(carry->data);
 }
 
 void CudfGroupby::prepareInputForStateStream(const CudfVectorPtr& input) {
@@ -1716,7 +1884,7 @@ void CudfGroupby::doAddInput(RowVectorPtr input) {
   VELOX_CHECK_NOT_NULL(cudfInput);
   input.reset();
 
-  if (!isPartialOutput_ && !isSingleStep_) {
+  if (streamingEnabled_) {
     prepareInputForStateStream(cudfInput);
   }
 
@@ -1814,17 +1982,22 @@ CudfVectorPtr CudfGroupby::releaseAndResetBufferedResult() {
 RowVectorPtr CudfGroupby::doGetOutput() {
   // Handle partial streaming groupby.
   if (isPartialOutput_ && streamingEnabled_) {
-    if (bufferedResult_ &&
-        bufferedResult_->estimateFlatSize() >
-            maxPartialAggregationMemoryUsage_) {
+    if (!bufferedResult_ && maxPartialAggregationMemoryUsage_ > 0 &&
+        intermediateBufferedBytes_ >
+            static_cast<uint64_t>(maxPartialAggregationMemoryUsage_)) {
+      bufferedResult_ = drainIntermediateAggregationRuns();
+    }
+    if (bufferedResult_) {
       return releaseAndResetBufferedResult();
     }
-    if (not noMoreInput_) {
+    if (!noMoreInput_) {
       // Don't produce output if the partial output hasn't reached memory limit
       // and there's more batches to come.
       return nullptr;
     }
-    if (!bufferedResult_ && finished_) {
+    bufferedResult_ = drainIntermediateAggregationRuns();
+    if (!bufferedResult_) {
+      finished_ = true;
       return nullptr;
     }
     return releaseAndResetBufferedResult();
@@ -1845,6 +2018,9 @@ RowVectorPtr CudfGroupby::doGetOutput() {
   // At this point isPartialOutput_ is false (handled above) and noMoreInput_
   // is true (guarded by the check above).
   if (streamingEnabled_) {
+    if (isSingleStep_ && !bufferedResult_) {
+      bufferedResult_ = drainIntermediateAggregationRuns();
+    }
     if (!isPartialOutput_ && !isSingleStep_ &&
         finalAggregationMode_ == FinalAggregationMode::kStreaming) {
       finished_ = true;
@@ -1940,6 +2116,8 @@ void CudfGroupby::doClose() {
   }
   finalStreamingGroupby_.reset();
   finalStreamingRequestAggregationCounts_.clear();
+  intermediateRunLevels_.clear();
+  intermediateBufferedBytes_ = 0;
   finalRunLevels_.clear();
   bufferedResult_.reset();
   inputs_.clear();

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -125,6 +125,11 @@ class CudfGroupby : public CudfOperatorBase {
     uint64_t representedRows;
   };
 
+  struct IntermediateAggregationRun {
+    CudfVectorPtr data;
+    uint64_t representedRows;
+  };
+
   CudfVectorPtr doGroupByAggregation(
       cudf::table_view tableView,
       std::vector<column_index_t> const& groupByKeys,
@@ -140,6 +145,14 @@ class CudfGroupby : public CudfOperatorBase {
   void computePartialGroupbyStreaming(CudfVectorPtr tbl);
   void computeFinalGroupbyStreaming(CudfVectorPtr tbl);
   void computeSingleGroupbyStreaming(CudfVectorPtr tbl);
+
+  void addIntermediateAggregationRun(IntermediateAggregationRun run);
+  IntermediateAggregationRun mergeIntermediateAggregationRuns(
+      IntermediateAggregationRun left,
+      IntermediateAggregationRun right,
+      size_t outputLevel,
+      bool finalizing);
+  CudfVectorPtr drainIntermediateAggregationRuns();
 
   void addFinalAggregationRun(FinalAggregationRun run);
   FinalAggregationRun mergeFinalAggregationRuns(
@@ -184,6 +197,16 @@ class CudfGroupby : public CudfOperatorBase {
   TypePtr inputType_;
   RowTypePtr bufferedResultType_;
   CudfVectorPtr bufferedResult_;
+
+  // PARTIAL and SINGLE aggregation produce one compacted state per input
+  // page. Keep those states in logarithmic size levels and merge only peers
+  // of comparable weight. This avoids regrouping the complete accumulated
+  // state for every page while retaining the configured partial-memory flush
+  // boundary.
+  std::vector<std::optional<IntermediateAggregationRun>> intermediateRunLevels_;
+  uint64_t intermediateBufferedBytes_{0};
+  uint64_t intermediateInputRunCount_{0};
+  uint64_t intermediateRunMergeCount_{0};
 
   // Supported FINAL aggregates use cuDF's persistent hash state directly
   // across exchange pages. The choice is made from the first page and is never

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
@@ -296,7 +297,8 @@ void CudfHashJoinBuild::doNoMoreInput() {
   bool buildHashJoin =
       (joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
        joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
-       joinNode_->isLeftSemiProjectJoin());
+       joinNode_->isLeftSemiProjectJoin() ||
+       joinNode_->isRightSemiProjectJoin());
 
   std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
   for (auto i = 0; i < tbls.size(); i++) {
@@ -431,9 +433,10 @@ CudfHashJoinProbe::CudfHashJoinProbe(
       rightColumnOutputIndices_.push_back(i);
       continue;
     }
-    // For LEFT SEMI PROJECT, the last column is the boolean "match" column
-    // which is not in probe or build types - skip it here, handled separately
-    if (isLeftSemiProjectJoin(joinNode_->joinType()) &&
+    // For SEMI PROJECT, the last column is the boolean "match" column which is
+    // not in probe or build types - skip it here, handled separately.
+    if ((isLeftSemiProjectJoin(joinNode_->joinType()) ||
+         isRightSemiProjectJoin(joinNode_->joinType())) &&
         i == outputType->size() - 1 &&
         outputType->childAt(i)->kind() == TypeKind::BOOLEAN) {
       continue;
@@ -549,6 +552,13 @@ void CudfHashJoinProbe::doAddInput(RowVectorPtr input) {
   }
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput);
+  if (joinNode_->isRightSemiProjectJoin() && input->size() > 0) {
+    probeSideHasRows_ = true;
+    if (joinNode_->isNullAware() && !probeSideHasNullKeys_) {
+      probeSideHasNullKeys_ =
+          cudf::has_nulls(cudfInput->getTableView().select(leftKeyIndices_));
+    }
+  }
   // Count nulls in join key columns
   auto [_, null_count] = cudf::bitmask_and(
       cudfInput->getTableView(), cudfInput->stream(), get_temp_mr());
@@ -573,7 +583,7 @@ void CudfHashJoinProbe::doAddInput(RowVectorPtr input) {
 void CudfHashJoinProbe::doNoMoreInput() {
   Operator::noMoreInput();
   if (!joinNode_->isRightJoin() && !joinNode_->isRightSemiFilterJoin() &&
-      !joinNode_->isFullJoin()) {
+      !joinNode_->isRightSemiProjectJoin() && !joinNode_->isFullJoin()) {
     return;
   }
   std::vector<ContinuePromise> promises;
@@ -593,7 +603,8 @@ void CudfHashJoinProbe::doNoMoreInput() {
     }
   };
 
-  if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
+  if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
+      joinNode_->isRightSemiProjectJoin()) {
     isLastDriver_ = true;
     if (hashObject_.has_value()) {
       auto stream = cudfGlobalStreamPool().get_stream();
@@ -633,6 +644,13 @@ void CudfHashJoinProbe::doNoMoreInput() {
         if (probe == nullptr) {
           continue;
         }
+        if (joinNode_->isRightSemiProjectJoin()) {
+          probeSideHasRows_ = probeSideHasRows_ || probe->probeSideHasRows_;
+          probeSideHasNullKeys_ =
+              probeSideHasNullKeys_ || probe->probeSideHasNullKeys_;
+        }
+        VELOX_CHECK_EQ(
+            probe->rightMatchedFlags_.size(), rightMatchedFlags_.size());
         // Combine flags per partition using cuDF bitwise OR
         // DM: This needs a relook. This is for when build side exceeds cudf
         // size_type limits. In case of multiple right side chunks, I'm not sure
@@ -1944,6 +1962,197 @@ CudfHashJoinProbe::rightSemiFilterJoin(
   return cudfOutputs;
 }
 
+std::vector<CudfHashJoinProbe::JoinOutput>
+CudfHashJoinProbe::rightSemiProjectJoin(
+    cudf::table_view leftTableView,
+    rmm::cuda_stream_view stream) {
+  auto& rightTables = hashObject_.value().first;
+  auto& hbs = hashObject_.value().second;
+  VELOX_CHECK_EQ(rightTables.size(), hbs.size());
+  VELOX_CHECK_EQ(rightTables.size(), rightMatchedFlags_.size());
+
+  // Precompute probe columns once per input batch when the AST filter needs
+  // them. HashJoinNode rejects null-aware RIGHT SEMI PROJECT with a filter.
+  std::vector<ColumnOrView> leftPrecomputed;
+  cudf::table_view extendedLeftView = leftTableView;
+  if (joinNode_->filter() && useAstFilter_ &&
+      !leftPrecomputeInstructions_.empty()) {
+    auto leftColumnViews = tableViewToColumnViews(leftTableView);
+    leftPrecomputed = precomputeSubexpressions(
+        leftColumnViews,
+        leftPrecomputeInstructions_,
+        scalars_,
+        probeType_,
+        stream);
+    extendedLeftView = createExtendedTableView(leftTableView, leftPrecomputed);
+  }
+
+  for (size_t i = 0; i < rightTables.size(); ++i) {
+    auto rightTableView = rightTables[i]->view();
+    auto& hb = hbs[i];
+    VELOX_CHECK_NOT_NULL(hb);
+
+    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
+        leftTableView.select(leftKeyIndices_),
+        std::nullopt,
+        stream,
+        get_temp_mr());
+
+    auto leftIndicesCol = cudf::column_view{
+        cudf::device_span<cudf::size_type const>{*leftJoinIndices}};
+    auto rightIndicesCol = cudf::column_view{
+        cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>>
+        astFilteredRightIndices;
+    std::unique_ptr<cudf::column> evaluatedFilteredRightIndices;
+
+    if (joinNode_->filter()) {
+      if (useAstFilter_) {
+        auto extendedRightView = !rightPrecomputeInstructions_.empty()
+            ? cachedExtendedRightViews_[i]
+            : rightTableView;
+        auto filteredIndices = cudf::filter_join_indices(
+            extendedLeftView,
+            extendedRightView,
+            leftIndicesCol,
+            rightIndicesCol,
+            tree_.back(),
+            cudf::join_kind::INNER_JOIN,
+            stream,
+            get_temp_mr());
+        astFilteredRightIndices = std::move(filteredIndices.second);
+        rightIndicesCol = cudf::column_view{
+            cudf::device_span<cudf::size_type const>{*astFilteredRightIndices}};
+      } else {
+        // Evaluate non-AST residuals over candidate pairs, then apply the same
+        // mask to the build indices. Null filter results are excluded by
+        // apply_boolean_mask, matching SQL join predicate semantics.
+        auto leftResult = cudf::gather(
+            leftTableView, leftIndicesCol, oobPolicy, stream, get_temp_mr());
+        auto rightResult = cudf::gather(
+            rightTableView, rightIndicesCol, oobPolicy, stream, get_temp_mr());
+        auto joinedCols = leftResult->release();
+        auto rightCols = rightResult->release();
+        joinedCols.insert(
+            joinedCols.end(),
+            std::make_move_iterator(rightCols.begin()),
+            std::make_move_iterator(rightCols.end()));
+        std::vector<cudf::column_view> joinedViews;
+        joinedViews.reserve(joinedCols.size());
+        for (const auto& col : joinedCols) {
+          joinedViews.push_back(col->view());
+        }
+        VELOX_CHECK_NOT_NULL(filterEvaluator_);
+        auto filterColumn =
+            filterEvaluator_->eval(joinedViews, stream, get_temp_mr());
+        auto filteredTable = cudf::apply_boolean_mask(
+            cudf::table_view{{rightIndicesCol}},
+            asView(filterColumn),
+            stream,
+            get_temp_mr());
+        evaluatedFilteredRightIndices = std::move(filteredTable->release()[0]);
+        rightIndicesCol = evaluatedFilteredRightIndices->view();
+      }
+    }
+
+    // Mark only the build rows matched by this probe batch. The previous
+    // implementation materialized sequence(buildRows), evaluated contains()
+    // over the complete build side, and OR'ed a complete BOOL8 column for
+    // every probe batch. Large exchange consumers can receive thousands of
+    // batches, turning an otherwise incremental semi join into
+    // O(buildRows * probeBatches) work. Each driver owns its flag column, and
+    // setting TRUE is monotonic and idempotent even when a residual produces
+    // duplicate build indices.
+    connector::hive::iceberg::scatterDeletesToMask(
+        rightMatchedFlags_[i]->mutable_view(),
+        cudf::device_span<cudf::size_type const>{
+            rightIndicesCol.data<cudf::size_type>(),
+            static_cast<std::size_t>(rightIndicesCol.size())},
+        stream,
+        get_temp_mr());
+    // rightIndicesCol can reference a batch-local device buffer. Complete the
+    // scatter before its owner is destroyed and before this driver accepts the
+    // next probe batch.
+    stream.synchronize();
+  }
+
+  // RIGHT SEMI PROJECT is build preserving. Probe batches only update state;
+  // output is emitted once every driver has completed probing.
+  return {};
+}
+
+RowVectorPtr CudfHashJoinProbe::rightSemiProjectOutput(
+    rmm::cuda_stream_view stream) {
+  auto& rightTables = hashObject_.value().first;
+  VELOX_CHECK_EQ(rightTables.size(), rightMatchedFlags_.size());
+
+  while (nextBuildOutputIndex_ < rightTables.size()) {
+    const auto i = nextBuildOutputIndex_++;
+    auto rightTableView = rightTables[i]->view();
+    const auto numRows = rightTableView.num_rows();
+    if (numRows == 0) {
+      continue;
+    }
+
+    std::vector<std::unique_ptr<cudf::column>> outputCols(outputType_->size());
+    auto rightInput = rightTableView.select(rightColumnIndicesToGather_);
+    for (size_t j = 0; j < rightColumnIndicesToGather_.size(); ++j) {
+      outputCols[rightColumnOutputIndices_[j]] = std::make_unique<cudf::column>(
+          rightInput.column(j), stream, get_output_mr());
+    }
+
+    std::unique_ptr<cudf::column> matchColumn;
+    if (joinNode_->isNullAware() && probeSideHasRows_) {
+      auto noMatch = cudf::unary_operation(
+          rightMatchedFlags_[i]->view(),
+          cudf::unary_operator::NOT,
+          stream,
+          get_temp_mr());
+      std::unique_ptr<cudf::column> nullMask;
+      if (probeSideHasNullKeys_) {
+        // Any unmatched build row is indeterminate if the probe side contains
+        // a null key. Rows with a true equality match remain true.
+        nullMask = std::move(noMatch);
+      } else {
+        // With a non-empty, non-null probe side, only build rows with a null
+        // key are indeterminate.
+        auto buildKeyNullMask = createProbeKeyNullMask(
+            rightTableView.select(rightKeyIndices_), stream, get_temp_mr());
+        nullMask = cudf::binary_operation(
+            noMatch->view(),
+            buildKeyNullMask->view(),
+            cudf::binary_operator::BITWISE_AND,
+            cudf::data_type{cudf::type_id::BOOL8},
+            stream,
+            get_temp_mr());
+      }
+      matchColumn = applyNullMask(
+          rightMatchedFlags_[i]->view(),
+          nullMask->view(),
+          stream,
+          get_output_mr());
+    } else {
+      // Regular EXISTS semantics, and null-aware IN with an empty probe side,
+      // both use the non-nullable accumulated flags directly.
+      matchColumn = std::make_unique<cudf::column>(
+          rightMatchedFlags_[i]->view(), stream, get_output_mr());
+    }
+    outputCols.back() = std::move(matchColumn);
+
+    stream.synchronize();
+    finished_ = nextBuildOutputIndex_ == rightTables.size();
+    return std::make_shared<CudfVector>(
+        pool(),
+        outputType_,
+        static_cast<vector_size_t>(numRows),
+        std::make_unique<cudf::table>(std::move(outputCols)),
+        stream);
+  }
+
+  finished_ = true;
+  return nullptr;
+}
+
 std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::antiJoin(
     cudf::table_view leftTableViewParam,
     rmm::cuda_stream_view stream) {
@@ -2042,6 +2251,10 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
     return nullptr;
   }
   if (!input_) {
+    if (joinNode_->isRightSemiProjectJoin() && noMoreInput_ && !finished_ &&
+        isLastDriver_) {
+      return rightSemiProjectOutput(cudfGlobalStreamPool().get_stream());
+    }
     // If no more input, emit unmatched-right rows if needed.
     if ((joinNode_->isRightJoin() || joinNode_->isFullJoin()) && noMoreInput_ &&
         !finished_ && isLastDriver_) {
@@ -2171,6 +2384,9 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
     case core::JoinType::kRightSemiFilter:
       cudfOutputs = rightSemiFilterJoin(leftTableView, stream);
       break;
+    case core::JoinType::kRightSemiProject:
+      cudfOutputs = rightSemiProjectJoin(leftTableView, stream);
+      break;
     case core::JoinType::kAnti:
       cudfOutputs = antiJoin(leftTableView, stream);
       break;
@@ -2182,7 +2398,8 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
   }
 
   // Record probe stream for cross-driver synchronization in noMoreInput().
-  if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
+  if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
+      joinNode_->isRightSemiProjectJoin()) {
     lastProbeStream_ = stream;
   }
 
@@ -2192,8 +2409,13 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
   // the refcount while cudfInput still holds a reference.
   cudfInput.reset();
   input_.reset();
-  finished_ =
-      noMoreInput_ && !joinNode_->isRightJoin() && !joinNode_->isFullJoin();
+  finished_ = noMoreInput_ && !joinNode_->isRightJoin() &&
+      !joinNode_->isFullJoin() && !joinNode_->isRightSemiProjectJoin();
+
+  if (joinNode_->isRightSemiProjectJoin()) {
+    VELOX_CHECK(cudfOutputs.empty());
+    return nullptr;
+  }
 
   vector_size_t zeroColumnOutputRows = 0;
   std::vector<std::unique_ptr<cudf::table>> cudfOutputTables;
@@ -2223,7 +2445,7 @@ bool CudfHashJoinProbe::skipProbeOnEmptyBuild() const {
 
 exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
   if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin() ||
-       joinNode_->isFullJoin()) &&
+       joinNode_->isRightSemiProjectJoin() || joinNode_->isFullJoin()) &&
       hashObject_.has_value()) {
     if (!future_.valid()) {
       return exec::BlockingReason::kNotBlocked;
@@ -2255,7 +2477,8 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
   buildReadyEvent_ = cudfJoinBridge->getBuildReadyEvent();
 
   // Lazy initialize matched flags only when build side is done
-  if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
+  if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
+      joinNode_->isRightSemiProjectJoin()) {
     auto& rightTablesInit = hashObject_.value().first;
     rightMatchedFlags_.clear();
     rightMatchedFlags_.reserve(rightTablesInit.size());
@@ -2333,7 +2556,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
     }
   }
   if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin() ||
-       joinNode_->isFullJoin()) &&
+       joinNode_->isRightSemiProjectJoin() || joinNode_->isFullJoin()) &&
       future_.valid()) {
     *future = std::move(future_);
     return exec::BlockingReason::kWaitForJoinProbe;
@@ -2342,7 +2565,12 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
 }
 
 bool CudfHashJoinProbe::isFinished() {
-  auto const isFinished = finished_ || (noMoreInput_ && input_ == nullptr);
+  // RIGHT SEMI PROJECT can emit one build table per getOutput() call. Keep the
+  // last driver alive until all build tables are emitted; peer drivers have no
+  // output after the end-of-probe barrier and can finish normally.
+  const auto hasNoMoreWork = noMoreInput_ && input_ == nullptr &&
+      !(joinNode_->isRightSemiProjectJoin() && isLastDriver_ && !finished_);
+  const auto isFinished = finished_ || hasNoMoreWork;
 
   // Release hashObject_ if finished
   if (isFinished) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -152,10 +152,9 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   /// Supported types:
   /// - Inner, Left, Right, Full joins
   /// - Left/Right Semi Filter joins
-  /// - Left Semi Project join (excluding null-aware join with filter)
+  /// - Left/Right Semi Project joins (null-aware right semi project with a
+  ///   filter is rejected by HashJoinNode validation)
   /// - Anti join (non-null-aware, or null-aware without filter)
-  /// Note: Right Semi Project, and null-aware left semi-project join with
-  /// filter not yet supported.
   static bool isSupportedJoinType(core::JoinType joinType) {
     return joinType == core::JoinType::kInner ||
         joinType == core::JoinType::kLeft ||
@@ -164,6 +163,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
         joinType == core::JoinType::kLeftSemiProject ||
         joinType == core::JoinType::kRight ||
         joinType == core::JoinType::kRightSemiFilter ||
+        joinType == core::JoinType::kRightSemiProject ||
         joinType == core::JoinType::kFull;
   }
 
@@ -226,6 +226,12 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   /// nullability.
   bool buildSideHasNullKeys_{false};
 
+  /// Whether this probe driver has seen any non-empty probe input and whether
+  /// any such input has a null join key. These are reduced across drivers at
+  /// the end-of-probe barrier for null-aware RIGHT SEMI PROJECT joins.
+  bool probeSideHasRows_{false};
+  bool probeSideHasNullKeys_{false};
+
   // Copied from HashProbe.h
   // Indicates whether to skip probe input data processing or not. It only
   // applies for a specific set of join types (see skipProbeOnEmptyBuild()), and
@@ -245,8 +251,8 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   // Streaming right join state
   // Per-build-table flags indicating whether a build row has had at least one
   // left match.
-  /** @brief Flags tracking which build rows have been matched (for right joins)
-   */
+  /** @brief Flags tracking which build rows have been matched for right/full
+   * and right-semi-project joins. */
   std::vector<std::unique_ptr<cudf::column>> rightMatchedFlags_;
 
   /// Cached precomputed columns for right (build) tables
@@ -254,17 +260,24 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   /// Cached extended views for right tables (original + precomputed columns)
   std::vector<cudf::table_view> cachedExtendedRightViews_;
 
-  // For Right joins, only one driver collects the unmatched rows mask and
-  // emits. This value is set true only for that driver. See noMoreInput
+  // For right/full and right-semi-project joins, only one driver combines the
+  // build-row match masks and emits build-side output. This value is set true
+  // only for that driver. See noMoreInput().
   bool isLastDriver_{false};
 
+  /// Next build table to emit for RIGHT SEMI PROJECT. Build tables are emitted
+  /// one at a time so the multi-table path does not concatenate past the cuDF
+  /// size_type limit.
+  size_t nextBuildOutputIndex_{0};
+
   /// CUDA stream used during the last getOutput() probe operation. Set only
-  /// for right/full joins, and only for drivers that process at least one probe
-  /// batch. Used in noMoreInput() to synchronize GPU streams across drivers
-  /// before combining rightMatchedFlags_. Drivers with no probe input are safe
-  /// to skip: the driver loop guarantees all addInput batches are consumed by
-  /// getOutput() before noMoreInput() fires, and unset flags remain in their
-  /// host-synchronized all-false init state with no pending GPU work.
+  /// for right/full/right-semi-project joins, and only for drivers that process
+  /// at least one probe batch. Used in noMoreInput() to synchronize GPU streams
+  /// across drivers before combining rightMatchedFlags_. Drivers with no probe
+  /// input are safe to skip: the driver loop guarantees all addInput batches
+  /// are consumed by getOutput() before noMoreInput() fires, and unset flags
+  /// remain in their host-synchronized all-false init state with no pending GPU
+  /// work.
   std::optional<rmm::cuda_stream_view> lastProbeStream_;
 
   static constexpr auto oobPolicy = cudf::out_of_bounds_policy::NULLIFY;
@@ -341,6 +354,17 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   std::vector<JoinOutput> rightSemiFilterJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
+  /**
+   * @brief Accumulates per-build-row matches for a right semi project join.
+   * This produces no rows while probing; the build rows and match column are
+   * emitted after all probe drivers reach the end-of-input barrier.
+   */
+  std::vector<JoinOutput> rightSemiProjectJoin(
+      cudf::table_view leftTableView,
+      rmm::cuda_stream_view stream);
+
+  /// Emits the next build-side batch for RIGHT SEMI PROJECT.
+  RowVectorPtr rightSemiProjectOutput(rmm::cuda_stream_view stream);
   /**
    * @brief Performs anti join between probe table and all build tables.
    * @param leftTableView Probe-side table view to join

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -17,7 +17,9 @@
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/CudfLocalPartition.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
+#include "velox/experimental/ucx-exchange/RangePartitionFunction.h"
 
 #include "velox/core/PlanNode.h"
 #include "velox/exec/HashPartitionFunction.h"
@@ -26,6 +28,7 @@
 
 #include <cudf/copying.hpp>
 #include <cudf/partitioning.hpp>
+#include <cudf/search.hpp>
 
 namespace facebook::velox::cudf_velox {
 
@@ -38,11 +41,13 @@ bool isAnyOf(const Base* p) {
 
 bool CudfLocalPartition::shouldReplace(
     const std::shared_ptr<const core::LocalPartitionNode>& planNode) {
-  // Only replace for Hash, Round Robin, and Round Robin Row-Wise Partitioning.
+  // Replace all partition functions with a native cuDF implementation. RANGE
+  // is shared with the UCX output path through RangePartitionFunctionSpec.
   if (isAnyOf<
           exec::HashPartitionFunctionSpec,
           exec::RoundRobinPartitionFunctionSpec,
-          core::GatherPartitionFunctionSpec>(
+          core::GatherPartitionFunctionSpec,
+          ucx_exchange::RangePartitionFunctionSpec>(
           &planNode->partitionFunctionSpec())) {
     return true;
   }
@@ -91,9 +96,17 @@ CudfLocalPartition::CudfLocalPartition(
   std::string spec = planNode->partitionFunctionSpec().toString();
   auto* hashFunctionSpec = dynamic_cast<const exec::HashPartitionFunctionSpec*>(
       &planNode->partitionFunctionSpec());
+  auto* rangeFunctionSpec =
+      dynamic_cast<const ucx_exchange::RangePartitionFunctionSpec*>(
+          &planNode->partitionFunctionSpec());
 
-  // Only parse keys if it's a hash function
-  if (hashFunctionSpec) {
+  // RANGE exposes its key channels directly. Hash still uses the legacy
+  // textual spec parsing below.
+  if (rangeFunctionSpec) {
+    partitionKeyIndices_ = rangeFunctionSpec->keyChannels();
+    rangeBoundsJson_ = rangeFunctionSpec->boundsJson();
+    partitionFunctionType_ = PartitionFunctionType::kRange;
+  } else if (hashFunctionSpec) {
     // Extract keys between HASH( and )
     size_t start = spec.find("HASH(") + 5;
     size_t end = spec.find(")", start);
@@ -222,6 +235,49 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
             hashSeed_,
             stream,
             get_temp_mr());
+      } else if (partitionFunctionType_ == PartitionFunctionType::kRange) {
+        if (!rangeBoundaries_) {
+          auto boundaryVector = ucx_exchange::buildRangeBoundaryVector(
+              rangeBoundsJson_,
+              outputType_,
+              partitionKeyIndices_,
+              pool(),
+              rangeOrders_,
+              rangeNullOrders_);
+          rangeBoundaries_ = with_arrow::toCudfTable(
+              boundaryVector, pool(), stream, get_output_mr());
+          VELOX_CHECK_LT(
+              rangeBoundaries_->num_rows(),
+              numPartitions_,
+              "RANGE_PID boundary count must be smaller than requested partitions");
+        }
+
+        std::vector<cudf::size_type> rangeKeyIndices;
+        rangeKeyIndices.reserve(partitionKeyIndices_.size());
+        for (const auto index : partitionKeyIndices_) {
+          rangeKeyIndices.push_back(static_cast<cudf::size_type>(index));
+        }
+        const auto keyTable = tableView.select(rangeKeyIndices);
+        auto partitionIds = cudf::lower_bound(
+            rangeBoundaries_->view(),
+            keyTable,
+            rangeOrders_,
+            rangeNullOrders_,
+            stream,
+            get_temp_mr());
+        VELOX_CHECK_EQ(
+            partitionIds->size(),
+            tableView.num_rows(),
+            "RANGE_PID must produce exactly one id per input row");
+        VELOX_CHECK(
+            partitionIds->type().id() == cudf::type_id::INT32,
+            "RANGE_PID must produce an INT32 partition map");
+        return cudf::partition(
+            tableView,
+            partitionIds->view(),
+            numPartitions_,
+            stream,
+            get_temp_mr());
       } else if (
           partitionFunctionType_ == PartitionFunctionType::kRoundRobinRow) {
         auto result = cudf::round_robin_partition(
@@ -232,16 +288,18 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
       VELOX_FAIL("Unsupported partition function");
     }();
 
-    // cuDF partitioning APIs return num_partitions + 1 offsets where:
-    // - offsets[i] is the starting row index for partition i
-    // - offsets[num_partitions] is the total row count
-    VELOX_CHECK(partitionOffsets.size() == numPartitions_ + 1);
+    // cuDF partitioning APIs return either one starting offset per partition
+    // or those offsets plus a terminal row count, depending on the primitive.
+    VELOX_CHECK(
+        partitionOffsets.size() == numPartitions_ ||
+        partitionOffsets.size() == numPartitions_ + 1);
     VELOX_CHECK(partitionOffsets[0] == 0);
 
-    // cudf::split expects split points (excluding first 0 and last totalRows).
-    // Erase first element (always 0) and last element (total row count).
+    // cudf::split expects only the N - 1 interior split points.
     partitionOffsets.erase(partitionOffsets.begin());
-    partitionOffsets.pop_back();
+    if (partitionOffsets.size() == numPartitions_) {
+      partitionOffsets.pop_back();
+    }
 
     auto partitionedTables =
         cudf::split(partitionedTable->view(), partitionOffsets, stream);

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -70,7 +70,11 @@ CudfLocalPartition::CudfLocalPartition(
           planNode),
       queues_{
           ctx->task->getLocalExchangeQueues(ctx->splitGroupId, planNode->id())},
-      numPartitions_{queues_.size()} {
+      numPartitions_{queues_.size()},
+      hashSeed_{
+          planNode->id().find("_keyed_final_local_hash") != std::string::npos
+              ? cudf::DEFAULT_HASH_SEED ^ 0x9e3779b9U
+              : cudf::DEFAULT_HASH_SEED} {
   // Following is IMO a hacky way to get the partition key indices. It is to
   // workaround the fact that the partition spec constructs the hash function
   // directly and has no public methods to get the partition key indices.
@@ -119,6 +123,11 @@ CudfLocalPartition::CudfLocalPartition(
       }
     }
     partitionFunctionType_ = PartitionFunctionType::kHash;
+    if (hashSeed_ != cudf::DEFAULT_HASH_SEED) {
+      LOG(WARNING) << "CudfLocalPartition: decorrelated keyed-FINAL hash "
+                   << "planNode=" << planNode->id()
+                   << " partitions=" << numPartitions_ << " seed=" << hashSeed_;
+    }
   } else if (
       dynamic_cast<const exec::RoundRobinPartitionFunctionSpec*>(
           &planNode->partitionFunctionSpec()) &&
@@ -210,7 +219,7 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
             partitionKeyIndices,
             numPartitions_,
             cudf::hash_id::HASH_MURMUR3,
-            cudf::DEFAULT_HASH_SEED,
+            hashSeed_,
             stream,
             get_temp_mr());
       } else if (

--- a/velox/experimental/cudf/exec/CudfLocalPartition.h
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.h
@@ -21,10 +21,14 @@
 #include "velox/exec/LocalPartition.h"
 #include "velox/exec/Operator.h"
 
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+
 namespace facebook::velox::cudf_velox {
 
 enum class PartitionFunctionType {
   kHash,
+  kRange,
   kRoundRobin,
   kRoundRobinRow,
 };
@@ -83,6 +87,10 @@ class CudfLocalPartition : public CudfOperatorBase {
   std::vector<ContinueFuture> futures_;
 
   std::vector<column_index_t> partitionKeyIndices_;
+  std::string rangeBoundsJson_;
+  std::unique_ptr<cudf::table> rangeBoundaries_;
+  std::vector<cudf::order> rangeOrders_;
+  std::vector<cudf::null_order> rangeNullOrders_;
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfLocalPartition.h
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.h
@@ -74,6 +74,11 @@ class CudfLocalPartition : public CudfOperatorBase {
   PartitionFunctionType partitionFunctionType_;
   size_t counter_{0};
 
+  // A local keyed-FINAL repartition must not reuse the remote exchange seed.
+  // If local partition count divides remote partition count (Q17: 4 vs 32),
+  // identical hashing sends the peer's entire remote bucket to one local lane.
+  uint32_t hashSeed_;
+
   std::vector<exec::BlockingReason> blockingReasons_;
   std::vector<ContinueFuture> futures_;
 

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -107,8 +107,10 @@ bool isSpillSafeType(const TypePtr& type) {
         }
       }
       return true;
-    case TypeKind::VARBINARY:
     case TypeKind::MAP:
+      return type->size() == 2 && isSpillSafeType(type->childAt(0)) &&
+          isSpillSafeType(type->childAt(1));
+    case TypeKind::VARBINARY:
     case TypeKind::UNKNOWN:
     case TypeKind::FUNCTION:
     case TypeKind::OPAQUE:
@@ -125,7 +127,8 @@ bool isSupportedSortKeyType(const TypePtr& type) {
 
   // Nested cuDF sort semantics have not been validated against Velox. Nested
   // values may still be carried as payload when every leaf is spill-safe.
-  return type->kind() != TypeKind::ARRAY && type->kind() != TypeKind::ROW;
+  return type->kind() != TypeKind::ARRAY && type->kind() != TypeKind::MAP &&
+      type->kind() != TypeKind::ROW;
 }
 
 void updateAtomicMax(std::atomic<uint64_t>& target, uint64_t value) {

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -42,16 +42,14 @@ namespace {
 constexpr uint64_t kMergeChunkBytes = 32ULL << 20;
 constexpr uint64_t kMergePassBytes = 128ULL << 20;
 constexpr uint64_t kSpillRowGroupBytes = 64ULL << 20;
-constexpr uint64_t kOutputChunkBytes = 32ULL << 20;
 constexpr size_t kFinalMergeRuns = 2;
-constexpr cudf::size_type kMaxOutputRows = 262144;
 
 std::atomic<uint64_t> orderBySpillDirectorySequence{0};
 std::atomic<uint64_t> testingSortedRunBytes{0};
 std::atomic<size_t> testingMergeFanIn{0};
 std::atomic<uint64_t> mergeChunkBytes{kMergeChunkBytes};
-std::atomic<uint64_t> outputChunkBytes{kOutputChunkBytes};
-std::atomic<cudf::size_type> maxOutputRows{kMaxOutputRows};
+std::atomic<uint64_t> testingOutputChunkBytes{0};
+std::atomic<cudf::size_type> testingMaxOutputRows{0};
 
 // Read-only diagnostics used to assert the external-sort bounds in GPU tests.
 // They never participate in operator scheduling or correctness.
@@ -208,8 +206,8 @@ void CudfOrderBy::testingSetMemoryLimits(
   testingSortedRunBytes.store(runBytes);
   testingMergeFanIn.store(fanIn);
   mergeChunkBytes.store(chunkBytes);
-  outputChunkBytes.store(outputBytes);
-  maxOutputRows.store(outputRows);
+  testingOutputChunkBytes.store(outputBytes);
+  testingMaxOutputRows.store(outputRows);
   resetTestingStats();
 }
 
@@ -217,8 +215,8 @@ void CudfOrderBy::testingResetMemoryLimits() {
   testingSortedRunBytes.store(0);
   testingMergeFanIn.store(0);
   mergeChunkBytes.store(kMergeChunkBytes);
-  outputChunkBytes.store(kOutputChunkBytes);
-  maxOutputRows.store(kMaxOutputRows);
+  testingOutputChunkBytes.store(0);
+  testingMaxOutputRows.store(0);
   resetTestingStats();
 }
 
@@ -266,7 +264,16 @@ CudfOrderBy::CudfOrderBy(
           testingMergeFanIn.load() > 0
               ? testingMergeFanIn.load()
               : static_cast<size_t>(
-                    CudfConfig::getInstance().orderByMergeFanIn)) {
+                    CudfConfig::getInstance().orderByMergeFanIn)),
+      outputChunkBytes_(
+          testingOutputChunkBytes.load() > 0
+              ? testingOutputChunkBytes.load()
+              : CudfConfig::getInstance().orderByOutputChunkBytes),
+      maxOutputRows_(
+          testingMaxOutputRows.load() > 0
+              ? testingMaxOutputRows.load()
+              : static_cast<cudf::size_type>(
+                    CudfConfig::getInstance().orderByMaxOutputRows)) {
   VELOX_CHECK(
       isSupported(orderByNode),
       "CudfOrderBy received an unsupported external-spill schema or sorting "
@@ -846,8 +853,8 @@ CudfVectorPtr CudfOrderBy::takePendingOutput() {
   const auto totalRows = pendingOutput_->num_rows();
   VELOX_CHECK_LT(pendingOutputOffset_, totalRows);
   const auto remainingRows = totalRows - pendingOutputOffset_;
-  const auto byteLimit = outputChunkBytes.load();
-  cudf::size_type targetRows = std::min(remainingRows, maxOutputRows.load());
+  const auto byteLimit = outputChunkBytes_;
+  cudf::size_type targetRows = std::min(remainingRows, maxOutputRows_);
   if (pendingOutputBytes_ > byteLimit) {
     const auto proportionalRows =
         static_cast<cudf::size_type>(std::max<uint64_t>(
@@ -855,6 +862,23 @@ CudfVectorPtr CudfOrderBy::takePendingOutput() {
             static_cast<uint64_t>(totalRows) * byteLimit /
                 pendingOutputBytes_));
     targetRows = std::min(targetRows, proportionalRows);
+  }
+
+  // Avoid copying an already materialized in-memory sort result when it fits
+  // the configured output bounds. Spilled/oversized results keep the bounded
+  // slicing path below.
+  if (pendingOutputOffset_ == 0 && targetRows == totalRows &&
+      pendingOutputBytes_ <= byteLimit) {
+    auto output = std::make_shared<CudfVector>(
+        pool(),
+        outputType_,
+        totalRows,
+        std::move(pendingOutput_),
+        stateStream_);
+    pendingOutputOffset_ = 0;
+    pendingOutputBytes_ = 0;
+    observedEmittedChunks.fetch_add(1);
+    return output;
   }
 
   while (true) {

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -143,6 +143,8 @@ class CudfOrderBy : public CudfOperatorBase {
   std::vector<cudf::null_order> nullOrder_;
   const uint64_t sortedRunBytes_;
   const size_t mergeFanIn_;
+  const uint64_t outputChunkBytes_;
+  const cudf::size_type maxOutputRows_;
   uint64_t bufferedBytes_{0};
   std::vector<SortedRun> sortedRuns_;
   std::string spillDirectory_;

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -59,6 +59,7 @@
 #include <atomic>
 #include <filesystem>
 #include <limits>
+#include <numeric>
 #include <optional>
 #include <unordered_set>
 #include <utility>
@@ -68,7 +69,12 @@ namespace facebook::velox::cudf_velox {
 namespace {
 
 constexpr uint64_t kWindowMergeChunkBytes = 256ULL << 20;
+constexpr uint64_t kWindowStreamingActiveRowsBytes = 256ULL << 20;
 std::atomic<uint64_t> windowSpillDirectorySequence{0};
+std::atomic<uint64_t> testingStreamingActiveRowsBytes{0};
+std::atomic<uint64_t> testingStreamingReplayChunkBytes{0};
+std::atomic<uint64_t> observedStreamingSpillWrites{0};
+std::atomic<uint64_t> observedStreamingSpillCleanups{0};
 
 std::unique_ptr<cudf::table> copyTableSlice(
     cudf::table_view input,
@@ -106,6 +112,75 @@ std::vector<cudf::column_view> selectColumns(
     columns.push_back(table.column(index));
   }
   return columns;
+}
+
+std::unique_ptr<cudf::column> makeSizeTypeColumn(
+    const std::vector<cudf::size_type>& values,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto column = cudf::make_fixed_width_column(
+      cudf::data_type{cudf::type_id::INT32},
+      static_cast<cudf::size_type>(values.size()),
+      cudf::mask_state::UNALLOCATED,
+      stream,
+      mr);
+  if (!values.empty()) {
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        column->mutable_view().data<cudf::size_type>(),
+        values.data(),
+        values.size() * sizeof(cudf::size_type),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+  }
+  return column;
+}
+
+std::unique_ptr<cudf::column> makeInt64Column(
+    const std::vector<int64_t>& values,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto column = cudf::make_fixed_width_column(
+      cudf::data_type{cudf::type_id::INT64},
+      static_cast<cudf::size_type>(values.size()),
+      cudf::mask_state::UNALLOCATED,
+      stream,
+      mr);
+  if (!values.empty()) {
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        column->mutable_view().data<int64_t>(),
+        values.data(),
+        values.size() * sizeof(int64_t),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+  }
+  return column;
+}
+
+std::unique_ptr<cudf::scalar> copyScalar(
+    const cudf::scalar& value,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto column = cudf::make_column_from_scalar(value, 1, stream, mr);
+  return cudf::get_element(column->view(), 0, stream, mr);
+}
+
+std::unique_ptr<cudf::scalar> addValidScalars(
+    const cudf::scalar& left,
+    const cudf::scalar& right,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK(left.is_valid(stream));
+  VELOX_CHECK(right.is_valid(stream));
+  VELOX_CHECK(left.type() == right.type());
+  auto leftColumn = cudf::make_column_from_scalar(left, 1, stream, mr);
+  auto result = cudf::binary_operation(
+      leftColumn->view(),
+      right,
+      cudf::binary_operator::ADD,
+      left.type(),
+      stream,
+      mr);
+  return cudf::get_element(result->view(), 0, stream, mr);
 }
 
 // Returns true when the window function's value argument is a cast expression.
@@ -250,6 +325,81 @@ bool isStreamingRankWindow(const core::WindowNode& windowNode) {
   return windowNode.inputsSorted() && !windowNode.partitionKeys().empty() &&
       !windowNode.sortingKeys().empty() && !functions.empty() &&
       std::all_of(functions.begin(), functions.end(), isStreamingRankFunction);
+}
+
+bool isFullPartitionRowsFrame(const core::WindowNode::Frame& frame) {
+  return frame.type == core::WindowNode::WindowType::kRows &&
+      frame.startType == core::WindowNode::BoundType::kUnboundedPreceding &&
+      frame.endType == core::WindowNode::BoundType::kUnboundedFollowing &&
+      frame.startValue == nullptr && frame.endValue == nullptr;
+}
+
+bool isStreamingFullPartitionCountFunction(
+    const core::WindowNode::Function& function) {
+  const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
+  const auto baseName =
+      stripFunctionPrefix(function.functionCall->name(), prefix);
+  if (baseName != "count" || function.ignoreNulls ||
+      function.functionCall->type()->kind() != TypeKind::BIGINT ||
+      function.functionCall->inputs().size() != 1 ||
+      !isFullPartitionRowsFrame(function.frame)) {
+    return false;
+  }
+  const auto constant =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
+          function.functionCall->inputs().front());
+  return constant != nullptr && !constant->isNull();
+}
+
+bool isStreamingFullPartitionCountWindow(const core::WindowNode& windowNode) {
+  const auto& functions = windowNode.windowFunctions();
+  return windowNode.inputsSorted() && !windowNode.partitionKeys().empty() &&
+      windowNode.sortingKeys().empty() && !functions.empty() &&
+      std::all_of(
+             functions.begin(),
+             functions.end(),
+             isStreamingFullPartitionCountFunction);
+}
+
+bool isSupportedStreamingSumInputType(const TypePtr& type) {
+  switch (type->kind()) {
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+    case TypeKind::DOUBLE:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool isStreamingRangeSumFunction(const core::WindowNode::Function& function) {
+  const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
+  const auto baseName =
+      stripFunctionPrefix(function.functionCall->name(), prefix);
+  if (baseName != "sum" || function.ignoreNulls ||
+      function.functionCall->inputs().size() != 1 ||
+      function.frame.type != core::WindowNode::WindowType::kRange ||
+      function.frame.startType !=
+          core::WindowNode::BoundType::kUnboundedPreceding ||
+      function.frame.endType != core::WindowNode::BoundType::kCurrentRow ||
+      function.frame.startValue != nullptr ||
+      function.frame.endValue != nullptr) {
+    return false;
+  }
+  const auto& input = function.functionCall->inputs().front();
+  return std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(input) !=
+      nullptr &&
+      isSupportedStreamingSumInputType(input->type());
+}
+
+bool isStreamingRangeSumWindow(const core::WindowNode& windowNode) {
+  const auto& functions = windowNode.windowFunctions();
+  return windowNode.inputsSorted() && !windowNode.partitionKeys().empty() &&
+      !windowNode.sortingKeys().empty() && !functions.empty() &&
+      std::all_of(
+             functions.begin(), functions.end(), isStreamingRangeSumFunction);
 }
 
 bool isPartitionFirstFunction(const core::WindowNode::Function& function) {
@@ -502,6 +652,30 @@ bool CudfWindow::isSupportedWindowFunction(
   return true;
 }
 
+void CudfWindow::testingSetStreamingMemoryLimits(
+    uint64_t activeRowsBytes,
+    uint64_t replayChunkBytes) {
+  VELOX_CHECK_GT(activeRowsBytes, 0);
+  VELOX_CHECK_GT(replayChunkBytes, 0);
+  testingStreamingActiveRowsBytes.store(activeRowsBytes);
+  testingStreamingReplayChunkBytes.store(replayChunkBytes);
+  observedStreamingSpillWrites.store(0);
+  observedStreamingSpillCleanups.store(0);
+}
+
+void CudfWindow::testingResetStreamingMemoryLimits() {
+  testingStreamingActiveRowsBytes.store(0);
+  testingStreamingReplayChunkBytes.store(0);
+}
+
+uint64_t CudfWindow::testingStreamingSpillWrites() {
+  return observedStreamingSpillWrites.load();
+}
+
+uint64_t CudfWindow::testingStreamingSpillCleanups() {
+  return observedStreamingSpillCleanups.load();
+}
+
 bool CudfWindow::canRunOnGPU(const core::WindowNode& windowNode) {
   return canRunOnGPU(windowNode, nullptr);
 }
@@ -509,13 +683,26 @@ bool CudfWindow::canRunOnGPU(const core::WindowNode& windowNode) {
 bool CudfWindow::canRunOnGPU(
     const core::WindowNode& windowNode,
     std::string* reason) {
+  const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
+  const bool fullPartitionCountStreaming =
+      isStreamingFullPartitionCountWindow(windowNode);
   if (windowNode.sortingKeys().size() > 1 &&
       !isStreamingRankWindow(windowNode) &&
       !isPartitionFirstWindow(windowNode)) {
-    if (reason) {
-      *reason = "Multi-column ORDER BY requires a cuDF upgrade (follow-on PR)";
+    const auto hasUnsupportedRank = std::any_of(
+        windowNode.windowFunctions().begin(),
+        windowNode.windowFunctions().end(),
+        [&](const auto& function) {
+          const auto baseName =
+              stripFunctionPrefix(function.functionCall->name(), prefix);
+          return baseName == "rank" || baseName == "dense_rank";
+        });
+    if (hasUnsupportedRank) {
+      if (reason) {
+        *reason = "Multi-column rank requires the ordered streaming rank path";
+      }
+      return false;
     }
-    return false;
   }
 
   for (const auto& key : windowNode.partitionKeys()) {
@@ -542,7 +729,6 @@ bool CudfWindow::canRunOnGPU(
     }
   }
 
-  const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
   const auto inputType = asRowType(windowNode.inputType());
   for (const auto& func : windowNode.windowFunctions()) {
     const auto baseName =
@@ -695,10 +881,13 @@ bool CudfWindow::canRunOnGPU(
     if (usesFrame) {
       if (auto channel = resolveInputChannel(func, inputType)) {
         if (*channel == kConstantChannel) {
-          if (reason) {
-            *reason = "Constant window aggregate input not supported";
+          if (!fullPartitionCountStreaming ||
+              !isStreamingFullPartitionCountFunction(func)) {
+            if (reason) {
+              *reason = "Constant window aggregate input not supported";
+            }
+            return false;
           }
-          return false;
         }
       }
 
@@ -825,7 +1014,19 @@ CudfWindow::CudfWindow(
       windowNode_(windowNode),
       inputRowType_(asRowType(windowNode->inputType())),
       rankLikeStreaming_(isStreamingRankWindow(*windowNode)),
+      fullPartitionCountStreaming_(
+          isStreamingFullPartitionCountWindow(*windowNode)),
+      rangeSumStreaming_(isStreamingRangeSumWindow(*windowNode)),
+      boundedStreaming_(fullPartitionCountStreaming_ || rangeSumStreaming_),
       stateStream_(cudfGlobalStreamPool().get_stream()),
+      activeRowsLimit_(
+          testingStreamingActiveRowsBytes.load() > 0
+              ? testingStreamingActiveRowsBytes.load()
+              : kWindowStreamingActiveRowsBytes),
+      replayChunkLimit_(
+          testingStreamingReplayChunkBytes.load() > 0
+              ? testingStreamingReplayChunkBytes.load()
+              : kWindowMergeChunkBytes),
       sortedRunBytes_(CudfConfig::getInstance().windowSortedRunBytes) {
   const auto& inputType = windowNode->inputType();
 
@@ -855,6 +1056,32 @@ void CudfWindow::doAddInput(RowVectorPtr input) {
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput, "CudfWindow expects CudfVector input");
+
+  if (boundedStreaming_) {
+    VELOX_CHECK_NULL(
+        pendingOutput_,
+        "CudfWindow received sorted input before prior output was drained");
+    VELOX_CHECK_NULL(
+        deferredInput_,
+        "CudfWindow received sorted input while deferred input remained");
+    VELOX_CHECK_NULL(
+        streamingReplay_,
+        "CudfWindow received sorted input while replay was active");
+    const auto inputStream = cudfInput->stream();
+    if (inputStream.value() != stateStream_.value()) {
+      cudf::detail::join_streams(
+          std::vector<rmm::cuda_stream_view>{inputStream}, stateStream_);
+    }
+    VELOX_CHECK(
+        cudfInput->rebindStream(stateStream_),
+        "CudfWindow cannot rebind sorted input to its state stream");
+
+    stream_ = stateStream_;
+    streamAcquired_ = true;
+    deferredInput_ = cudfInput->release();
+    advanceBoundedStreaming();
+    return;
+  }
 
   if (rankLikeStreaming_) {
     VELOX_CHECK_NULL(
@@ -888,6 +1115,630 @@ void CudfWindow::doAddInput(RowVectorPtr input) {
   if (!windowNode_->inputsSorted() && !partitionKeyIndices_.empty() &&
       bufferedBytes_ >= sortedRunBytes_) {
     spillSortedRun();
+  }
+}
+
+std::vector<cudf::size_type> CudfWindow::streamingGroupIndices() const {
+  auto indices = partitionKeyIndices_;
+  if (rangeSumStreaming_) {
+    indices.insert(
+        indices.end(), sortKeyIndices_.begin(), sortKeyIndices_.end());
+  }
+  return indices;
+}
+
+std::vector<cudf::order> CudfWindow::streamingGroupOrders() const {
+  std::vector<cudf::order> orders(
+      partitionKeyIndices_.size(), cudf::order::ASCENDING);
+  if (rangeSumStreaming_) {
+    orders.insert(orders.end(), sortOrders_.begin(), sortOrders_.end());
+  }
+  return orders;
+}
+
+std::vector<cudf::null_order> CudfWindow::streamingGroupNullOrders() const {
+  std::vector<cudf::null_order> nullOrders(
+      partitionKeyIndices_.size(), cudf::null_order::BEFORE);
+  if (rangeSumStreaming_) {
+    nullOrders.insert(nullOrders.end(), nullOrders_.begin(), nullOrders_.end());
+  }
+  return nullOrders;
+}
+
+cudf::size_type CudfWindow::trailingGroupStart(
+    cudf::table_view input,
+    const std::vector<cudf::size_type>& indices,
+    const std::vector<cudf::order>& orders,
+    const std::vector<cudf::null_order>& nullOrders,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  VELOX_CHECK_GT(input.num_rows(), 0);
+  auto keys = cudf::table_view(selectColumns(input, indices));
+  auto last =
+      cudf::slice(keys, {input.num_rows() - 1, input.num_rows()}, stream);
+  auto positions =
+      cudf::lower_bound(keys, last.front(), orders, nullOrders, stream, mr);
+  return firstSearchPosition(positions->view(), stream);
+}
+
+uint64_t CudfWindow::measureTableBytes(std::unique_ptr<cudf::table>& table) {
+  VELOX_CHECK_NOT_NULL(table);
+  auto vector = std::make_shared<CudfVector>(
+      pool(), inputRowType_, table->num_rows(), std::move(table), stateStream_);
+  const auto bytes = vector->estimateFlatSize();
+  table = vector->release();
+  return bytes;
+}
+
+void CudfWindow::setPendingOutput(std::unique_ptr<cudf::table> output) {
+  VELOX_CHECK_NOT_NULL(output);
+  VELOX_CHECK_NULL(pendingOutput_);
+  if (output->num_rows() == 0) {
+    return;
+  }
+  pendingOutput_ = std::make_shared<CudfVector>(
+      pool(), outputType_, output->num_rows(), std::move(output), stateStream_);
+}
+
+std::unique_ptr<cudf::table> CudfWindow::appendConstantResults(
+    std::unique_ptr<cudf::table> rows,
+    const std::vector<std::unique_ptr<cudf::scalar>>& results) {
+  VELOX_CHECK_NOT_NULL(rows);
+  VELOX_CHECK_EQ(results.size(), windowNode_->windowFunctions().size());
+  const auto numRows = rows->num_rows();
+  auto columns = rows->release();
+  columns.reserve(columns.size() + results.size());
+  for (const auto& result : results) {
+    VELOX_CHECK_NOT_NULL(result);
+    columns.push_back(
+        cudf::make_column_from_scalar(
+            *result, numRows, stateStream_, get_output_mr()));
+  }
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
+std::unique_ptr<cudf::table> CudfWindow::computeFullPartitionCountOutput(
+    std::unique_ptr<cudf::table> input,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  VELOX_CHECK_NOT_NULL(input);
+  auto partitionColumns = selectColumns(input->view(), partitionKeyIndices_);
+  cudf::groupby::groupby grouper(
+      cudf::table_view(partitionColumns),
+      cudf::null_policy::INCLUDE,
+      cudf::sorted::YES,
+      std::vector<cudf::order>(
+          partitionKeyIndices_.size(), cudf::order::ASCENDING),
+      std::vector<cudf::null_order>(
+          partitionKeyIndices_.size(), cudf::null_order::BEFORE));
+  auto groups = grouper.get_groups({}, stream, mr);
+  VELOX_CHECK_GE(groups.offsets.size(), 2);
+
+  std::vector<int64_t> counts;
+  std::vector<cudf::size_type> repeats;
+  counts.reserve(groups.offsets.size() - 1);
+  repeats.reserve(groups.offsets.size() - 1);
+  for (size_t i = 1; i < groups.offsets.size(); ++i) {
+    const auto size = groups.offsets[i] - groups.offsets[i - 1];
+    counts.push_back(size);
+    repeats.push_back(size);
+  }
+  auto countsColumn = makeInt64Column(counts, stream, mr);
+  auto repeatsColumn = makeSizeTypeColumn(repeats, stream, mr);
+
+  auto columns = input->release();
+  columns.reserve(columns.size() + windowNode_->windowFunctions().size());
+  for (size_t i = 0; i < windowNode_->windowFunctions().size(); ++i) {
+    auto repeated = cudf::repeat(
+        cudf::table_view{{countsColumn->view()}},
+        repeatsColumn->view(),
+        stream,
+        mr);
+    auto resultColumns = repeated->release();
+    VELOX_CHECK_EQ(resultColumns.size(), 1);
+    columns.push_back(std::move(resultColumns.front()));
+  }
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
+std::unique_ptr<cudf::column> CudfWindow::computeRunningPartitionSumColumn(
+    const cudf::table_view& sortedInput,
+    const core::WindowNode::Function& function,
+    const TypePtr& expectedType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  VELOX_CHECK(!partitionKeyIndices_.empty());
+  const auto valueChannel = resolveInputChannel(function, inputRowType_);
+  VELOX_CHECK(valueChannel.has_value());
+  VELOX_CHECK_NE(*valueChannel, kConstantChannel);
+
+  auto partitionColumns = selectColumns(sortedInput, partitionKeyIndices_);
+  std::vector<cudf::groupby::scan_request> requests(1);
+  requests[0].values = sortedInput.column(*valueChannel);
+  requests[0].aggregations.push_back(
+      cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>());
+
+  cudf::groupby::groupby grouper(
+      cudf::table_view(partitionColumns),
+      cudf::null_policy::INCLUDE,
+      cudf::sorted::YES,
+      std::vector<cudf::order>(
+          partitionKeyIndices_.size(), cudf::order::ASCENDING),
+      std::vector<cudf::null_order>(
+          partitionKeyIndices_.size(), cudf::null_order::BEFORE));
+  auto scanResult = grouper.scan(requests, stream, mr);
+  VELOX_CHECK_EQ(scanResult.second.size(), 1);
+  VELOX_CHECK_EQ(scanResult.second[0].results.size(), 1);
+  auto result = std::move(scanResult.second[0].results[0]);
+  const auto expectedCudfType = veloxToCudfDataType(expectedType);
+  if (result->type() != expectedCudfType) {
+    result = cudf::cast(result->view(), expectedCudfType, stream, mr);
+  }
+  return result;
+}
+
+std::unique_ptr<cudf::table> CudfWindow::computeRangeRunningSumOutput(
+    std::unique_ptr<cudf::table> input,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_NOT_NULL(input);
+  VELOX_CHECK_GT(input->num_rows(), 0);
+  const auto inputView = input->view();
+  const auto numFunctions = windowNode_->windowFunctions().size();
+  const auto inputSize = inputRowType_->size();
+
+  std::vector<std::unique_ptr<cudf::column>> runningColumns;
+  std::vector<cudf::column_view> runningViews;
+  runningColumns.reserve(numFunctions);
+  runningViews.reserve(numFunctions);
+  for (size_t i = 0; i < numFunctions; ++i) {
+    runningColumns.push_back(computeRunningPartitionSumColumn(
+        inputView,
+        windowNode_->windowFunctions()[i],
+        outputType_->childAt(inputSize + i),
+        stream,
+        mr));
+    runningViews.push_back(runningColumns.back()->view());
+  }
+
+  auto partitionColumns = selectColumns(inputView, partitionKeyIndices_);
+  const std::vector<cudf::order> partitionOrders(
+      partitionKeyIndices_.size(), cudf::order::ASCENDING);
+  const std::vector<cudf::null_order> partitionNullOrders(
+      partitionKeyIndices_.size(), cudf::null_order::BEFORE);
+  cudf::groupby::groupby partitionGrouper(
+      cudf::table_view(partitionColumns),
+      cudf::null_policy::INCLUDE,
+      cudf::sorted::YES,
+      partitionOrders,
+      partitionNullOrders);
+  const std::vector<cudf::replace_policy> preceding(
+      numFunctions, cudf::replace_policy::PRECEDING);
+  auto filledRunning = partitionGrouper.replace_nulls(
+      cudf::table_view(runningViews), preceding, stream, mr);
+  runningColumns = filledRunning.second->release();
+
+  const auto samePartitionEnd = continuingPrefixSize(
+      inputView,
+      partitionKeyIndices_,
+      cumulativePartitionKey_,
+      partitionOrders,
+      partitionNullOrders,
+      stream,
+      mr);
+  if (samePartitionEnd > 0) {
+    VELOX_CHECK_EQ(cumulativeSums_.size(), numFunctions);
+    VELOX_CHECK_EQ(cumulativeValidCounts_.size(), numFunctions);
+    for (size_t i = 0; i < numFunctions; ++i) {
+      if (cumulativeValidCounts_[i] == 0) {
+        continue;
+      }
+      auto prefix =
+          cudf::slice(runningColumns[i]->view(), {0, samePartitionEnd}, stream);
+      auto added = cudf::binary_operation(
+          prefix.front(),
+          *cumulativeSums_[i],
+          cudf::binary_operator::ADD,
+          runningColumns[i]->type(),
+          stream,
+          mr);
+      auto fixed =
+          cudf::replace_nulls(added->view(), *cumulativeSums_[i], stream, mr);
+      if (samePartitionEnd == input->num_rows()) {
+        runningColumns[i] = std::move(fixed);
+      } else {
+        auto suffix = cudf::slice(
+            runningColumns[i]->view(),
+            {samePartitionEnd, input->num_rows()},
+            stream);
+        const std::vector<cudf::column_view> pieces{
+            fixed->view(), suffix.front()};
+        runningColumns[i] = cudf::concatenate(pieces, stream, mr);
+      }
+    }
+  }
+
+  auto peerColumns = selectColumns(inputView, streamingGroupIndices());
+  cudf::groupby::groupby peerGrouper(
+      cudf::table_view(peerColumns),
+      cudf::null_policy::INCLUDE,
+      cudf::sorted::YES,
+      streamingGroupOrders(),
+      streamingGroupNullOrders());
+  auto groups = peerGrouper.get_groups({}, stream, mr);
+  VELOX_CHECK_GE(groups.offsets.size(), 2);
+
+  std::vector<cudf::size_type> peerEnds;
+  std::vector<cudf::size_type> repeats;
+  peerEnds.reserve(groups.offsets.size() - 1);
+  repeats.reserve(groups.offsets.size() - 1);
+  for (size_t i = 1; i < groups.offsets.size(); ++i) {
+    peerEnds.push_back(groups.offsets[i] - 1);
+    repeats.push_back(groups.offsets[i] - groups.offsets[i - 1]);
+  }
+  auto peerEndsColumn = makeSizeTypeColumn(peerEnds, stream, mr);
+  auto repeatsColumn = makeSizeTypeColumn(repeats, stream, mr);
+
+  runningViews.clear();
+  for (const auto& column : runningColumns) {
+    runningViews.push_back(column->view());
+  }
+  auto peerResults = cudf::gather(
+      cudf::table_view(runningViews),
+      peerEndsColumn->view(),
+      cudf::out_of_bounds_policy::DONT_CHECK,
+      stream,
+      mr);
+  auto repeatedResults =
+      cudf::repeat(peerResults->view(), repeatsColumn->view(), stream, mr);
+  auto resultColumns = repeatedResults->release();
+
+  auto finalPartition = cudf::slice(
+      cudf::table_view(partitionColumns),
+      {input->num_rows() - 1, input->num_rows()},
+      stream);
+  cumulativePartitionKey_ =
+      std::make_unique<cudf::table>(finalPartition.front(), stream, mr);
+  cumulativeSums_.clear();
+  cumulativeValidCounts_.clear();
+  cumulativeSums_.reserve(numFunctions);
+  cumulativeValidCounts_.reserve(numFunctions);
+  for (const auto& column : resultColumns) {
+    auto value =
+        cudf::get_element(column->view(), input->num_rows() - 1, stream, mr);
+    cumulativeValidCounts_.push_back(value->is_valid(stream) ? 1 : 0);
+    cumulativeSums_.push_back(std::move(value));
+  }
+
+  auto columns = input->release();
+  columns.reserve(columns.size() + resultColumns.size());
+  for (auto& column : resultColumns) {
+    columns.push_back(std::move(column));
+  }
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
+void CudfWindow::updateActiveRangeSums(cudf::table_view rows) {
+  VELOX_CHECK(rangeSumStreaming_);
+  const auto numFunctions = windowNode_->windowFunctions().size();
+  if (activeSums_.empty()) {
+    activeSums_.resize(numFunctions);
+    activeValidCounts_.assign(numFunctions, 0);
+  }
+  VELOX_CHECK_EQ(activeSums_.size(), numFunctions);
+  VELOX_CHECK_EQ(activeValidCounts_.size(), numFunctions);
+
+  for (size_t i = 0; i < numFunctions; ++i) {
+    const auto valueChannel =
+        resolveInputChannel(windowNode_->windowFunctions()[i], inputRowType_);
+    VELOX_CHECK(valueChannel.has_value());
+    VELOX_CHECK_NE(*valueChannel, kConstantChannel);
+    const auto values = rows.column(*valueChannel);
+    const auto validCount = rows.num_rows() - values.null_count();
+    auto aggregation = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+    auto reduced = cudf::reduce(
+        values,
+        *aggregation,
+        veloxToCudfDataType(outputType_->childAt(inputRowType_->size() + i)),
+        stateStream_,
+        get_output_mr());
+    if (activeValidCounts_[i] > 0 && validCount > 0) {
+      activeSums_[i] = addValidScalars(
+          *activeSums_[i], *reduced, stateStream_, get_output_mr());
+    } else if (!activeSums_[i] || validCount > 0) {
+      activeSums_[i] = std::move(reduced);
+    }
+    activeValidCounts_[i] += validCount;
+  }
+}
+
+void CudfWindow::spillActiveRows() {
+  if (!activeRows_ || activeRows_->num_rows() == 0) {
+    return;
+  }
+  namespace fs = std::filesystem;
+  if (spillDirectory_.empty()) {
+    const auto& taskSpillRoot =
+        operatorCtx_->task()->getOrCreateSpillDirectory();
+    VELOX_CHECK(
+        !taskSpillRoot.empty(),
+        "CudfWindow requires an explicit Task spill directory");
+    const auto sequence = windowSpillDirectorySequence.fetch_add(1);
+    spillDirectory_ = (fs::path(taskSpillRoot) /
+                       fmt::format(
+                           "velox-cudf-window-spill-{}-{}",
+                           static_cast<int64_t>(::getpid()),
+                           sequence))
+                          .string();
+    fs::create_directories(spillDirectory_);
+  }
+
+  auto path = fmt::format(
+      "{}/active-{:06}.parquet", spillDirectory_, spillFileSequence_++);
+  auto options = cudf::io::parquet_writer_options::builder(
+                     cudf::io::sink_info{path}, activeRows_->view())
+                     .build();
+  cudf::io::write_parquet(options, stateStream_);
+  activeSpillPaths_.push_back(std::move(path));
+  activeRows_.reset();
+  activeRowsBytes_ = 0;
+  streamingSpilled_ = true;
+  observedStreamingSpillWrites.fetch_add(1);
+  ::malloc_trim(0);
+}
+
+void CudfWindow::appendActiveGroup(std::unique_ptr<cudf::table> rows) {
+  VELOX_CHECK_NOT_NULL(rows);
+  VELOX_CHECK_GT(rows->num_rows(), 0);
+  activeRowCount_ += rows->num_rows();
+  if (rangeSumStreaming_) {
+    updateActiveRangeSums(rows->view());
+  }
+  if (activeRows_) {
+    const std::vector<cudf::table_view> pieces{
+        activeRows_->view(), rows->view()};
+    activeRows_ = cudf::concatenate(pieces, stateStream_, get_output_mr());
+  } else {
+    activeRows_ = std::move(rows);
+  }
+  activeRowsBytes_ = measureTableBytes(activeRows_);
+  if (activeRowsBytes_ >= activeRowsLimit_) {
+    spillActiveRows();
+  }
+}
+
+void CudfWindow::startActiveGroup(std::unique_ptr<cudf::table> rows) {
+  VELOX_CHECK_NOT_NULL(rows);
+  VELOX_CHECK_GT(rows->num_rows(), 0);
+  VELOX_CHECK_NULL(activeKey_);
+  VELOX_CHECK_EQ(activeRowCount_, 0);
+  VELOX_CHECK(activeSpillPaths_.empty());
+  VELOX_CHECK_NULL(activeRows_);
+
+  auto groupColumns = selectColumns(rows->view(), streamingGroupIndices());
+  auto firstGroup =
+      cudf::slice(cudf::table_view(groupColumns), {0, 1}, stateStream_);
+  activeKey_ = std::make_unique<cudf::table>(
+      firstGroup.front(), stateStream_, get_output_mr());
+
+  if (rangeSumStreaming_) {
+    const std::vector<cudf::order> partitionOrders(
+        partitionKeyIndices_.size(), cudf::order::ASCENDING);
+    const std::vector<cudf::null_order> partitionNullOrders(
+        partitionKeyIndices_.size(), cudf::null_order::BEFORE);
+    const auto samePartition = continuingPrefixSize(
+        rows->view(),
+        partitionKeyIndices_,
+        cumulativePartitionKey_,
+        partitionOrders,
+        partitionNullOrders,
+        stateStream_,
+        get_output_mr());
+    if (samePartition == 0) {
+      cumulativePartitionKey_.reset();
+      cumulativeSums_.clear();
+      cumulativeValidCounts_.clear();
+    }
+  }
+  appendActiveGroup(std::move(rows));
+}
+
+void CudfWindow::finalizeActiveGroup() {
+  VELOX_CHECK_NOT_NULL(activeKey_);
+  VELOX_CHECK_GT(activeRowCount_, 0);
+  VELOX_CHECK(
+      activeRows_ != nullptr || !activeSpillPaths_.empty(),
+      "Active Window group has no retained rows");
+  VELOX_CHECK_NULL(streamingReplay_);
+
+  std::vector<std::unique_ptr<cudf::scalar>> results;
+  const auto numFunctions = windowNode_->windowFunctions().size();
+  results.reserve(numFunctions);
+  if (fullPartitionCountStreaming_) {
+    for (size_t i = 0; i < numFunctions; ++i) {
+      results.push_back(
+          std::make_unique<cudf::numeric_scalar<int64_t>>(
+              activeRowCount_, true, stateStream_, get_output_mr()));
+    }
+  } else {
+    VELOX_CHECK(rangeSumStreaming_);
+    VELOX_CHECK_EQ(activeSums_.size(), numFunctions);
+    VELOX_CHECK_EQ(activeValidCounts_.size(), numFunctions);
+    for (size_t i = 0; i < numFunctions; ++i) {
+      const auto hasCumulative =
+          i < cumulativeValidCounts_.size() && cumulativeValidCounts_[i] > 0;
+      const auto hasActive = activeValidCounts_[i] > 0;
+      if (hasCumulative && hasActive) {
+        results.push_back(addValidScalars(
+            *cumulativeSums_[i],
+            *activeSums_[i],
+            stateStream_,
+            get_output_mr()));
+      } else if (hasCumulative) {
+        results.push_back(
+            copyScalar(*cumulativeSums_[i], stateStream_, get_output_mr()));
+      } else {
+        results.push_back(
+            copyScalar(*activeSums_[i], stateStream_, get_output_mr()));
+      }
+    }
+
+    std::vector<cudf::size_type> partitionPositions(
+        partitionKeyIndices_.size());
+    std::iota(partitionPositions.begin(), partitionPositions.end(), 0);
+    auto partitionColumns =
+        selectColumns(activeKey_->view(), partitionPositions);
+    cumulativePartitionKey_ = std::make_unique<cudf::table>(
+        cudf::table_view(partitionColumns), stateStream_, get_output_mr());
+    cumulativeSums_.clear();
+    cumulativeValidCounts_.clear();
+    cumulativeSums_.reserve(numFunctions);
+    cumulativeValidCounts_.reserve(numFunctions);
+    for (const auto& result : results) {
+      cumulativeValidCounts_.push_back(result->is_valid(stateStream_) ? 1 : 0);
+      cumulativeSums_.push_back(
+          copyScalar(*result, stateStream_, get_output_mr()));
+    }
+  }
+
+  streamingReplay_ = std::make_unique<StreamingReplay>();
+  streamingReplay_->paths = std::exchange(activeSpillPaths_, {});
+  streamingReplay_->memoryRows = std::exchange(activeRows_, nullptr);
+  streamingReplay_->results = std::move(results);
+  activeRowsBytes_ = 0;
+  activeKey_.reset();
+  activeRowCount_ = 0;
+  activeSums_.clear();
+  activeValidCounts_.clear();
+}
+
+void CudfWindow::prepareNextStreamingReplayOutput() {
+  while (streamingReplay_ && pendingOutput_ == nullptr) {
+    if (streamingReplay_->reader) {
+      if (streamingReplay_->reader->has_next()) {
+        auto chunk = streamingReplay_->reader->read_chunk();
+        if (chunk.tbl->num_rows() > 0) {
+          setPendingOutput(appendConstantResults(
+              std::move(chunk.tbl), streamingReplay_->results));
+          return;
+        }
+        continue;
+      }
+      streamingReplay_->reader.reset();
+      ++streamingReplay_->nextPath;
+      continue;
+    }
+
+    if (streamingReplay_->nextPath < streamingReplay_->paths.size()) {
+      auto options =
+          cudf::io::parquet_reader_options::builder(
+              cudf::io::source_info{
+                  streamingReplay_->paths[streamingReplay_->nextPath]})
+              .build();
+      streamingReplay_->reader =
+          std::make_unique<cudf::io::chunked_parquet_reader>(
+              replayChunkLimit_, 0, options, stateStream_, get_output_mr());
+      continue;
+    }
+
+    if (streamingReplay_->memoryRows) {
+      auto output = appendConstantResults(
+          std::exchange(streamingReplay_->memoryRows, nullptr),
+          streamingReplay_->results);
+      streamingReplay_.reset();
+      setPendingOutput(std::move(output));
+      return;
+    }
+    streamingReplay_.reset();
+  }
+}
+
+void CudfWindow::processDeferredStreamingInput() {
+  VELOX_CHECK_NOT_NULL(deferredInput_);
+  VELOX_CHECK_GT(deferredInput_->num_rows(), 0);
+  const auto indices = streamingGroupIndices();
+  const auto orders = streamingGroupOrders();
+  const auto nullOrders = streamingGroupNullOrders();
+
+  if (activeKey_) {
+    const auto continuingRows = continuingPrefixSize(
+        deferredInput_->view(),
+        indices,
+        activeKey_,
+        orders,
+        nullOrders,
+        stateStream_,
+        get_output_mr());
+    if (continuingRows > 0) {
+      auto prefix = copyTableSlice(
+          deferredInput_->view(),
+          0,
+          continuingRows,
+          stateStream_,
+          get_output_mr());
+      auto suffix = copyTableSlice(
+          deferredInput_->view(),
+          continuingRows,
+          deferredInput_->num_rows(),
+          stateStream_,
+          get_output_mr());
+      deferredInput_ = std::move(suffix);
+      appendActiveGroup(std::move(prefix));
+      if (!deferredInput_ || deferredInput_->num_rows() == 0) {
+        deferredInput_.reset();
+        return;
+      }
+    }
+    finalizeActiveGroup();
+    return;
+  }
+
+  const auto trailingStart = trailingGroupStart(
+      deferredInput_->view(),
+      indices,
+      orders,
+      nullOrders,
+      stateStream_,
+      get_output_mr());
+  auto trailing = copyTableSlice(
+      deferredInput_->view(),
+      trailingStart,
+      deferredInput_->num_rows(),
+      stateStream_,
+      get_output_mr());
+  auto complete = copyTableSlice(
+      deferredInput_->view(), 0, trailingStart, stateStream_, get_output_mr());
+  deferredInput_.reset();
+
+  std::unique_ptr<cudf::table> output;
+  if (complete && complete->num_rows() > 0) {
+    output = fullPartitionCountStreaming_
+        ? computeFullPartitionCountOutput(
+              std::move(complete), stateStream_, get_output_mr())
+        : computeRangeRunningSumOutput(
+              std::move(complete), stateStream_, get_output_mr());
+  }
+  startActiveGroup(std::move(trailing));
+  if (output) {
+    setPendingOutput(std::move(output));
+  }
+}
+
+void CudfWindow::advanceBoundedStreaming() {
+  while (pendingOutput_ == nullptr) {
+    if (streamingReplay_) {
+      prepareNextStreamingReplayOutput();
+      continue;
+    }
+    if (deferredInput_) {
+      processDeferredStreamingInput();
+      continue;
+    }
+    if (noMoreInput_ && activeKey_) {
+      finalizeActiveGroup();
+      continue;
+    }
+    return;
   }
 }
 
@@ -1429,7 +2280,8 @@ void CudfWindow::computeRankColumnsBatch(
   }
 
   const auto numRows = logicalRowCount_;
-  // Single-column ORDER BY only (multi-column rejected in canRunOnGPU).
+  // Multi-column rank and dense_rank are rejected in canRunOnGPU. row_number
+  // is position-based, so the first key is only a placeholder for the scan.
   auto colOrder =
       sortKeyIndices_.empty() ? cudf::order::ASCENDING : sortOrders_[0];
   auto nullOrd =
@@ -1712,6 +2564,19 @@ std::unique_ptr<cudf::column> CudfWindow::computeAggregateColumn(
 void CudfWindow::doNoMoreInput() {
   Operator::noMoreInput();
 
+  if (boundedStreaming_) {
+    advanceBoundedStreaming();
+    if (activeKey_) {
+      finalizeActiveGroup();
+      advanceBoundedStreaming();
+    }
+    if (pendingOutput_ == nullptr && streamingReplay_ == nullptr &&
+        deferredInput_ == nullptr) {
+      finished_ = true;
+    }
+    return;
+  }
+
   if (rankLikeStreaming_) {
     finished_ = true;
     return;
@@ -1789,6 +2654,53 @@ void CudfWindow::doNoMoreInput() {
 
 bool CudfWindow::isFinished() {
   return finished_ && pendingOutput_ == nullptr;
+}
+
+std::unique_ptr<cudf::column> CudfWindow::makeRangePeerOrdinalColumn(
+    const cudf::table_view& sortedInput,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  VELOX_CHECK_GT(sortedInput.num_rows(), 0);
+  VELOX_CHECK_GT(sortKeyIndices_.size(), 1);
+
+  std::vector<cudf::size_type> peerKeyIndices = partitionKeyIndices_;
+  peerKeyIndices.insert(
+      peerKeyIndices.end(), sortKeyIndices_.begin(), sortKeyIndices_.end());
+  std::vector<cudf::order> peerOrders(
+      partitionKeyIndices_.size(), cudf::order::ASCENDING);
+  peerOrders.insert(peerOrders.end(), sortOrders_.begin(), sortOrders_.end());
+  std::vector<cudf::null_order> peerNullOrders(
+      partitionKeyIndices_.size(), cudf::null_order::BEFORE);
+  peerNullOrders.insert(
+      peerNullOrders.end(), nullOrders_.begin(), nullOrders_.end());
+
+  cudf::groupby::groupby peerGrouper(
+      cudf::table_view(selectColumns(sortedInput, peerKeyIndices)),
+      cudf::null_policy::INCLUDE,
+      cudf::sorted::YES,
+      peerOrders,
+      peerNullOrders);
+  auto groups = peerGrouper.get_groups({}, stream, mr);
+  VELOX_CHECK_GE(groups.offsets.size(), 2);
+
+  std::vector<int64_t> ordinals;
+  std::vector<cudf::size_type> repeats;
+  ordinals.reserve(groups.offsets.size() - 1);
+  repeats.reserve(groups.offsets.size() - 1);
+  for (size_t i = 1; i < groups.offsets.size(); ++i) {
+    ordinals.push_back(static_cast<int64_t>(i - 1));
+    repeats.push_back(groups.offsets[i] - groups.offsets[i - 1]);
+  }
+  auto ordinalColumn = makeInt64Column(ordinals, stream, mr);
+  auto repeatsColumn = makeSizeTypeColumn(repeats, stream, mr);
+  auto repeated = cudf::repeat(
+      cudf::table_view{{ordinalColumn->view()}},
+      repeatsColumn->view(),
+      stream,
+      mr);
+  auto columns = repeated->release();
+  VELOX_CHECK_EQ(columns.size(), 1);
+  return std::move(columns.front());
 }
 
 RowVectorPtr CudfWindow::computeOutput() {
@@ -1975,6 +2887,9 @@ RowVectorPtr CudfWindow::computeOutput() {
       orderbyColHolder =
           cudf::sequence(logicalRowCount_, oneScalar, oneScalar, stream_, mr);
       orderbyCol = asView(orderbyColHolder);
+    } else if (sortKeyIndices_.size() > 1) {
+      orderbyColHolder = makeRangePeerOrdinalColumn(sortedView, stream_, mr);
+      orderbyCol = asView(orderbyColHolder);
     } else {
       orderbyCol = sortedView.column(sortKeyIndices_[0]);
       order = sortOrders_[0];
@@ -2075,8 +2990,29 @@ RowVectorPtr CudfWindow::computeNextSortedOutput() {
 }
 
 RowVectorPtr CudfWindow::doGetOutput() {
+  auto takePending = [&]() -> RowVectorPtr {
+    auto output = std::exchange(pendingOutput_, nullptr);
+    if (boundedStreaming_ && noMoreInput_ && streamingReplay_ == nullptr &&
+        deferredInput_ == nullptr && activeKey_ == nullptr) {
+      finished_ = true;
+    }
+    return output;
+  };
+
   if (pendingOutput_) {
-    return std::exchange(pendingOutput_, nullptr);
+    return takePending();
+  }
+
+  if (boundedStreaming_) {
+    advanceBoundedStreaming();
+    if (pendingOutput_) {
+      return takePending();
+    }
+    if (noMoreInput_ && streamingReplay_ == nullptr &&
+        deferredInput_ == nullptr && activeKey_ == nullptr) {
+      finished_ = true;
+    }
+    return nullptr;
   }
 
   if (finished_ || !noMoreInput_) {
@@ -2108,7 +3044,9 @@ void CudfWindow::cleanupSpillFiles() noexcept {
   sortedRuns_.clear();
   mergeCarry_.reset();
   partitionCarry_.reset();
+  activeSpillPaths_.clear();
   if (spillDirectory_.empty()) {
+    streamingSpilled_ = false;
     return;
   }
   std::error_code error;
@@ -2118,7 +3056,11 @@ void CudfWindow::cleanupSpillFiles() noexcept {
                  << spillDirectory_ << " error=" << error.message();
   } else {
     spillDirectory_.clear();
+    if (streamingSpilled_) {
+      observedStreamingSpillCleanups.fetch_add(1);
+    }
   }
+  streamingSpilled_ = false;
   ::malloc_trim(0);
 }
 
@@ -2135,6 +3077,15 @@ void CudfWindow::doClose() {
   inputBatches_.clear();
   pendingOutput_.reset();
   sortedData_.reset();
+  deferredInput_.reset();
+  activeRows_.reset();
+  activeKey_.reset();
+  activeSums_.clear();
+  activeValidCounts_.clear();
+  cumulativePartitionKey_.reset();
+  cumulativeSums_.clear();
+  cumulativeValidCounts_.clear();
+  streamingReplay_.reset();
   previousPartitionKey_.reset();
   previousOrderKey_.reset();
   hasRankLikeState_ = false;

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -28,12 +28,14 @@
 #include "velox/type/Type.h"
 
 #include <cudf/aggregation.hpp>
+#include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/groupby.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/join/hash_join.hpp>
 #include <cudf/merge.hpp>
 #include <cudf/reduction.hpp>
 #include <cudf/replace.hpp>
@@ -53,6 +55,7 @@
 #include <malloc.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <filesystem>
 #include <limits>
@@ -92,6 +95,17 @@ cudf::size_type firstSearchPosition(
       stream.value()));
   stream.synchronize();
   return result;
+}
+
+std::vector<cudf::column_view> selectColumns(
+    const cudf::table_view& table,
+    const std::vector<cudf::size_type>& indices) {
+  std::vector<cudf::column_view> columns;
+  columns.reserve(indices.size());
+  for (const auto index : indices) {
+    columns.push_back(table.column(index));
+  }
+  return columns;
 }
 
 // Returns true when the window function's value argument is a cast expression.
@@ -216,6 +230,26 @@ cudf::rank_method toRankMethod(const std::string& name) {
     return cudf::rank_method::DENSE;
   }
   VELOX_FAIL("Unsupported rank window function: {}", name);
+}
+
+bool isStreamingRankFunction(const core::WindowNode::Function& function) {
+  const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
+  const auto baseName =
+      stripFunctionPrefix(function.functionCall->name(), prefix);
+  return (baseName == "row_number" || baseName == "rank") &&
+      function.functionCall->inputs().empty() && !function.ignoreNulls &&
+      function.frame.startType ==
+      core::WindowNode::BoundType::kUnboundedPreceding &&
+      function.frame.endType == core::WindowNode::BoundType::kCurrentRow &&
+      function.frame.startValue == nullptr &&
+      function.frame.endValue == nullptr;
+}
+
+bool isStreamingRankWindow(const core::WindowNode& windowNode) {
+  const auto& functions = windowNode.windowFunctions();
+  return windowNode.inputsSorted() && !windowNode.partitionKeys().empty() &&
+      !windowNode.sortingKeys().empty() && !functions.empty() &&
+      std::all_of(functions.begin(), functions.end(), isStreamingRankFunction);
 }
 
 std::unique_ptr<cudf::column> makeConstantOnesColumn(
@@ -453,7 +487,8 @@ bool CudfWindow::canRunOnGPU(const core::WindowNode& windowNode) {
 bool CudfWindow::canRunOnGPU(
     const core::WindowNode& windowNode,
     std::string* reason) {
-  if (windowNode.sortingKeys().size() > 1) {
+  if (windowNode.sortingKeys().size() > 1 &&
+      !isStreamingRankWindow(windowNode)) {
     if (reason) {
       *reason = "Multi-column ORDER BY requires a cuDF upgrade (follow-on PR)";
     }
@@ -752,6 +787,8 @@ CudfWindow::CudfWindow(
           NvtxMethodFlag::kAddInput | NvtxMethodFlag::kGetOutput),
       windowNode_(windowNode),
       inputRowType_(asRowType(windowNode->inputType())),
+      rankLikeStreaming_(isStreamingRankWindow(*windowNode)),
+      stateStream_(cudfGlobalStreamPool().get_stream()),
       sortedRunBytes_(CudfConfig::getInstance().windowSortedRunBytes) {
   const auto& inputType = windowNode->inputType();
 
@@ -781,6 +818,28 @@ void CudfWindow::doAddInput(RowVectorPtr input) {
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput, "CudfWindow expects CudfVector input");
+
+  if (rankLikeStreaming_) {
+    VELOX_CHECK_NULL(
+        pendingOutput_,
+        "CudfWindow received sorted input before prior output was drained");
+    const auto inputStream = cudfInput->stream();
+    if (inputStream.value() != stateStream_.value()) {
+      cudf::detail::join_streams(
+          std::vector<rmm::cuda_stream_view>{inputStream}, stateStream_);
+    }
+    VELOX_CHECK(
+        cudfInput->rebindStream(stateStream_),
+        "CudfWindow cannot rebind sorted input to its state stream");
+
+    stream_ = stateStream_;
+    streamAcquired_ = true;
+    logicalRowCount_ = cudfInput->size();
+    sortedData_ = cudfInput->release();
+    pendingOutput_ = computeOutput();
+    return;
+  }
+
   bufferedBytes_ += cudfInput->estimateFlatSize();
   inputBatches_.push_back(std::move(cudfInput));
 
@@ -997,6 +1056,328 @@ std::unique_ptr<cudf::table> CudfWindow::takeCompletePartitions(
     return nullptr;
   }
   return copyTableSlice(sorted->view(), 0, completeEnd, stream_, mr);
+}
+
+std::unique_ptr<cudf::column> CudfWindow::computeStreamingRowNumberColumn(
+    const cudf::table_view& sortedInput,
+    const TypePtr& expectedType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  const auto valuesColumn = sortedInput.column(sortKeyIndices_[0]);
+  const auto order = sortOrders_[0];
+  const auto nullOrder = nullOrders_[0];
+
+  std::vector<cudf::groupby::scan_request> requests(1);
+  requests[0].values = valuesColumn;
+  requests[0].aggregations.push_back(
+      cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+          cudf::rank_method::FIRST,
+          order,
+          cudf::null_policy::INCLUDE,
+          nullOrder));
+
+  cudf::groupby::groupby grouper(
+      cudf::table_view(selectColumns(sortedInput, partitionKeyIndices_)),
+      cudf::null_policy::INCLUDE,
+      cudf::sorted::YES,
+      std::vector<cudf::order>(
+          partitionKeyIndices_.size(), cudf::order::ASCENDING),
+      std::vector<cudf::null_order>(
+          partitionKeyIndices_.size(), cudf::null_order::BEFORE));
+
+  auto scanResult = grouper.scan(requests, stream, mr);
+  VELOX_CHECK_EQ(scanResult.second.size(), 1);
+  VELOX_CHECK_EQ(scanResult.second[0].results.size(), 1);
+  auto rowNumber = std::move(scanResult.second[0].results[0]);
+
+  const auto expectedCudfType = veloxToCudfDataType(expectedType);
+  if (rowNumber->type() != expectedCudfType) {
+    rowNumber = cudf::cast(rowNumber->view(), expectedCudfType, stream, mr);
+  }
+  return rowNumber;
+}
+
+std::unique_ptr<cudf::column> CudfWindow::computeStreamingRankColumn(
+    const cudf::table_view& sortedInput,
+    const TypePtr& expectedType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  auto rowNumber =
+      computeStreamingRowNumberColumn(sortedInput, expectedType, stream, mr);
+
+  std::vector<cudf::size_type> rankKeyIndices = partitionKeyIndices_;
+  rankKeyIndices.insert(
+      rankKeyIndices.end(), sortKeyIndices_.begin(), sortKeyIndices_.end());
+  auto rankKeyColumns = selectColumns(sortedInput, rankKeyIndices);
+  cudf::groupby::groupby grouper(
+      cudf::table_view(rankKeyColumns), cudf::null_policy::INCLUDE);
+
+  std::vector<cudf::groupby::aggregation_request> requests(1);
+  requests[0].values = rowNumber->view();
+  requests[0].aggregations.push_back(
+      cudf::make_min_aggregation<cudf::groupby_aggregation>());
+
+  auto [groupKeys, results] = grouper.aggregate(requests, stream, mr);
+  VELOX_CHECK_EQ(results.size(), 1);
+  VELOX_CHECK_EQ(results[0].results.size(), 1);
+  auto minRankByPeerGroup = std::move(results[0].results[0]);
+
+  cudf::hash_join lookup(
+      groupKeys->view(),
+      cudf::nullable_join::YES,
+      cudf::null_equality::EQUAL,
+      0.5,
+      stream);
+  auto [leftJoinIndices, rightJoinIndices] = lookup.left_join(
+      cudf::table_view(rankKeyColumns),
+      static_cast<std::size_t>(sortedInput.num_rows()),
+      stream,
+      mr);
+
+  auto leftIndicesCol = cudf::column_view{
+      cudf::device_span<const cudf::size_type>{*leftJoinIndices}};
+  auto rightIndicesCol = cudf::column_view{
+      cudf::device_span<const cudf::size_type>{*rightJoinIndices}};
+  auto gatheredRanks = cudf::gather(
+      cudf::table_view{{minRankByPeerGroup->view()}},
+      rightIndicesCol,
+      cudf::out_of_bounds_policy::NULLIFY,
+      stream,
+      mr);
+  auto gatheredColumns = gatheredRanks->release();
+  VELOX_CHECK_EQ(gatheredColumns.size(), 1);
+
+  auto target = cudf::allocate_like(
+      gatheredColumns[0]->view(),
+      sortedInput.num_rows(),
+      cudf::mask_allocation_policy::RETAIN,
+      stream,
+      mr);
+  auto scattered = cudf::scatter(
+      cudf::table_view{{gatheredColumns[0]->view()}},
+      leftIndicesCol,
+      cudf::table_view{{target->view()}},
+      stream,
+      mr);
+  return std::move(scattered->release()[0]);
+}
+
+cudf::size_type CudfWindow::continuingPrefixSize(
+    const cudf::table_view& sortedInput,
+    const std::vector<cudf::size_type>& indices,
+    const std::unique_ptr<cudf::table>& previousKey,
+    const std::vector<cudf::order>& orders,
+    const std::vector<cudf::null_order>& nullOrders,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  if (!previousKey || sortedInput.num_rows() == 0) {
+    return 0;
+  }
+  VELOX_CHECK_EQ(indices.size(), orders.size());
+  VELOX_CHECK_EQ(indices.size(), nullOrders.size());
+  auto positions = cudf::upper_bound(
+      cudf::table_view(selectColumns(sortedInput, indices)),
+      previousKey->view(),
+      orders,
+      nullOrders,
+      stream,
+      mr);
+  return firstSearchPosition(positions->view(), stream);
+}
+
+std::unique_ptr<cudf::column> CudfWindow::fixRankLikeColumn(
+    std::unique_ptr<cudf::column> localResult,
+    std::string_view functionName,
+    const cudf::table_view& sortedInput,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  if (!hasRankLikeState_ || sortedInput.num_rows() == 0) {
+    return localResult;
+  }
+
+  const std::vector<cudf::order> partitionOrders(
+      partitionKeyIndices_.size(), cudf::order::ASCENDING);
+  const std::vector<cudf::null_order> partitionNullOrders(
+      partitionKeyIndices_.size(), cudf::null_order::BEFORE);
+  const auto samePartitionEnd = continuingPrefixSize(
+      sortedInput,
+      partitionKeyIndices_,
+      previousPartitionKey_,
+      partitionOrders,
+      partitionNullOrders,
+      stream,
+      mr);
+  if (samePartitionEnd == 0) {
+    return localResult;
+  }
+
+  auto addOffset = [&](cudf::column_view values,
+                       int64_t offset) -> std::unique_ptr<cudf::column> {
+    switch (values.type().id()) {
+      case cudf::type_id::INT32: {
+        cudf::numeric_scalar<int32_t> scalar(
+            static_cast<int32_t>(offset), true, stream, mr);
+        return cudf::binary_operation(
+            values,
+            scalar,
+            cudf::binary_operator::ADD,
+            values.type(),
+            stream,
+            mr);
+      }
+      case cudf::type_id::INT64: {
+        cudf::numeric_scalar<int64_t> scalar(offset, true, stream, mr);
+        return cudf::binary_operation(
+            values,
+            scalar,
+            cudf::binary_operator::ADD,
+            values.type(),
+            stream,
+            mr);
+      }
+      default:
+        VELOX_FAIL(
+            "Unsupported rank output type {}",
+            static_cast<int>(values.type().id()));
+    }
+  };
+  auto makeConstant =
+      [&](int64_t value,
+          cudf::size_type rows) -> std::unique_ptr<cudf::column> {
+    switch (localResult->type().id()) {
+      case cudf::type_id::INT32: {
+        cudf::numeric_scalar<int32_t> scalar(
+            static_cast<int32_t>(value), true, stream, mr);
+        return cudf::make_column_from_scalar(scalar, rows, stream, mr);
+      }
+      case cudf::type_id::INT64: {
+        cudf::numeric_scalar<int64_t> scalar(value, true, stream, mr);
+        return cudf::make_column_from_scalar(scalar, rows, stream, mr);
+      }
+      default:
+        VELOX_FAIL(
+            "Unsupported rank output type {}",
+            static_cast<int>(localResult->type().id()));
+    }
+  };
+
+  std::vector<std::unique_ptr<cudf::column>> ownedSegments;
+  std::vector<cudf::column_view> segments;
+  auto appendUnchanged = [&](cudf::size_type begin, cudf::size_type end) {
+    if (begin == end) {
+      return;
+    }
+    auto slice = cudf::slice(localResult->view(), {begin, end}, stream);
+    segments.push_back(slice.front());
+  };
+  auto appendOffset =
+      [&](cudf::size_type begin, cudf::size_type end, int64_t offset) {
+        if (begin == end) {
+          return;
+        }
+        auto slice = cudf::slice(localResult->view(), {begin, end}, stream);
+        ownedSegments.push_back(addOffset(slice.front(), offset));
+        segments.push_back(ownedSegments.back()->view());
+      };
+
+  cudf::size_type fixedEnd{0};
+  if (functionName == "rank") {
+    auto continuingPartition =
+        cudf::slice(sortedInput, {0, samePartitionEnd}, stream);
+    const auto sameOrderEnd = continuingPrefixSize(
+        continuingPartition.front(),
+        sortKeyIndices_,
+        previousOrderKey_,
+        sortOrders_,
+        nullOrders_,
+        stream,
+        mr);
+    if (sameOrderEnd > 0) {
+      ownedSegments.push_back(makeConstant(previousRank_, sameOrderEnd));
+      segments.push_back(ownedSegments.back()->view());
+    }
+    fixedEnd = sameOrderEnd;
+  }
+  appendOffset(fixedEnd, samePartitionEnd, previousPartitionRows_);
+  appendUnchanged(samePartitionEnd, localResult->size());
+  VELOX_CHECK(!segments.empty());
+  return segments.size() == 1
+      ? std::make_unique<cudf::column>(segments.front(), stream, mr)
+      : cudf::concatenate(segments, stream, mr);
+}
+
+void CudfWindow::updateRankLikeState(
+    const cudf::table_view& sortedInput,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_GT(sortedInput.num_rows(), 0);
+  const auto numRows = sortedInput.num_rows();
+  const std::vector<cudf::order> partitionOrders(
+      partitionKeyIndices_.size(), cudf::order::ASCENDING);
+  const std::vector<cudf::null_order> partitionNullOrders(
+      partitionKeyIndices_.size(), cudf::null_order::BEFORE);
+  const auto continuedRows = hasRankLikeState_ ? continuingPrefixSize(
+                                                     sortedInput,
+                                                     partitionKeyIndices_,
+                                                     previousPartitionKey_,
+                                                     partitionOrders,
+                                                     partitionNullOrders,
+                                                     stream,
+                                                     mr)
+                                               : 0;
+  const bool continuedWholeBatch = continuedRows == numRows;
+
+  auto partitionColumns =
+      cudf::table_view(selectColumns(sortedInput, partitionKeyIndices_));
+  auto lastPartition =
+      cudf::slice(partitionColumns, {numRows - 1, numRows}, stream);
+  auto partitionPositions = cudf::lower_bound(
+      partitionColumns,
+      lastPartition.front(),
+      partitionOrders,
+      partitionNullOrders,
+      stream,
+      mr);
+  const auto trailingPartitionBegin =
+      firstSearchPosition(partitionPositions->view(), stream);
+
+  auto trailingPartition =
+      cudf::slice(sortedInput, {trailingPartitionBegin, numRows}, stream);
+  auto trailingOrderColumns = cudf::table_view(
+      selectColumns(trailingPartition.front(), sortKeyIndices_));
+  auto lastOrder = cudf::slice(
+      trailingOrderColumns,
+      {trailingOrderColumns.num_rows() - 1, trailingOrderColumns.num_rows()},
+      stream);
+  auto orderPositions = cudf::lower_bound(
+      trailingOrderColumns,
+      lastOrder.front(),
+      sortOrders_,
+      nullOrders_,
+      stream,
+      mr);
+  const auto lastPeerBegin =
+      firstSearchPosition(orderPositions->view(), stream);
+  const bool lastPeerContinued = continuedWholeBatch &&
+      continuingPrefixSize(
+          sortedInput,
+          sortKeyIndices_,
+          previousOrderKey_,
+          sortOrders_,
+          nullOrders_,
+          stream,
+          mr) == numRows;
+
+  const auto priorRows = continuedWholeBatch ? previousPartitionRows_ : 0;
+  if (!lastPeerContinued) {
+    previousRank_ = priorRows + lastPeerBegin + 1;
+  }
+  previousPartitionRows_ = priorRows + numRows - trailingPartitionBegin;
+  previousPartitionKey_ =
+      std::make_unique<cudf::table>(lastPartition.front(), stream, mr);
+  previousOrderKey_ =
+      std::make_unique<cudf::table>(lastOrder.front(), stream, mr);
+  hasRankLikeState_ = true;
 }
 
 void CudfWindow::computeRankColumnsBatch(
@@ -1219,6 +1600,11 @@ std::unique_ptr<cudf::column> CudfWindow::computeAggregateColumn(
 void CudfWindow::doNoMoreInput() {
   Operator::noMoreInput();
 
+  if (rankLikeStreaming_) {
+    finished_ = true;
+    return;
+  }
+
   if (spilled_) {
     if (!inputBatches_.empty()) {
       spillSortedRun();
@@ -1290,7 +1676,7 @@ void CudfWindow::doNoMoreInput() {
 }
 
 bool CudfWindow::isFinished() {
-  return finished_;
+  return finished_ && pendingOutput_ == nullptr;
 }
 
 RowVectorPtr CudfWindow::computeOutput() {
@@ -1303,7 +1689,7 @@ RowVectorPtr CudfWindow::computeOutput() {
   auto partKeys = sortedView.select(partitionKeyIndices_);
 
   std::unique_ptr<cudf::groupby::groupby> rankGrouper;
-  if (!partitionKeyIndices_.empty()) {
+  if (!rankLikeStreaming_ && !partitionKeyIndices_.empty()) {
     bool needsRankGrouper = false;
     const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
     for (const auto& func : windowNode_->windowFunctions()) {
@@ -1343,7 +1729,23 @@ RowVectorPtr CudfWindow::computeOutput() {
 
     if (baseName == "row_number" || baseName == "rank" ||
         baseName == "dense_rank") {
-      pendingRanks.emplace_back(funcIndex, baseName);
+      if (rankLikeStreaming_) {
+        auto localResult = baseName == "rank"
+            ? computeStreamingRankColumn(
+                  sortedView,
+                  outputType_->childAt(inputRowType_->size() + funcIndex),
+                  stream_,
+                  mr)
+            : computeStreamingRowNumberColumn(
+                  sortedView,
+                  outputType_->childAt(inputRowType_->size() + funcIndex),
+                  stream_,
+                  mr);
+        windowResultCols[funcIndex] = fixRankLikeColumn(
+            std::move(localResult), baseName, sortedView, stream_, mr);
+      } else {
+        pendingRanks.emplace_back(funcIndex, baseName);
+      }
     } else if (baseName == "lag" || baseName == "lead") {
       auto inputColIdx = resolveInputChannel(func, inputRowType_);
       VELOX_CHECK(
@@ -1438,6 +1840,10 @@ RowVectorPtr CudfWindow::computeOutput() {
       windowResultCols,
       stream_,
       mr);
+
+  if (rankLikeStreaming_) {
+    updateRankLikeState(sortedView, stream_, mr);
+  }
 
   if (!rangeRollingBatches.empty()) {
     ColumnOrView orderbyColHolder{cudf::column_view{}};
@@ -1549,6 +1955,10 @@ RowVectorPtr CudfWindow::computeNextSortedOutput() {
 }
 
 RowVectorPtr CudfWindow::doGetOutput() {
+  if (pendingOutput_) {
+    return std::exchange(pendingOutput_, nullptr);
+  }
+
   if (finished_ || !noMoreInput_) {
     return nullptr;
   }
@@ -1603,7 +2013,11 @@ void CudfWindow::doClose() {
     }
   }
   inputBatches_.clear();
+  pendingOutput_.reset();
   sortedData_.reset();
+  previousPartitionKey_.reset();
+  previousOrderKey_.reset();
+  hasRankLikeState_ = false;
   cleanupSpillFiles();
   if (streamAcquired_) {
     try {

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -252,6 +252,27 @@ bool isStreamingRankWindow(const core::WindowNode& windowNode) {
       std::all_of(functions.begin(), functions.end(), isStreamingRankFunction);
 }
 
+bool isPartitionFirstFunction(const core::WindowNode::Function& function) {
+  const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
+  const auto baseName =
+      stripFunctionPrefix(function.functionCall->name(), prefix);
+  return (baseName == "first" || baseName == "first_value") &&
+      function.functionCall->inputs().size() == 1 && !function.ignoreNulls &&
+      function.frame.type == core::WindowNode::WindowType::kRange &&
+      function.frame.startType ==
+      core::WindowNode::BoundType::kUnboundedPreceding &&
+      function.frame.endType == core::WindowNode::BoundType::kCurrentRow &&
+      function.frame.startValue == nullptr &&
+      function.frame.endValue == nullptr;
+}
+
+bool isPartitionFirstWindow(const core::WindowNode& windowNode) {
+  const auto& functions = windowNode.windowFunctions();
+  return !windowNode.partitionKeys().empty() &&
+      !windowNode.sortingKeys().empty() && !functions.empty() &&
+      std::all_of(functions.begin(), functions.end(), isPartitionFirstFunction);
+}
+
 std::unique_ptr<cudf::column> makeConstantOnesColumn(
     cudf::size_type numRows,
     rmm::cuda_stream_view stream,
@@ -463,6 +484,7 @@ bool CudfWindow::isSupportedWindowFunction(
       "row_number",
       "rank",
       "dense_rank",
+      "first",
       "first_value",
       "last_value",
       "sum",
@@ -488,7 +510,8 @@ bool CudfWindow::canRunOnGPU(
     const core::WindowNode& windowNode,
     std::string* reason) {
   if (windowNode.sortingKeys().size() > 1 &&
-      !isStreamingRankWindow(windowNode)) {
+      !isStreamingRankWindow(windowNode) &&
+      !isPartitionFirstWindow(windowNode)) {
     if (reason) {
       *reason = "Multi-column ORDER BY requires a cuDF upgrade (follow-on PR)";
     }
@@ -529,6 +552,20 @@ bool CudfWindow::canRunOnGPU(
       if (reason) {
         *reason = fmt::format(
             "Unsupported window function: {}", func.functionCall->name());
+      }
+      return false;
+    }
+
+    // Spark serializes its FIRST window aggregate as "first". Only admit the
+    // semantics implemented by computePartitionFirstColumn: RESPECT NULLS and
+    // RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW.
+    if (baseName == "first" &&
+        (!isPartitionFirstFunction(func) ||
+         windowNode.partitionKeys().empty() ||
+         windowNode.sortingKeys().empty())) {
+      if (reason) {
+        *reason =
+            "first is only supported for an ordered partition-first RANGE frame";
       }
       return false;
     }
@@ -651,7 +688,7 @@ bool CudfWindow::canRunOnGPU(
       return false;
     }
 
-    const bool usesFrame = baseName == "first_value" ||
+    const bool usesFrame = baseName == "first" || baseName == "first_value" ||
         baseName == "last_value" || baseName == "sum" || baseName == "min" ||
         baseName == "max" || baseName == "count" || baseName == "avg";
 
@@ -1579,6 +1616,81 @@ std::unique_ptr<cudf::column> CudfWindow::computeNthValueColumn(
       partKeys, inputCol, func, std::move(agg), isFullPartition, stream, mr);
 }
 
+std::unique_ptr<cudf::column> CudfWindow::computePartitionFirstColumn(
+    const cudf::table_view& sortedInput,
+    const core::WindowNode::Function& func,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  VELOX_CHECK(!partitionKeyIndices_.empty());
+  VELOX_CHECK(!sortKeyIndices_.empty());
+  VELOX_CHECK(isPartitionFirstFunction(func));
+
+  const auto valueChannel = resolveInputChannel(func, inputRowType_);
+  VELOX_CHECK(
+      valueChannel.has_value() && *valueChannel != kConstantChannel,
+      "Window first input must be a column");
+
+  auto partitionColumns = selectColumns(sortedInput, partitionKeyIndices_);
+  cudf::groupby::groupby grouper(
+      cudf::table_view(partitionColumns),
+      cudf::null_policy::INCLUDE,
+      cudf::sorted::YES,
+      std::vector<cudf::order>(
+          partitionKeyIndices_.size(), cudf::order::ASCENDING),
+      std::vector<cudf::null_order>(
+          partitionKeyIndices_.size(), cudf::null_order::BEFORE));
+
+  std::vector<cudf::groupby::aggregation_request> requests(1);
+  requests[0].values = sortedInput.column(*valueChannel);
+  requests[0].aggregations.push_back(
+      cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(
+          0, cudf::null_policy::INCLUDE));
+
+  auto [groupKeys, results] = grouper.aggregate(requests, stream, mr);
+  VELOX_CHECK_EQ(results.size(), 1);
+  VELOX_CHECK_EQ(results[0].results.size(), 1);
+  auto firstByGroup = std::move(results[0].results[0]);
+
+  cudf::hash_join lookup(
+      groupKeys->view(),
+      cudf::nullable_join::YES,
+      cudf::null_equality::EQUAL,
+      0.5,
+      stream);
+  auto [leftJoinIndices, rightJoinIndices] = lookup.left_join(
+      cudf::table_view(partitionColumns),
+      static_cast<std::size_t>(sortedInput.num_rows()),
+      stream,
+      mr);
+  auto leftIndicesCol = cudf::column_view{
+      cudf::device_span<cudf::size_type const>{*leftJoinIndices}};
+  auto rightIndicesCol = cudf::column_view{
+      cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
+
+  auto gatheredFirstValues = cudf::gather(
+      cudf::table_view{{firstByGroup->view()}},
+      rightIndicesCol,
+      cudf::out_of_bounds_policy::NULLIFY,
+      stream,
+      mr);
+  auto gatheredColumns = gatheredFirstValues->release();
+  VELOX_CHECK_EQ(gatheredColumns.size(), 1);
+
+  auto target = cudf::allocate_like(
+      gatheredColumns[0]->view(),
+      sortedInput.num_rows(),
+      cudf::mask_allocation_policy::RETAIN,
+      stream,
+      mr);
+  auto scattered = cudf::scatter(
+      cudf::table_view{{gatheredColumns[0]->view()}},
+      leftIndicesCol,
+      cudf::table_view{{target->view()}},
+      stream,
+      mr);
+  return std::move(scattered->release()[0]);
+}
+
 std::unique_ptr<cudf::column> CudfWindow::computeAggregateColumn(
     const cudf::table_view& partKeys,
     cudf::column_view inputCol,
@@ -1755,13 +1867,21 @@ RowVectorPtr CudfWindow::computeOutput() {
       auto inputCol = sortedView.column(*inputColIdx);
       windowResultCols[funcIndex] =
           computeLeadLagColumn(partKeys, inputCol, func, baseName, stream_, mr);
-    } else if (baseName == "first_value" || baseName == "last_value") {
+    } else if (
+        baseName == "first" || baseName == "first_value" ||
+        baseName == "last_value") {
       auto inputColIdx = resolveInputChannel(func, inputRowType_);
       VELOX_CHECK(
           inputColIdx.has_value(),
           "Window function {} requires an input column",
           baseName);
       auto inputCol = sortedView.column(*inputColIdx);
+      if (isPartitionFirstFunction(func) &&
+          (baseName == "first" || sortKeyIndices_.size() > 1)) {
+        windowResultCols[funcIndex] =
+            computePartitionFirstColumn(sortedView, func, stream_, mr);
+        continue;
+      }
       const bool isFullPartition =
           isFullPartitionFrame(func, !sortKeyIndices_.empty());
       if (auto rangeTypes = toBatchRangeWindowTypes(func, isFullPartition)) {

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -33,16 +33,19 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace facebook::velox::cudf_velox {
 
 /// GPU-accelerated Window operator using cuDF.
 ///
-/// Incoming GPU batches are stored in addInput(). Small inputs are concatenated
-/// and sorted when noMoreInput() is called. Large, unsorted, partitioned inputs
-/// are written as sorted runs and merged into complete-partition batches before
-/// window evaluation.
+/// Partitioned row_number/rank windows with an inputsSorted contract are
+/// evaluated and emitted one input batch at a time while retaining only the
+/// partition/order boundary state. Other windows store incoming GPU batches in
+/// addInput(). Small inputs are concatenated and sorted when noMoreInput() is
+/// called. Large, unsorted, partitioned inputs are written as sorted runs and
+/// merged into complete-partition batches before window evaluation.
 ///
 /// inputsSorted fast path: when WindowNode::inputsSorted() is true, this
 /// operator skips stable_sorted_order and the full-table gather (see
@@ -54,9 +57,9 @@ namespace facebook::velox::cudf_velox {
 /// sortOrders_/nullOrders_). Rank grouping with partition keys also assumes
 /// that partition-key ordering when constructing the groupby grouper.
 ///
-/// Memory: the sorted path peaks at roughly concat output plus gather copy plus
-/// window result columns. Batch-wise / streaming evaluation would require a
-/// larger redesign.
+/// Memory: the buffered sorted path peaks at roughly concat output plus gather
+/// copy plus window result columns. The narrow rank-like streaming path is
+/// bounded by one input/output batch and constant-size boundary state.
 ///
 /// Rank-like functions (row_number, rank, dense_rank) use
 /// cudf::groupby::scan with cudf::make_rank_aggregation.
@@ -83,7 +86,7 @@ class CudfWindow : public CudfOperatorBase {
       size_t numArgs);
 
   bool needsInput() const override {
-    return !noMoreInput_;
+    return !noMoreInput_ && pendingOutput_ == nullptr;
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -116,6 +119,39 @@ class CudfWindow : public CudfOperatorBase {
   RowVectorPtr computeNextSortedOutput();
   RowVectorPtr computeOutput();
   void cleanupSpillFiles() noexcept;
+
+  std::unique_ptr<cudf::column> computeStreamingRowNumberColumn(
+      const cudf::table_view& sortedInput,
+      const TypePtr& expectedType,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  std::unique_ptr<cudf::column> computeStreamingRankColumn(
+      const cudf::table_view& sortedInput,
+      const TypePtr& expectedType,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  std::unique_ptr<cudf::column> fixRankLikeColumn(
+      std::unique_ptr<cudf::column> localResult,
+      std::string_view functionName,
+      const cudf::table_view& sortedInput,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  void updateRankLikeState(
+      const cudf::table_view& sortedInput,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+
+  cudf::size_type continuingPrefixSize(
+      const cudf::table_view& sortedInput,
+      const std::vector<cudf::size_type>& indices,
+      const std::unique_ptr<cudf::table>& previousKey,
+      const std::vector<cudf::order>& orders,
+      const std::vector<cudf::null_order>& nullOrders,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
 
   // Compute row_number/rank/dense_rank via cudf::groupby::scan or cudf::scan.
   void computeRankColumnsBatch(
@@ -168,6 +204,8 @@ class CudfWindow : public CudfOperatorBase {
 
   std::shared_ptr<const core::WindowNode> windowNode_;
   const RowTypePtr inputRowType_;
+  const bool rankLikeStreaming_;
+  const rmm::cuda_stream_view stateStream_;
 
   std::vector<cudf::size_type> partitionKeyIndices_;
   std::vector<cudf::size_type> sortKeyIndices_;
@@ -175,6 +213,7 @@ class CudfWindow : public CudfOperatorBase {
   std::vector<cudf::null_order> nullOrders_;
 
   std::vector<CudfVectorPtr> inputBatches_;
+  RowVectorPtr pendingOutput_;
   const uint64_t sortedRunBytes_;
   uint64_t bufferedBytes_{0};
   std::vector<SortedRun> sortedRuns_;
@@ -191,6 +230,12 @@ class CudfWindow : public CudfOperatorBase {
   cudf::size_type logicalRowCount_{0};
   rmm::cuda_stream_view stream_{};
   bool streamAcquired_{false};
+
+  bool hasRankLikeState_{false};
+  std::unique_ptr<cudf::table> previousPartitionKey_;
+  std::unique_ptr<cudf::table> previousOrderKey_;
+  int64_t previousPartitionRows_{0};
+  int64_t previousRank_{0};
 
   bool finished_ = false;
 };

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -25,6 +25,7 @@
 #include <cudf/groupby.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/rolling.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 
@@ -85,8 +86,17 @@ class CudfWindow : public CudfOperatorBase {
       const std::string& baseName,
       size_t numArgs);
 
+  static void testingSetStreamingMemoryLimits(
+      uint64_t activeRowsBytes,
+      uint64_t replayChunkBytes);
+  static void testingResetStreamingMemoryLimits();
+  static uint64_t testingStreamingSpillWrites();
+  static uint64_t testingStreamingSpillCleanups();
+
   bool needsInput() const override {
-    return !noMoreInput_ && pendingOutput_ == nullptr;
+    return !noMoreInput_ && pendingOutput_ == nullptr &&
+        (!boundedStreaming_ ||
+         (deferredInput_ == nullptr && streamingReplay_ == nullptr));
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -105,6 +115,14 @@ class CudfWindow : public CudfOperatorBase {
   void doClose() override;
 
  private:
+  struct StreamingReplay {
+    std::vector<std::string> paths;
+    size_t nextPath{0};
+    std::unique_ptr<cudf::io::chunked_parquet_reader> reader;
+    std::unique_ptr<cudf::table> memoryRows;
+    std::vector<std::unique_ptr<cudf::scalar>> results;
+  };
+
   struct SortedRun {
     std::string path;
     std::unique_ptr<cudf::io::chunked_parquet_reader> reader;
@@ -119,6 +137,52 @@ class CudfWindow : public CudfOperatorBase {
   RowVectorPtr computeNextSortedOutput();
   RowVectorPtr computeOutput();
   void cleanupSpillFiles() noexcept;
+
+  std::unique_ptr<cudf::table> computeFullPartitionCountOutput(
+      std::unique_ptr<cudf::table> input,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  std::unique_ptr<cudf::table> computeRangeRunningSumOutput(
+      std::unique_ptr<cudf::table> input,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+
+  std::unique_ptr<cudf::column> computeRunningPartitionSumColumn(
+      const cudf::table_view& sortedInput,
+      const core::WindowNode::Function& function,
+      const TypePtr& expectedType,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  std::unique_ptr<cudf::column> makeRangePeerOrdinalColumn(
+      const cudf::table_view& sortedInput,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  std::vector<cudf::size_type> streamingGroupIndices() const;
+  std::vector<cudf::order> streamingGroupOrders() const;
+  std::vector<cudf::null_order> streamingGroupNullOrders() const;
+  cudf::size_type trailingGroupStart(
+      cudf::table_view input,
+      const std::vector<cudf::size_type>& indices,
+      const std::vector<cudf::order>& orders,
+      const std::vector<cudf::null_order>& nullOrders,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+  void advanceBoundedStreaming();
+  void processDeferredStreamingInput();
+  void startActiveGroup(std::unique_ptr<cudf::table> rows);
+  void appendActiveGroup(std::unique_ptr<cudf::table> rows);
+  void updateActiveRangeSums(cudf::table_view rows);
+  void finalizeActiveGroup();
+  void prepareNextStreamingReplayOutput();
+  void spillActiveRows();
+  uint64_t measureTableBytes(std::unique_ptr<cudf::table>& table);
+  void setPendingOutput(std::unique_ptr<cudf::table> output);
+  std::unique_ptr<cudf::table> appendConstantResults(
+      std::unique_ptr<cudf::table> rows,
+      const std::vector<std::unique_ptr<cudf::scalar>>& results);
 
   std::unique_ptr<cudf::column> computeStreamingRowNumberColumn(
       const cudf::table_view& sortedInput,
@@ -213,6 +277,9 @@ class CudfWindow : public CudfOperatorBase {
   std::shared_ptr<const core::WindowNode> windowNode_;
   const RowTypePtr inputRowType_;
   const bool rankLikeStreaming_;
+  const bool fullPartitionCountStreaming_;
+  const bool rangeSumStreaming_;
+  const bool boundedStreaming_;
   const rmm::cuda_stream_view stateStream_;
 
   std::vector<cudf::size_type> partitionKeyIndices_;
@@ -222,6 +289,8 @@ class CudfWindow : public CudfOperatorBase {
 
   std::vector<CudfVectorPtr> inputBatches_;
   RowVectorPtr pendingOutput_;
+  const uint64_t activeRowsLimit_;
+  const uint64_t replayChunkLimit_;
   const uint64_t sortedRunBytes_;
   uint64_t bufferedBytes_{0};
   std::vector<SortedRun> sortedRuns_;
@@ -232,12 +301,28 @@ class CudfWindow : public CudfOperatorBase {
   bool readersInitialized_{false};
   bool mergeFinished_{false};
   bool spilled_{false};
+  bool streamingSpilled_{false};
 
   // Sorted and concatenated input data, prepared in doNoMoreInput().
   std::unique_ptr<cudf::table> sortedData_;
   cudf::size_type logicalRowCount_{0};
   rmm::cuda_stream_view stream_{};
   bool streamAcquired_{false};
+
+  std::unique_ptr<cudf::table> deferredInput_;
+  std::unique_ptr<cudf::table> activeRows_;
+  uint64_t activeRowsBytes_{0};
+  std::vector<std::string> activeSpillPaths_;
+  std::unique_ptr<cudf::table> activeKey_;
+  int64_t activeRowCount_{0};
+  std::vector<std::unique_ptr<cudf::scalar>> activeSums_;
+  std::vector<int64_t> activeValidCounts_;
+
+  std::unique_ptr<cudf::table> cumulativePartitionKey_;
+  std::vector<std::unique_ptr<cudf::scalar>> cumulativeSums_;
+  std::vector<int64_t> cumulativeValidCounts_;
+
+  std::unique_ptr<StreamingReplay> streamingReplay_;
 
   bool hasRankLikeState_{false};
   std::unique_ptr<cudf::table> previousPartitionKey_;

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -170,6 +170,14 @@ class CudfWindow : public CudfOperatorBase {
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const;
 
+  // Compute a RESPECT NULLS first/first_value whose frame starts at the first
+  // row of its partition. This path supports ordering by multiple columns.
+  std::unique_ptr<cudf::column> computePartitionFirstColumn(
+      const cudf::table_view& sortedInput,
+      const core::WindowNode::Function& func,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
   // Compute first_value or last_value via cudf rolling window APIs.
   std::unique_ptr<cudf::column> computeNthValueColumn(
       const cudf::table_view& partKeys,

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -40,16 +40,76 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
 #include <cstdlib>
+#include <limits>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace facebook::velox::cudf_velox {
+
+namespace {
+std::mutex asyncMemoryPoolsMutex;
+std::vector<cudaMemPool_t> asyncMemoryPools;
+// registerCudf creates the main resource before its optional output resource.
+// Remember which device has seen that first resource so an async output-only
+// pool is never mistaken for the primary cuDF allocation pool.
+std::unordered_set<int> primaryMemoryResourceDevices;
+std::unordered_map<int, cudaMemPool_t> primaryAsyncMemoryPools;
+
+std::mutex deviceMemoryAdmissionMutex;
+std::unordered_map<int, std::size_t> deviceMemoryAdmissionBytes;
+
+struct MemoryResourceRegistration {
+  int device{-1};
+  bool primary{false};
+};
+
+MemoryResourceRegistration beginMemoryResourceRegistration() {
+  MemoryResourceRegistration registration;
+  if (cudaGetDevice(&registration.device) != cudaSuccess) {
+    return registration;
+  }
+  std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+  registration.primary =
+      primaryMemoryResourceDevices.insert(registration.device).second;
+  return registration;
+}
+
+void registerAsyncMemoryPool(
+    const MemoryResourceRegistration& registration,
+    cudaMemPool_t pool) {
+  std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+  asyncMemoryPools.push_back(pool);
+  if (registration.primary && registration.device >= 0) {
+    primaryAsyncMemoryPools[registration.device] = pool;
+  }
+}
+
+void releaseDeviceMemoryAdmission(int device, std::size_t bytes) noexcept {
+  std::lock_guard<std::mutex> lock(deviceMemoryAdmissionMutex);
+  const auto it = deviceMemoryAdmissionBytes.find(device);
+  if (it == deviceMemoryAdmissionBytes.end() || it->second < bytes) {
+    LOG(ERROR) << "Invalid device-memory admission release device=" << device
+               << " bytes=" << bytes;
+    return;
+  }
+  it->second -= bytes;
+  if (it->second == 0) {
+    deviceMemoryAdmissionBytes.erase(it);
+  }
+}
+} // namespace
 
 cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
     std::string_view mode,
     int percent) {
+  const auto registration = beginMemoryResourceRegistration();
   if (mode == "cuda") {
     return rmm::mr::cuda_memory_resource{};
   } else if (mode == "pool") {
@@ -57,7 +117,17 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
         rmm::mr::cuda_memory_resource{},
         rmm::percent_of_free_device_memory(percent));
   } else if (mode == "async") {
-    return rmm::mr::cuda_async_memory_resource{};
+    // cuda_async_memory_resource otherwise defaults its release threshold to
+    // UINT64_MAX. After a transient large join/partition workspace, the CUDA
+    // pool then retains almost the entire device even when RMM's live bytes
+    // have fallen. UCX receive buffers use a separate cudaMalloc resource and
+    // cannot reuse those cached blocks. Apply memoryPercent as the async
+    // pool's retention threshold so synchronization returns high-watermark
+    // slack while preserving a large cache for steady-state operators.
+    auto resource = rmm::mr::cuda_async_memory_resource(
+        std::nullopt, rmm::percent_of_free_device_memory(percent));
+    registerAsyncMemoryPool(registration, resource.pool_handle());
+    return resource;
   } else if (mode == "arena") {
     return rmm::mr::arena_memory_resource(
         rmm::mr::cuda_memory_resource{},
@@ -89,6 +159,199 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
       "Unknown memory resource mode: " + std::string(mode) +
       "\nExpecting: cuda, pool, async, arena, managed, prefetch_managed, " +
       "managed_pool, prefetch_managed_pool, managed_async, prefetch_managed_async");
+}
+
+bool trimAsyncMemoryPoolsAtQueryEnd() {
+  const auto* value = std::getenv("GLUTEN_CUDF_ASYNC_QUERY_END_TRIM_BYTES");
+  if (value == nullptr || value[0] == '\0') {
+    return false;
+  }
+
+  char* end = nullptr;
+  errno = 0;
+  const auto parsed = std::strtoull(value, &end, 10);
+  if (errno != 0 || end == value || *end != '\0') {
+    LOG(ERROR) << "Ignoring invalid GLUTEN_CUDF_ASYNC_QUERY_END_TRIM_BYTES='"
+               << value << "'";
+    return false;
+  }
+  return trimAsyncMemoryPoolsAtQueryEnd(static_cast<std::size_t>(parsed));
+}
+
+bool trimAsyncMemoryPoolsAtQueryEnd(std::size_t bytesToKeep) {
+  std::vector<cudaMemPool_t> pools;
+  {
+    std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+    pools = asyncMemoryPools;
+  }
+  if (pools.empty()) {
+    return false;
+  }
+
+  std::size_t freeBefore = 0;
+  std::size_t totalBytes = 0;
+  cudaMemGetInfo(&freeBefore, &totalBytes);
+  const auto syncStatus = cudaDeviceSynchronize();
+  if (syncStatus != cudaSuccess) {
+    LOG(ERROR) << "CUDF_ASYNC_QUERY_END_TRIM cudaDeviceSynchronize failed: "
+               << cudaGetErrorString(syncStatus);
+    return false;
+  }
+
+  for (const auto pool : pools) {
+    const auto trimStatus = cudaMemPoolTrimTo(pool, bytesToKeep);
+    if (trimStatus != cudaSuccess) {
+      LOG(ERROR) << "CUDF_ASYNC_QUERY_END_TRIM cudaMemPoolTrimTo failed: "
+                 << cudaGetErrorString(trimStatus)
+                 << " bytesToKeep=" << bytesToKeep;
+      return false;
+    }
+  }
+
+  std::size_t freeAfter = 0;
+  cudaMemGetInfo(&freeAfter, &totalBytes);
+  LOG(INFO) << "CUDF_ASYNC_QUERY_END_TRIM pools=" << pools.size()
+            << " bytesToKeep=" << bytesToKeep << " freeBefore=" << freeBefore
+            << " freeAfter=" << freeAfter << " released="
+            << (freeAfter >= freeBefore ? freeAfter - freeBefore : 0);
+  return true;
+}
+
+void clearAsyncMemoryPoolHandles() {
+  std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+  asyncMemoryPools.clear();
+  primaryAsyncMemoryPools.clear();
+  primaryMemoryResourceDevices.clear();
+}
+
+std::size_t DeviceAllocationHeadroom::reusablePoolBytes() const noexcept {
+  if (!asyncPoolValid || poolReservedBytes <= poolUsedBytes) {
+    return 0;
+  }
+  return poolReservedBytes - poolUsedBytes;
+}
+
+std::size_t DeviceAllocationHeadroom::allocatableBytes() const noexcept {
+  if (!cudaValid) {
+    return 0;
+  }
+  const auto reusable = reusablePoolBytes();
+  if (freeBytes > std::numeric_limits<std::size_t>::max() - reusable) {
+    return std::numeric_limits<std::size_t>::max();
+  }
+  return freeBytes + reusable;
+}
+
+DeviceAllocationHeadroom captureDeviceAllocationHeadroom() {
+  DeviceAllocationHeadroom headroom;
+  if (cudaGetDevice(&headroom.device) != cudaSuccess) {
+    return headroom;
+  }
+
+  headroom.cudaValid =
+      cudaMemGetInfo(&headroom.freeBytes, &headroom.totalBytes) == cudaSuccess;
+  if (!headroom.cudaValid) {
+    headroom.freeBytes = 0;
+    headroom.totalBytes = 0;
+    return headroom;
+  }
+
+  std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+  const auto poolIt = primaryAsyncMemoryPools.find(headroom.device);
+  if (poolIt == primaryAsyncMemoryPools.end()) {
+    return headroom;
+  }
+
+  std::uint64_t reservedBytes = 0;
+  std::uint64_t usedBytes = 0;
+  const auto reservedStatus = cudaMemPoolGetAttribute(
+      poolIt->second, cudaMemPoolAttrReservedMemCurrent, &reservedBytes);
+  const auto usedStatus = cudaMemPoolGetAttribute(
+      poolIt->second, cudaMemPoolAttrUsedMemCurrent, &usedBytes);
+  if (reservedStatus != cudaSuccess || usedStatus != cudaSuccess) {
+    return headroom;
+  }
+
+  headroom.asyncPoolValid = true;
+  headroom.poolReservedBytes = static_cast<std::size_t>(reservedBytes);
+  headroom.poolUsedBytes = static_cast<std::size_t>(usedBytes);
+  return headroom;
+}
+
+DeviceMemoryAdmissionReservation::DeviceMemoryAdmissionReservation(
+    int device,
+    std::size_t bytes) noexcept
+    : device_{device}, bytes_{bytes}, active_{true} {}
+
+DeviceMemoryAdmissionReservation::~DeviceMemoryAdmissionReservation() {
+  release();
+}
+
+DeviceMemoryAdmissionReservation::DeviceMemoryAdmissionReservation(
+    DeviceMemoryAdmissionReservation&& other) noexcept
+    : device_{other.device_}, bytes_{other.bytes_}, active_{other.active_} {
+  other.device_ = -1;
+  other.bytes_ = 0;
+  other.active_ = false;
+}
+
+DeviceMemoryAdmissionReservation& DeviceMemoryAdmissionReservation::operator=(
+    DeviceMemoryAdmissionReservation&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  release();
+  device_ = other.device_;
+  bytes_ = other.bytes_;
+  active_ = other.active_;
+  other.device_ = -1;
+  other.bytes_ = 0;
+  other.active_ = false;
+  return *this;
+}
+
+void DeviceMemoryAdmissionReservation::release() noexcept {
+  if (!active_) {
+    return;
+  }
+  releaseDeviceMemoryAdmission(device_, bytes_);
+  device_ = -1;
+  bytes_ = 0;
+  active_ = false;
+}
+
+std::optional<DeviceMemoryAdmissionReservation> tryAcquireDeviceMemoryAdmission(
+    int device,
+    std::size_t bytes,
+    std::size_t capacityBytes) {
+  if (device < 0 || bytes > capacityBytes) {
+    return std::nullopt;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(deviceMemoryAdmissionMutex);
+    const auto it = deviceMemoryAdmissionBytes.find(device);
+    const auto reserved =
+        it == deviceMemoryAdmissionBytes.end() ? 0 : it->second;
+    if (reserved > capacityBytes - bytes) {
+      return std::nullopt;
+    }
+    if (it == deviceMemoryAdmissionBytes.end()) {
+      deviceMemoryAdmissionBytes.emplace(device, bytes);
+    } else {
+      it->second += bytes;
+    }
+  }
+  return DeviceMemoryAdmissionReservation{device, bytes};
+}
+
+std::size_t deviceMemoryAdmissionReservedBytes(int device) {
+  if (device < 0) {
+    return 0;
+  }
+  std::lock_guard<std::mutex> lock(deviceMemoryAdmissionMutex);
+  const auto it = deviceMemoryAdmissionBytes.find(device);
+  return it == deviceMemoryAdmissionBytes.end() ? 0 : it->second;
 }
 
 cudf::detail::cuda_stream_pool& cudfGlobalStreamPool() {

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -46,6 +46,69 @@ struct DeviceMemorySnapshot {
   int64_t rmmTotalAllocations{0};
 };
 
+/// A cheap, always-available view of memory that allocations through the
+/// current device's primary cuDF resource may be able to use. When the primary
+/// resource is not cudaMallocAsync, or its pool attributes cannot be read,
+/// allocatableBytes() conservatively reports cudaMemGetInfo's free bytes only.
+struct DeviceAllocationHeadroom {
+  bool cudaValid{false};
+  bool asyncPoolValid{false};
+  int device{-1};
+  std::size_t freeBytes{0};
+  std::size_t totalBytes{0};
+  std::size_t poolReservedBytes{0};
+  std::size_t poolUsedBytes{0};
+
+  [[nodiscard]] std::size_t reusablePoolBytes() const noexcept;
+  [[nodiscard]] std::size_t allocatableBytes() const noexcept;
+};
+
+/// Process-wide, per-device admission reservation. This does not allocate GPU
+/// memory; it prevents cooperating operators from admitting work against the
+/// same headroom snapshot. The reservation is released on destruction.
+class DeviceMemoryAdmissionReservation {
+ public:
+  DeviceMemoryAdmissionReservation() = default;
+  ~DeviceMemoryAdmissionReservation();
+
+  DeviceMemoryAdmissionReservation(
+      DeviceMemoryAdmissionReservation&& other) noexcept;
+  DeviceMemoryAdmissionReservation& operator=(
+      DeviceMemoryAdmissionReservation&& other) noexcept;
+
+  DeviceMemoryAdmissionReservation(const DeviceMemoryAdmissionReservation&) =
+      delete;
+  DeviceMemoryAdmissionReservation& operator=(
+      const DeviceMemoryAdmissionReservation&) = delete;
+
+  [[nodiscard]] explicit operator bool() const noexcept {
+    return active_;
+  }
+
+  [[nodiscard]] int device() const noexcept {
+    return device_;
+  }
+
+  [[nodiscard]] std::size_t reservedBytes() const noexcept {
+    return bytes_;
+  }
+
+  void release() noexcept;
+
+ private:
+  friend std::optional<DeviceMemoryAdmissionReservation>
+  tryAcquireDeviceMemoryAdmission(
+      int device,
+      std::size_t bytes,
+      std::size_t capacityBytes);
+
+  DeviceMemoryAdmissionReservation(int device, std::size_t bytes) noexcept;
+
+  int device_{-1};
+  std::size_t bytes_{0};
+  bool active_{false};
+};
+
 extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
     output_mr_;
@@ -60,11 +123,42 @@ rmm::device_async_resource_ref get_output_mr();
  * @brief Creates a memory resource based on the given mode.
  *
  * @param mode rmm::mr::pool_memory_resource mode.
- * @param percent The initial percent of GPU memory to allocate for memory
- * resource.
+ * @param percent The initial percent of GPU memory to allocate for pool or
+ * arena resources, or the retained-memory release threshold for async.
  */
 [[nodiscard]] cuda::mr::any_resource<cuda::mr::device_accessible>
 createMemoryResource(std::string_view mode, int percent);
+
+/// If GLUTEN_CUDF_ASYNC_QUERY_END_TRIM_BYTES is set, synchronizes the device
+/// and releases unused cudaMallocAsync pool memory down to that retained-byte
+/// target. Returns true when a trim was requested and completed successfully.
+[[nodiscard]] bool trimAsyncMemoryPoolsAtQueryEnd();
+
+/// Explicit query-scoped variant. Unlike the no-argument environment
+/// fallback, a zero value is a valid request to release every unused block.
+[[nodiscard]] bool trimAsyncMemoryPoolsAtQueryEnd(std::size_t bytesToKeep);
+
+/// Drops native pool handles after their owning RMM resources are destroyed.
+void clearAsyncMemoryPoolHandles();
+
+/// Captures current-device free memory and, when the primary cuDF resource is
+/// cudaMallocAsync, that pool's currently reusable reserved memory. This API is
+/// independent of diagnostic logging and returns a conservative partial
+/// snapshot when pool attributes are unavailable.
+[[nodiscard]] DeviceAllocationHeadroom captureDeviceAllocationHeadroom();
+
+/// Atomically acquires a cooperative admission reservation for a device when
+/// existing reservations plus 'bytes' do not exceed 'capacityBytes'. Returns
+/// nullopt for invalid devices or insufficient capacity.
+[[nodiscard]] std::optional<DeviceMemoryAdmissionReservation>
+tryAcquireDeviceMemoryAdmission(
+    int device,
+    std::size_t bytes,
+    std::size_t capacityBytes);
+
+/// Returns bytes currently reserved by cooperative admission clients on a
+/// device. This is admission accounting, not live RMM allocation usage.
+[[nodiscard]] std::size_t deviceMemoryAdmissionReservedBytes(int device);
 
 /**
  * @brief Returns the global CUDA stream pool used by cudf.

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -1333,7 +1333,11 @@ class ExchangeAdapter : public OperatorAdapter {
               ctx,
               planNode,
               planNode->outputType(),
-              CudfConfig::getInstance().exchangeBatchSizeMinThreshold));
+              CudfConfig::getInstance().exchangeBatchSizeMinThreshold,
+              ctx->queryConfig().get<uint64_t>(
+                  CudfConfig::kCudfExchangeBatchSizeMinThresholdBytes,
+                  CudfConfig::getInstance()
+                      .exchangeBatchSizeMinThresholdBytes)));
     }
     return result;
   }

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -1325,6 +1325,16 @@ class ExchangeAdapter : public OperatorAdapter {
     result.push_back(
         std::make_unique<ucx_exchange::UcxExchange>(
             operatorId, ctx, planNode, client));
+    if (CudfConfig::getInstance().concatOptimizationEnabled &&
+        CudfConfig::getInstance().exchangeConcatOptimizationEnabled) {
+      result.push_back(
+          std::make_unique<CudfBatchConcat>(
+              operatorId,
+              ctx,
+              planNode,
+              planNode->outputType(),
+              CudfConfig::getInstance().exchangeBatchSizeMinThreshold));
+    }
     return result;
   }
 

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -503,6 +503,10 @@ void CudfConfig::initialize(
     batchSizeMinThreshold =
         folly::to<int32_t>(config[kCudfBatchSizeMinThreshold]);
   }
+  if (config.find(kCudfBatchSizeMinThresholdBytes) != config.end()) {
+    batchSizeMinThresholdBytes =
+        folly::to<uint64_t>(config[kCudfBatchSizeMinThresholdBytes]);
+  }
   if (config.find(kCudfBatchSizeMaxThreshold) != config.end()) {
     batchSizeMaxThreshold =
         folly::to<int32_t>(config[kCudfBatchSizeMaxThreshold]);

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -529,6 +529,7 @@ void unregisterCudf() {
   mr_.reset();
   output_statistics_mr_.reset();
   statistics_mr_.reset();
+  clearAsyncMemoryPoolHandles();
   exec::DriverFactory::adapters.erase(
       std::remove_if(
           exec::DriverFactory::adapters.begin(),
@@ -570,6 +571,10 @@ void CudfConfig::initialize(
   if (config.find(kCudfBatchSizeMinThresholdBytes) != config.end()) {
     batchSizeMinThresholdBytes =
         folly::to<uint64_t>(config[kCudfBatchSizeMinThresholdBytes]);
+  }
+  if (config.find(kCudfExchangeBatchSizeMinThreshold) != config.end()) {
+    exchangeBatchSizeMinThreshold =
+        folly::to<int32_t>(config[kCudfExchangeBatchSizeMinThreshold]);
   }
   if (config.find(kCudfBatchSizeMaxThreshold) != config.end()) {
     batchSizeMaxThreshold =
@@ -615,6 +620,28 @@ void CudfConfig::initialize(
     VELOX_USER_CHECK_GT(
         value, 0, "{} must be positive", kCudfWindowSortedRunBytes);
     windowSortedRunBytes = static_cast<uint64_t>(value);
+  }
+  if (config.find(kCudfOrderByOutputChunkBytes) != config.end()) {
+    const auto value = folly::to<int64_t>(config[kCudfOrderByOutputChunkBytes]);
+    VELOX_USER_CHECK_GT(
+        value, 0, "{} must be positive", kCudfOrderByOutputChunkBytes);
+    orderByOutputChunkBytes = static_cast<uint64_t>(value);
+  }
+  if (config.find(kCudfOrderByMaxOutputRows) != config.end()) {
+    const auto value = folly::to<int64_t>(config[kCudfOrderByMaxOutputRows]);
+    VELOX_USER_CHECK_GT(
+        value, 0, "{} must be positive", kCudfOrderByMaxOutputRows);
+    VELOX_USER_CHECK_LE(
+        value,
+        std::numeric_limits<int32_t>::max(),
+        "{} must not exceed {}",
+        kCudfOrderByMaxOutputRows,
+        std::numeric_limits<int32_t>::max());
+    orderByMaxOutputRows = static_cast<int32_t>(value);
+  }
+  if (config.find(kCudfExchangeConcatOptimizationEnabled) != config.end()) {
+    exchangeConcatOptimizationEnabled =
+        folly::to<bool>(config[kCudfExchangeConcatOptimizationEnabled]);
   }
   if (config.find(kCudfFunctionNamePrefix) != config.end()) {
     functionNamePrefix = config[kCudfFunctionNamePrefix];

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -33,6 +33,7 @@
 #include "velox/experimental/cudf/expression/JitExpression.h"
 #include "velox/experimental/cudf/expression/PrestoFunctions.h"
 #include "velox/experimental/cudf/expression/SparkFunctions.h"
+#include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
 
 #include "folly/Conv.h"
 #include "velox/core/PlanNode.h"
@@ -41,6 +42,7 @@
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/PartitionedOutput.h"
+#include "velox/exec/Task.h"
 #include "velox/exec/Values.h"
 
 #include <cudf/detail/nvtx/ranges.hpp>
@@ -120,6 +122,59 @@ RowTypePtr gpuInputBoundaryType(
   VELOX_CHECK_GT(
       planNode->sources().size(), 0, "GPU input boundary requires a source");
   return planNode->sources()[0]->outputType();
+}
+
+class UcxPartitionedOutputBufferManager final
+    : public exec::PartitionedOutputBufferManager {
+ public:
+  bool supports(
+      const core::PartitionedOutputNode& node,
+      const core::QueryConfig& queryConfig) const override {
+    const auto& config = CudfConfig::getInstance();
+    const auto cudfEnabled =
+        queryConfig.get<bool>(CudfConfig::kCudfEnabled, config.enabled);
+    return cudfEnabled && config.exchange &&
+        node.transportType() ==
+        core::PartitionedOutputNode::TransportType::kUcx;
+  }
+
+  void initializeTask(
+      std::shared_ptr<exec::Task> task,
+      core::PartitionedOutputNode::Kind kind,
+      int numPartitions,
+      int numOutputDrivers) override {
+    ucx_exchange::UcxOutputQueueManager::getInstanceRef()->initializeTask(
+        std::move(task), kind, numPartitions, numOutputDrivers);
+  }
+
+  void updateOutputBuffers(
+      const std::string& taskId,
+      int numBuffers,
+      bool noMoreBuffers) override {
+    ucx_exchange::UcxOutputQueueManager::getInstanceRef()
+        ->updateOutputBuffersIfExists(taskId, numBuffers, noMoreBuffers);
+  }
+
+  void updateNumDrivers(const std::string& taskId, uint32_t numOutputDrivers)
+      override {
+    ucx_exchange::UcxOutputQueueManager::getInstanceRef()
+        ->updateNumDriversIfExists(taskId, numOutputDrivers);
+  }
+
+  std::optional<exec::OutputBuffer::Stats> stats(
+      const std::string& taskId) override {
+    return ucx_exchange::UcxOutputQueueManager::getInstanceRef()->stats(taskId);
+  }
+
+  void removeTask(const std::string& taskId) override {
+    ucx_exchange::UcxOutputQueueManager::getInstanceRef()->removeTask(taskId);
+  }
+};
+
+std::shared_ptr<exec::PartitionedOutputBufferManager>&
+ucxPartitionedOutputBufferManagerRegistration() {
+  static std::shared_ptr<exec::PartitionedOutputBufferManager> manager;
+  return manager;
 }
 
 } // namespace
@@ -457,10 +512,19 @@ void registerCudf() {
     registerJitEvaluator(CudfConfig::getInstance().jitExpressionPriority);
   }
 
+  auto outputManager = std::make_shared<UcxPartitionedOutputBufferManager>();
+  VELOX_CHECK(exec::registerPartitionedOutputBufferManager(outputManager));
+  ucxPartitionedOutputBufferManagerRegistration() = std::move(outputManager);
+
   isCudfRegistered = true;
 }
 
 void unregisterCudf() {
+  auto& outputManager = ucxPartitionedOutputBufferManagerRegistration();
+  if (outputManager != nullptr) {
+    VELOX_CHECK(exec::unregisterPartitionedOutputBufferManager(outputManager));
+    outputManager.reset();
+  }
   output_mr_.reset();
   mr_.reset();
   output_statistics_mr_.reset();

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -576,6 +576,10 @@ void CudfConfig::initialize(
     exchangeBatchSizeMinThreshold =
         folly::to<int32_t>(config[kCudfExchangeBatchSizeMinThreshold]);
   }
+  if (config.find(kCudfExchangeBatchSizeMinThresholdBytes) != config.end()) {
+    exchangeBatchSizeMinThresholdBytes =
+        folly::to<uint64_t>(config[kCudfExchangeBatchSizeMinThresholdBytes]);
+  }
   if (config.find(kCudfBatchSizeMaxThreshold) != config.end()) {
     batchSizeMaxThreshold =
         folly::to<int32_t>(config[kCudfBatchSizeMaxThreshold]);

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -116,6 +116,14 @@ std::unique_ptr<cudf::column> makeEmptyColumnForType(
         0);
   };
   switch (type->kind()) {
+    case TypeKind::UNKNOWN:
+      // Velox uses UNKNOWN for an untyped NULL literal. cuDF has no physical
+      // UNKNOWN type, but an empty column carries no values whose type could
+      // be observed. Keep the same INT8 placeholder used by the row
+      // constructor for all-null UNKNOWN fields. This is required when an
+      // empty hash-join build side contains such a field and must synthesize
+      // its physical schema in noMoreInput().
+      return cudf::make_empty_column(cudf::data_type{cudf::type_id::INT8});
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
       return cudf::make_strings_column(

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -167,6 +167,122 @@ void setArrowSchemaTypesForCudfImport(
   }
 }
 
+bool containsUnknownType(const TypePtr& type) {
+  if (type->kind() == TypeKind::UNKNOWN) {
+    return true;
+  }
+  for (size_t i = 0; i < type->size(); ++i) {
+    if (containsUnknownType(type->childAt(i))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+TypePtr physicalTypeForCudfImport(const TypePtr& type) {
+  if (!containsUnknownType(type)) {
+    return type;
+  }
+  switch (type->kind()) {
+    case TypeKind::UNKNOWN:
+      return TINYINT();
+    case TypeKind::ROW: {
+      const auto rowType = asRowType(type);
+      std::vector<TypePtr> children;
+      children.reserve(rowType->size());
+      for (size_t i = 0; i < rowType->size(); ++i) {
+        children.push_back(physicalTypeForCudfImport(rowType->childAt(i)));
+      }
+      return ROW(rowType->names(), std::move(children));
+    }
+    case TypeKind::ARRAY:
+      return ARRAY(physicalTypeForCudfImport(type->childAt(0)));
+    case TypeKind::MAP:
+      return MAP(
+          physicalTypeForCudfImport(type->childAt(0)),
+          physicalTypeForCudfImport(type->childAt(1)));
+    default:
+      VELOX_UNREACHABLE(
+          "Type {} reported an UNKNOWN child but is not complex", type);
+  }
+}
+
+// Arrow's null type imports into cuDF as an EMPTY column. EMPTY is useful as
+// an Arrow placeholder, but cuDF operators such as gather and hash join cannot
+// dispatch it. Convert logical Velox UNKNOWN vectors to all-null INT8 transport
+// vectors before Arrow export. The reverse conversion in restoreLogicalTypes()
+// restores the requested UNKNOWN schema when data returns to Velox.
+VectorPtr prepareLogicalTypesForCudfImport(
+    const VectorPtr& vector,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(vector);
+  const auto& type = vector->type();
+  if (!containsUnknownType(type)) {
+    return vector;
+  }
+
+  if (type->kind() == TypeKind::UNKNOWN) {
+    for (vector_size_t i = 0; i < vector->size(); ++i) {
+      VELOX_CHECK(
+          vector->isNullAt(i),
+          "Cannot encode UNKNOWN non-null value for cuDF at row {}",
+          i);
+    }
+    return BaseVector::createNullConstant(TINYINT(), vector->size(), pool);
+  }
+
+  switch (type->kind()) {
+    case TypeKind::ROW: {
+      const auto row = std::dynamic_pointer_cast<RowVector>(vector);
+      VELOX_CHECK_NOT_NULL(row);
+      std::vector<VectorPtr> children;
+      children.reserve(row->childrenSize());
+      for (size_t i = 0; i < row->childrenSize(); ++i) {
+        children.push_back(
+            prepareLogicalTypesForCudfImport(row->childAt(i), pool));
+      }
+      return std::make_shared<RowVector>(
+          pool,
+          physicalTypeForCudfImport(type),
+          row->nulls(),
+          row->size(),
+          std::move(children),
+          row->getNullCount());
+    }
+    case TypeKind::ARRAY: {
+      const auto array = std::dynamic_pointer_cast<ArrayVector>(vector);
+      VELOX_CHECK_NOT_NULL(array);
+      return std::make_shared<ArrayVector>(
+          pool,
+          physicalTypeForCudfImport(type),
+          array->nulls(),
+          array->size(),
+          array->offsets(),
+          array->sizes(),
+          prepareLogicalTypesForCudfImport(array->elements(), pool),
+          array->getNullCount());
+    }
+    case TypeKind::MAP: {
+      const auto map = std::dynamic_pointer_cast<MapVector>(vector);
+      VELOX_CHECK_NOT_NULL(map);
+      return std::make_shared<MapVector>(
+          pool,
+          physicalTypeForCudfImport(type),
+          map->nulls(),
+          map->size(),
+          map->offsets(),
+          map->sizes(),
+          prepareLogicalTypesForCudfImport(map->mapKeys(), pool),
+          prepareLogicalTypesForCudfImport(map->mapValues(), pool),
+          map->getNullCount(),
+          map->hasSortedKeys());
+    }
+    default:
+      VELOX_UNREACHABLE(
+          "Type {} reported an UNKNOWN child but is not complex", type);
+  }
+}
+
 } // namespace
 
 std::unique_ptr<cudf::table> toCudfTable(
@@ -202,13 +318,8 @@ std::unique_ptr<cudf::table> toCudfTable(
       .timestampTimeZone = timestampTimeZone,
       .exportVarbinaryAsString = true,
       .useDecimalTypeWidth = true};
-  auto exportVector =
-      std::static_pointer_cast<BaseVector>(std::make_shared<RowVector>(
-          veloxTable->pool(),
-          veloxTable->type(),
-          veloxTable->nulls(),
-          veloxTable->size(),
-          veloxTable->children()));
+  auto exportVector = std::static_pointer_cast<BaseVector>(
+      prepareLogicalTypesForCudfImport(veloxTable, pool));
   BaseVector::flattenVector(exportVector);
   ArrowArray arrowArray;
   exportToArrow(exportVector, arrowArray, pool, arrowOptions);
@@ -288,6 +399,114 @@ void setArrowSchemaTypesFromVelox(ArrowSchema* schema, const TypePtr& type) {
   }
 }
 
+// cuDF has no physical representation for Velox's UNKNOWN type. Producers use
+// an all-null INT8 column as the transport representation. Arrow therefore
+// imports that column as TINYINT, which makes RowVector::setType fail before it
+// can restore the requested logical schema. Rebuild the complex-vector path and
+// replace these placeholders with real UNKNOWN null constants first.
+VectorPtr restoreLogicalTypes(
+    const VectorPtr& vector,
+    const TypePtr& type,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(vector);
+  VELOX_CHECK_NOT_NULL(type);
+
+  if (type->kind() == TypeKind::UNKNOWN) {
+    for (vector_size_t i = 0; i < vector->size(); ++i) {
+      VELOX_CHECK(
+          vector->isNullAt(i),
+          "Cannot restore UNKNOWN from a non-null physical value at row {}",
+          i);
+    }
+    return BaseVector::createNullConstant(type, vector->size(), pool);
+  }
+
+  switch (type->kind()) {
+    case TypeKind::ROW: {
+      auto row = std::dynamic_pointer_cast<RowVector>(vector);
+      VELOX_CHECK_NOT_NULL(
+          row,
+          "Expected ROW physical vector for logical type {}, got {}",
+          type,
+          vector->type());
+      VELOX_CHECK_EQ(row->childrenSize(), type->size());
+      std::vector<VectorPtr> children;
+      children.reserve(type->size());
+      for (size_t i = 0; i < type->size(); ++i) {
+        children.push_back(
+            restoreLogicalTypes(row->childAt(i), type->childAt(i), pool));
+      }
+      return std::make_shared<RowVector>(
+          pool,
+          type,
+          row->nulls(),
+          row->size(),
+          std::move(children),
+          row->getNullCount());
+    }
+    case TypeKind::ARRAY: {
+      auto array = std::dynamic_pointer_cast<ArrayVector>(vector);
+      VELOX_CHECK_NOT_NULL(
+          array,
+          "Expected ARRAY physical vector for logical type {}, got {}",
+          type,
+          vector->type());
+      return std::make_shared<ArrayVector>(
+          pool,
+          type,
+          array->nulls(),
+          array->size(),
+          array->offsets(),
+          array->sizes(),
+          restoreLogicalTypes(array->elements(), type->childAt(0), pool),
+          array->getNullCount());
+    }
+    case TypeKind::MAP: {
+      auto map = std::dynamic_pointer_cast<MapVector>(vector);
+      VELOX_CHECK_NOT_NULL(
+          map,
+          "Expected MAP physical vector for logical type {}, got {}",
+          type,
+          vector->type());
+      return std::make_shared<MapVector>(
+          pool,
+          type,
+          map->nulls(),
+          map->size(),
+          map->offsets(),
+          map->sizes(),
+          restoreLogicalTypes(map->mapKeys(), type->childAt(0), pool),
+          restoreLogicalTypes(map->mapValues(), type->childAt(1), pool),
+          map->getNullCount(),
+          map->hasSortedKeys());
+    }
+    default:
+      // An untyped NULL can acquire a concrete logical type after Spark/Velox
+      // type coercion without adding a physical cuDF cast.  Its transport
+      // column is still all-null INT8.  Rebuild such columns with the requested
+      // logical type; never reinterpret a non-null physical value.
+      if (!vector->type()->kindEquals(type)) {
+        for (vector_size_t i = 0; i < vector->size(); ++i) {
+          VELOX_CHECK(
+              vector->isNullAt(i),
+              "Cannot restore logical type {} from physical type {} with a "
+              "non-null value at row {}",
+              type,
+              vector->type(),
+              i);
+        }
+        return BaseVector::createNullConstant(type, vector->size(), pool);
+      }
+      VELOX_CHECK(
+          vector->type()->kindEquals(type),
+          "Cannot restore logical type {} from physical type {}",
+          type,
+          vector->type());
+      vector->setType(type);
+      return vector;
+  }
+}
+
 RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
     memory::MemoryPool* pool,
@@ -325,6 +544,9 @@ RowVectorPtr toVeloxColumn(
   }
 
   auto veloxTable = importFromArrowAsOwner(schemaCopy, arrayCopy, pool);
+  if (outputType) {
+    veloxTable = restoreLogicalTypes(veloxTable, *outputType, pool);
+  }
 
   // BaseVector to RowVector
   auto castedPtr =

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -670,6 +670,15 @@ bool isUnsupportedConstantLiteral(
   return !isSupportedCudfScalarLiteralType(expr->type());
 }
 
+bool isUntypedNullConstantLiteral(
+    const std::shared_ptr<velox::exec::Expr>& expr) {
+  const auto constant =
+      std::dynamic_pointer_cast<velox::exec::ConstantExpr>(expr);
+  return constant != nullptr && constant->value() != nullptr &&
+      constant->type()->kind() == TypeKind::UNKNOWN &&
+      constant->value()->isNullAt(0);
+}
+
 bool isNonNullEmptyArrayConstantLiteral(
     const std::shared_ptr<velox::exec::Expr>& expr) {
   const auto constant =
@@ -694,8 +703,12 @@ bool isNonNullEmptyArrayConstantLiteral(
 
 bool hasUnsupportedComplexConstantLiteral(
     const std::shared_ptr<velox::exec::Expr>& expr) {
+  const bool isRowConstructor = expr->name() == "row_constructor" ||
+      expr->name() == "row_constructor_with_null" ||
+      expr->name() == "row_constructor_with_all_null";
   for (const auto& input : expr->inputs()) {
     if (isUnsupportedConstantLiteral(input) &&
+        !(isRowConstructor && isUntypedNullConstantLiteral(input)) &&
         !(expr->name() == "coalesce" &&
           isNonNullEmptyArrayConstantLiteral(input))) {
       return true;
@@ -3882,10 +3895,14 @@ class RowConstructorFunction : public CudfFunction {
     literals_.reserve(numInputs_);
     for (const auto& input : expr->inputs()) {
       if (auto constant = std::dynamic_pointer_cast<ConstantExpr>(input)) {
-        literals_.push_back(makeScalarFromConstantExpr(constant));
+        const bool isUntypedNull = isUntypedNullConstantLiteral(input);
+        literals_.push_back(
+            isUntypedNull ? nullptr : makeScalarFromConstantExpr(constant));
+        untypedNullLiterals_.push_back(isUntypedNull);
       } else {
         hasNonLiteralInput = true;
         literals_.push_back(nullptr);
+        untypedNullLiterals_.push_back(false);
       }
     }
     if (!hasNonLiteralInput) {
@@ -3906,10 +3923,22 @@ class RowConstructorFunction : public CudfFunction {
     children.reserve(numInputs_);
 
     size_t nextInputColumnIndex = 0;
-    for (const auto& literal : literals_) {
+    for (size_t i = 0; i < literals_.size(); ++i) {
+      const auto& literal = literals_[i];
       if (literal) {
         children.push_back(
             cudf::make_column_from_scalar(*literal, outputSize, stream, mr));
+      } else if (untypedNullLiterals_[i]) {
+        // Velox UNKNOWN is the logical type of an untyped NULL literal and
+        // has no cuDF physical type. Keep the logical UNKNOWN in the row
+        // schema and use an all-null byte column as its inert physical child.
+        children.push_back(
+            cudf::make_fixed_width_column(
+                cudf::data_type{cudf::type_id::INT8},
+                outputSize,
+                cudf::mask_state::ALL_NULL,
+                stream,
+                mr));
       } else {
         VELOX_CHECK_LT(nextInputColumnIndex, inputColumns.size());
         children.push_back(
@@ -3949,6 +3978,7 @@ class RowConstructorFunction : public CudfFunction {
       rmm::device_async_resource_ref mr);
 
   std::vector<std::unique_ptr<cudf::scalar>> literals_;
+  std::vector<bool> untypedNullLiterals_;
   RowParentNullPolicy parentNullPolicy_;
   std::string functionName_;
   size_t numInputs_{0};

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/experimental/cudf/tests/CudfFunctionBaseTest.h"
 
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/WindowFunction.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -396,6 +397,37 @@ TEST_F(AdapterOperatorTest, orderedFirstValueUsesCudfWindow) {
                   .assertResults(
                       "SELECT k, v, o0, o1, first_value(v) over (partition by "
                       "k order by o0 desc nulls last, o1 desc nulls last) "
+                      "FROM tmp");
+
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(AdapterOperatorTest, orderedSparkFirstUsesCudfWindow) {
+  // Spark's Substrait conversion emits the aggregate-window alias "first".
+  // Reuse first_value's CPU registration so PlanBuilder can construct the
+  // same WindowNode shape that the Spark integration sends to the adapter.
+  exec::windowFunctions()["first"] = exec::windowFunctions().at("first_value");
+
+  auto data = makeRowVector(
+      {"k", "v", "o0", "o1"},
+      {makeFlatVector<int64_t>({1, 1, 1, 2, 2, 2}),
+       makeNullableFlatVector<int64_t>({10, 20, 40, 7, std::nullopt, 9}),
+       makeNullableFlatVector<int64_t>({5, 7, 9, 1, 3, 2}),
+       makeNullableFlatVector<int64_t>({100, 50, 10, 1, 1, 1})});
+  createDuckDbTable({data});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"first(v) over (partition by k order by o0 desc "
+                           "nulls last, o1 desc nulls last) as first_v"})
+                  .planNode();
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .config("cudf.enabled", true)
+                  .plan(plan)
+                  .assertResults(
+                      "SELECT k, v, o0, o1, first(v) over (partition by k "
+                      "order by o0 desc nulls last, o1 desc nulls last) "
                       "FROM tmp");
 
   EXPECT_TRUE(wasCudfWindowUsed(task));

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -19,6 +19,8 @@
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/tests/CudfFunctionBaseTest.h"
 
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/WindowFunction.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -37,6 +39,7 @@ class AdapterOperatorTest : public OperatorTestBase {
  protected:
   void SetUp() override {
     OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
     aggregate::prestosql::registerAllAggregateFunctions();
     functions::prestosql::registerAllScalarFunctions();
     window::prestosql::registerAllWindowFunctions();
@@ -60,6 +63,19 @@ class AdapterOperatorTest : public OperatorTestBase {
       }
     }
     return false;
+  }
+
+  std::shared_ptr<const core::WindowNode> withRowsFrame(
+      const core::PlanNodePtr& plan) {
+    auto window = std::dynamic_pointer_cast<const core::WindowNode>(plan);
+    VELOX_CHECK_NOT_NULL(window);
+    auto functions = window->windowFunctions();
+    for (auto& function : functions) {
+      function.frame.type = core::WindowNode::WindowType::kRows;
+    }
+    return core::WindowNode::Builder(*window)
+        .windowFunctions(std::move(functions))
+        .build();
   }
 };
 
@@ -121,6 +137,140 @@ TEST_F(AdapterOperatorTest, fullPartitionWindowSumUsesCudfWindow) {
                       "following) FROM tmp");
 
   EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(AdapterOperatorTest, streamingFullPartitionCountCrossesInputBatches) {
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "payload"},
+          {makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt, 1}),
+           makeFlatVector<int64_t>({0, 1, 2})}),
+      makeRowVector(
+          {"k", "payload"},
+          {makeNullableFlatVector<int64_t>({1, 1, 2}),
+           makeFlatVector<int64_t>({3, 4, 5})}),
+      makeRowVector(
+          {"k", "payload"},
+          {makeNullableFlatVector<int64_t>({2, 2, 3}),
+           makeFlatVector<int64_t>({6, 7, 8})})};
+  createDuckDbTable(data);
+
+  auto plan = withRowsFrame(
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"count(1) over (partition by k rows between unbounded preceding "
+               "and unbounded following) as c"})
+          .planNode());
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .config("cudf.enabled", true)
+                  .plan(plan)
+                  .assertResults(
+                      "SELECT k, payload, count(1) over (partition by k rows "
+                      "between unbounded preceding and unbounded following) "
+                      "FROM tmp");
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(
+    AdapterOperatorTest,
+    streamingFullPartitionCountProducesOutputBeforeNoMoreInput) {
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "payload"},
+          {makeFlatVector<int64_t>({1, 1}), makeFlatVector<int64_t>({0, 1})}),
+      makeRowVector(
+          {"k", "payload"},
+          {makeFlatVector<int64_t>({1, 2}), makeFlatVector<int64_t>({2, 3})})};
+  auto plan = withRowsFrame(
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"count(1) over (partition by k rows between unbounded preceding "
+               "and unbounded following) as c"})
+          .planNode());
+  auto windowNode = std::dynamic_pointer_cast<const core::WindowNode>(plan);
+  ASSERT_NE(windowNode, nullptr);
+  auto valuesNode = std::dynamic_pointer_cast<const core::ValuesNode>(
+      windowNode->sources()[0]);
+  ASSERT_NE(valuesNode, nullptr);
+
+  auto task = Task::create(
+      "streaming-count-produces-output-before-no-more-input",
+      core::PlanFragment{plan},
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
+  auto driver = Driver::testingCreate(
+      std::make_unique<DriverCtx>(task, 0, 0, kUngroupedGroupId, 0));
+  cudf_velox::CudfValues values(0, driver->driverCtx(), valuesNode);
+  cudf_velox::CudfWindow window(1, driver->driverCtx(), windowNode);
+  values.initialize();
+  window.initialize();
+
+  auto first = values.getOutput();
+  ASSERT_NE(first, nullptr);
+  window.addInput(std::move(first));
+  EXPECT_TRUE(window.needsInput());
+  EXPECT_EQ(window.getOutput(), nullptr);
+
+  auto second = values.getOutput();
+  ASSERT_NE(second, nullptr);
+  window.addInput(std::move(second));
+  EXPECT_FALSE(window.needsInput());
+  auto completedPartition = window.getOutput();
+  ASSERT_NE(completedPartition, nullptr);
+  EXPECT_EQ(completedPartition->size(), 3);
+  EXPECT_EQ(window.getOutput(), nullptr);
+  EXPECT_TRUE(window.needsInput());
+
+  window.noMoreInput();
+  auto finalPartition = window.getOutput();
+  ASSERT_NE(finalPartition, nullptr);
+  EXPECT_EQ(finalPartition->size(), 1);
+  EXPECT_TRUE(window.isFinished());
+  EXPECT_EQ(window.getOutput(), nullptr);
+  window.close();
+  values.close();
+}
+
+TEST_F(AdapterOperatorTest, streamingFullPartitionCountSpillsActivePartition) {
+  cudf_velox::CudfWindow::testingSetStreamingMemoryLimits(1, 1);
+  SCOPE_EXIT {
+    cudf_velox::CudfWindow::testingResetStreamingMemoryLimits();
+  };
+  auto spillDirectory = common::testutil::TempDirectoryPath::create();
+
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "payload"},
+          {makeFlatVector<int64_t>({1, 1}), makeFlatVector<int64_t>({0, 1})}),
+      makeRowVector(
+          {"k", "payload"},
+          {makeFlatVector<int64_t>({1, 1}), makeFlatVector<int64_t>({2, 3})}),
+      makeRowVector(
+          {"k", "payload"},
+          {makeFlatVector<int64_t>({2, 2}), makeFlatVector<int64_t>({4, 5})})};
+  auto plan = withRowsFrame(
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"count(1) over (partition by k rows between unbounded preceding "
+               "and unbounded following) as c"})
+          .planNode());
+  auto expected = makeRowVector(
+      {"k", "payload", "c"},
+      {makeFlatVector<int64_t>({1, 1, 1, 1, 2, 2}),
+       makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5}),
+       makeFlatVector<int64_t>({4, 4, 4, 4, 2, 2})});
+
+  auto task = AssertQueryBuilder(plan)
+                  .maxDrivers(1)
+                  .spillDirectory(spillDirectory->getPath())
+                  .assertResults(expected);
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+  EXPECT_GE(cudf_velox::CudfWindow::testingStreamingSpillWrites(), 3);
+  EXPECT_EQ(cudf_velox::CudfWindow::testingStreamingSpillCleanups(), 1);
 }
 
 TEST_F(AdapterOperatorTest, streamingRowNumberCrossesInputBatches) {
@@ -373,6 +523,203 @@ TEST_F(AdapterOperatorTest, streamingRankDoesNotRetainGiantPartition) {
       "FROM tmp ORDER BY k, o",
       {0, 1});
   EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(AdapterOperatorTest, multiColumnAggregateRowsAndRangeUseCudfWindow) {
+  auto data = makeRowVector(
+      {"k", "a", "b", "v"},
+      {makeFlatVector<int64_t>({1, 1, 1, 1, 2, 2}),
+       makeFlatVector<int64_t>({1, 1, 1, 2, 1, 1}),
+       makeFlatVector<int64_t>({2, 1, 1, 0, 2, 1}),
+       makeNullableFlatVector<int64_t>({5, 10, 20, 7, std::nullopt, 3})});
+  createDuckDbTable({data});
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window(
+              {"sum(v) over (partition by k order by a, b rows between "
+               "unbounded preceding and current row) as rows_s",
+               "sum(v) over (partition by k order by a, b range between "
+               "unbounded preceding and current row) as range_s"})
+          .planNode();
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .config("cudf.enabled", true)
+                  .plan(plan)
+                  .assertResults(
+                      "SELECT k, a, b, v, "
+                      "sum(v) over (partition by k order by a, b rows between "
+                      "unbounded preceding and current row), "
+                      "sum(v) over (partition by k order by a, b range between "
+                      "unbounded preceding and current row) FROM tmp");
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(AdapterOperatorTest, streamingMultiKeyRangeSumCrossesPeersAndNulls) {
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "a", "b", "v", "payload"},
+          {makeFlatVector<int64_t>({1, 1}),
+           makeNullableFlatVector<int64_t>({3, 3}),
+           makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt}),
+           makeNullableFlatVector<int64_t>({std::nullopt, 5}),
+           makeFlatVector<int64_t>({0, 1})}),
+      makeRowVector(
+          {"k", "a", "b", "v", "payload"},
+          {makeFlatVector<int64_t>({1, 1, 1, 2}),
+           makeNullableFlatVector<int64_t>({3, 3, 2, 5}),
+           makeNullableFlatVector<int64_t>({std::nullopt, 1, 0, 1}),
+           makeNullableFlatVector<int64_t>({7, std::nullopt, 2, std::nullopt}),
+           makeFlatVector<int64_t>({2, 3, 4, 5})}),
+      makeRowVector(
+          {"k", "a", "b", "v", "payload"},
+          {makeFlatVector<int64_t>({2, 2, 2, 2, 3, 3}),
+           makeNullableFlatVector<int64_t>(
+               {5, 4, 4, 4, std::nullopt, std::nullopt}),
+           makeNullableFlatVector<int64_t>(
+               {1, std::nullopt, std::nullopt, 2, std::nullopt, 1}),
+           makeNullableFlatVector<int64_t>(
+               {4, std::nullopt, 6, -1, std::nullopt, 8}),
+           makeFlatVector<int64_t>({6, 7, 8, 9, 10, 11})})};
+  createDuckDbTable(data);
+
+  auto plan =
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"sum(v) over (partition by k order by a desc nulls last, b asc "
+               "nulls first range between unbounded preceding and current row) "
+               "as s"})
+          .planNode();
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .config("cudf.enabled", true)
+                  .plan(plan)
+                  .assertResults(
+                      "SELECT k, a, b, v, payload, sum(v) over (partition by k "
+                      "order by a desc nulls last, b asc nulls first range "
+                      "between unbounded preceding and current row) FROM tmp");
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(AdapterOperatorTest, streamingRangeSumProducesOutputBeforeNoMoreInput) {
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "a", "b", "v"},
+          {makeFlatVector<int64_t>({1, 1}),
+           makeFlatVector<int64_t>({3, 3}),
+           makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt}),
+           makeNullableFlatVector<int64_t>({std::nullopt, 5})}),
+      makeRowVector(
+          {"k", "a", "b", "v"},
+          {makeFlatVector<int64_t>({1, 1}),
+           makeFlatVector<int64_t>({3, 2}),
+           makeNullableFlatVector<int64_t>({std::nullopt, 0}),
+           makeNullableFlatVector<int64_t>({7, 2})})};
+  auto plan =
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"sum(v) over (partition by k order by a desc nulls last, b asc "
+               "nulls first range between unbounded preceding and current row) "
+               "as s"})
+          .planNode();
+  auto windowNode = std::dynamic_pointer_cast<const core::WindowNode>(plan);
+  ASSERT_NE(windowNode, nullptr);
+  auto valuesNode = std::dynamic_pointer_cast<const core::ValuesNode>(
+      windowNode->sources()[0]);
+  ASSERT_NE(valuesNode, nullptr);
+
+  auto task = Task::create(
+      "streaming-range-sum-produces-output-before-no-more-input",
+      core::PlanFragment{plan},
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
+  auto driver = Driver::testingCreate(
+      std::make_unique<DriverCtx>(task, 0, 0, kUngroupedGroupId, 0));
+  cudf_velox::CudfValues values(0, driver->driverCtx(), valuesNode);
+  cudf_velox::CudfWindow window(1, driver->driverCtx(), windowNode);
+  values.initialize();
+  window.initialize();
+
+  auto first = values.getOutput();
+  ASSERT_NE(first, nullptr);
+  window.addInput(std::move(first));
+  EXPECT_TRUE(window.needsInput());
+  EXPECT_EQ(window.getOutput(), nullptr);
+
+  auto second = values.getOutput();
+  ASSERT_NE(second, nullptr);
+  window.addInput(std::move(second));
+  EXPECT_FALSE(window.needsInput());
+  auto completedPeer = window.getOutput();
+  ASSERT_NE(completedPeer, nullptr);
+  EXPECT_EQ(completedPeer->size(), 3);
+  EXPECT_EQ(window.getOutput(), nullptr);
+  EXPECT_TRUE(window.needsInput());
+
+  window.noMoreInput();
+  auto finalPeer = window.getOutput();
+  ASSERT_NE(finalPeer, nullptr);
+  EXPECT_EQ(finalPeer->size(), 1);
+  EXPECT_TRUE(window.isFinished());
+  EXPECT_EQ(window.getOutput(), nullptr);
+  window.close();
+  values.close();
+}
+
+TEST_F(AdapterOperatorTest, streamingRangeSumSpillsActivePeer) {
+  cudf_velox::CudfWindow::testingSetStreamingMemoryLimits(1, 1);
+  SCOPE_EXIT {
+    cudf_velox::CudfWindow::testingResetStreamingMemoryLimits();
+  };
+  auto spillDirectory = common::testutil::TempDirectoryPath::create();
+
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "a", "b", "v", "payload"},
+          {makeFlatVector<int64_t>({1, 1}),
+           makeFlatVector<int64_t>({10, 10}),
+           makeFlatVector<int64_t>({5, 5}),
+           makeNullableFlatVector<int64_t>({1, 2}),
+           makeFlatVector<int64_t>({0, 1})}),
+      makeRowVector(
+          {"k", "a", "b", "v", "payload"},
+          {makeFlatVector<int64_t>({1, 1}),
+           makeFlatVector<int64_t>({10, 10}),
+           makeFlatVector<int64_t>({5, 5}),
+           makeNullableFlatVector<int64_t>({std::nullopt, 3}),
+           makeFlatVector<int64_t>({2, 3})}),
+      makeRowVector(
+          {"k", "a", "b", "v", "payload"},
+          {makeFlatVector<int64_t>({1}),
+           makeFlatVector<int64_t>({9}),
+           makeFlatVector<int64_t>({0}),
+           makeNullableFlatVector<int64_t>({4}),
+           makeFlatVector<int64_t>({4})})};
+  auto plan =
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"sum(v) over (partition by k order by a desc, b desc range "
+               "between unbounded preceding and current row) as s"})
+          .planNode();
+  auto expected = makeRowVector(
+      {"k", "a", "b", "v", "payload", "s"},
+      {makeFlatVector<int64_t>({1, 1, 1, 1, 1}),
+       makeFlatVector<int64_t>({10, 10, 10, 10, 9}),
+       makeFlatVector<int64_t>({5, 5, 5, 5, 0}),
+       makeNullableFlatVector<int64_t>({1, 2, std::nullopt, 3, 4}),
+       makeFlatVector<int64_t>({0, 1, 2, 3, 4}),
+       makeFlatVector<int64_t>({6, 6, 6, 6, 10})});
+
+  auto task = AssertQueryBuilder(plan)
+                  .maxDrivers(1)
+                  .spillDirectory(spillDirectory->getPath())
+                  .assertResults(expected);
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+  EXPECT_GE(cudf_velox::CudfWindow::testingStreamingSpillWrites(), 3);
+  EXPECT_EQ(cudf_velox::CudfWindow::testingStreamingSpillCleanups(), 1);
 }
 
 TEST_F(AdapterOperatorTest, orderedFirstValueUsesCudfWindow) {

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -252,6 +252,42 @@ TEST_F(AdapterOperatorTest, streamingRankProducesOutputBeforeNoMoreInput) {
   values.close();
 }
 
+TEST_F(AdapterOperatorTest, streamingRankClosesWithPendingOutput) {
+  auto data = makeRowVector(
+      {"k", "o"},
+      {makeFlatVector<int64_t>({1, 1}), makeFlatVector<int64_t>({0, 1})});
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .streamingWindow({"rank() over (partition by k order by o) as rnk"})
+          .planNode();
+  auto windowNode = std::dynamic_pointer_cast<const core::WindowNode>(plan);
+  ASSERT_NE(windowNode, nullptr);
+  auto valuesNode = std::dynamic_pointer_cast<const core::ValuesNode>(
+      windowNode->sources()[0]);
+  ASSERT_NE(valuesNode, nullptr);
+
+  auto task = Task::create(
+      "streaming-rank-closes-with-pending-output",
+      core::PlanFragment{plan},
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
+  auto driver = Driver::testingCreate(
+      std::make_unique<DriverCtx>(task, 0, 0, kUngroupedGroupId, 0));
+  cudf_velox::CudfValues values(0, driver->driverCtx(), valuesNode);
+  cudf_velox::CudfWindow window(1, driver->driverCtx(), windowNode);
+  values.initialize();
+  window.initialize();
+
+  auto input = values.getOutput();
+  ASSERT_NE(input, nullptr);
+  window.addInput(std::move(input));
+  EXPECT_FALSE(window.needsInput());
+  EXPECT_NO_THROW(window.close());
+  values.close();
+}
+
 TEST_F(AdapterOperatorTest, streamingRankThreeBatchDescendingNullTie) {
   std::vector<RowVectorPtr> data{
       makeRowVector(

--- a/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
@@ -63,8 +63,9 @@ using namespace facebook::velox::exec::test;
 
 namespace {
 
-class CudfAggregationSelectionTest : public ::testing::Test,
-                                     public facebook::velox::test::VectorTestBase {
+class CudfAggregationSelectionTest
+    : public ::testing::Test,
+      public facebook::velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});

--- a/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
@@ -64,7 +64,7 @@ using namespace facebook::velox::exec::test;
 namespace {
 
 class CudfAggregationSelectionTest : public ::testing::Test,
-                                     public test::VectorTestBase {
+                                     public facebook::velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -1154,6 +1154,84 @@ TEST_F(FinalAggregationStreamingTest, finalAggregationStreamsOnAddInput) {
   assertStreamingFinalStats(planStats.at(finalAggId).customStats);
 }
 
+TEST_F(FinalAggregationStreamingTest, finalAggregationLevelledRuns) {
+  ScopedStreamingCapacity levelledCapacity{0};
+  auto vectors = {
+      makeRowVector({makeFlatVector<int32_t>(
+          100, [](auto row) { return row % 17; })}),
+      makeRowVector({makeFlatVector<int32_t>(
+          110, [](auto row) { return (row + 7) % 17; })}),
+      makeRowVector({makeFlatVector<int32_t>(
+          90, [](auto row) { return (row + 13) % 17; })}),
+  };
+  createDuckDbTable(vectors);
+
+  core::PlanNodeId finalAggId;
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .config(QueryConfig::kMaxPartialAggregationMemory, 1)
+                  .plan(
+                      PlanBuilder()
+                          .values(vectors)
+                          .partialAggregation({"c0"}, {"sum(c0)"})
+                          .finalAggregation()
+                          .capturePlanNodeId(finalAggId)
+                          .planNode())
+                  .assertResults("SELECT c0, sum(c0) FROM tmp GROUP BY c0");
+
+  const auto planStats = toPlanStats(task->taskStats());
+  const auto finalStatsIt = std::find_if(
+      planStats.begin(), planStats.end(), [](const auto& entry) {
+        return entry.second.customStats.contains(
+            "cudfFinalAggregationInputRuns");
+      });
+  ASSERT_NE(finalStatsIt, planStats.end());
+  const auto& finalStats = finalStatsIt->second.customStats;
+  ASSERT_TRUE(finalStats.contains("cudfFinalAggregationRunMerges"));
+  EXPECT_GT(finalStats.at("cudfFinalAggregationInputRuns").sum, 1);
+  EXPECT_GT(finalStats.at("cudfFinalAggregationRunMerges").sum, 0);
+  EXPECT_EQ(finalStats.count("cudfFinalStreamingBatches"), 0);
+}
+
+TEST_F(
+    FinalAggregationStreamingTest,
+    companionFinalAggregationUsesLevelledRuns) {
+  ScopedStreamingCapacity levelledCapacity{0};
+  auto vectors = {
+      makeRowVector(
+          {makeFlatVector<int64_t>(100, [](auto row) { return row % 17; }),
+           makeFlatVector<int64_t>(100, [](auto row) { return row + 1; })}),
+      makeRowVector(
+          {makeFlatVector<int64_t>(110, [](auto row) { return row % 17; }),
+           makeFlatVector<int64_t>(110, [](auto row) { return row + 101; })}),
+      makeRowVector(
+          {makeFlatVector<int64_t>(90, [](auto row) { return row % 17; }),
+           makeFlatVector<int64_t>(90, [](auto row) { return row + 211; })}),
+  };
+  createDuckDbTable(vectors);
+
+  core::PlanNodeId finalAggId;
+  auto task =
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .config(QueryConfig::kMaxPartialAggregationMemory, 1)
+          .plan(
+              PlanBuilder()
+                  .values(vectors)
+                  .partialAggregation({"c0"}, {"sum_partial(c1)"})
+                  .finalAggregation(
+                      {"c0"},
+                      {"sum_merge_extract_BIGINT(a0)"},
+                      {{BIGINT()}})
+                  .capturePlanNodeId(finalAggId)
+                  .planNode())
+          .assertResults("SELECT c0, sum(c1) FROM tmp GROUP BY c0");
+
+  const auto planStats = toPlanStats(task->taskStats());
+  const auto& finalStats = planStats.at(finalAggId).customStats;
+  EXPECT_GT(finalStats.at("cudfFinalAggregationInputRuns").sum, 1);
+  EXPECT_GT(finalStats.at("cudfFinalAggregationRunMerges").sum, 0);
+  EXPECT_EQ(finalStats.count("cudfFinalStreamingBatches"), 0);
+}
+
 TEST_F(FinalAggregationStreamingTest, finalAggregationStreamingMixedAggs) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -1019,6 +1019,59 @@ TEST_F(AggregationTest, partialAggregationMemoryLimit) {
           .customStats.count("flushRowCount"));
 }
 
+TEST_F(AggregationTest, partialAggregationUsesBalancedRunMerges) {
+  std::vector<RowVectorPtr> vectors;
+  constexpr int32_t kBatches = 8;
+  constexpr int32_t kRowsPerBatch = 100;
+  for (int32_t batch = 0; batch < kBatches; ++batch) {
+    vectors.push_back(makeRowVector(
+        {makeFlatVector<int64_t>(
+             kRowsPerBatch,
+             [batch](vector_size_t row) {
+               return static_cast<int64_t>(batch) * kRowsPerBatch + row;
+             }),
+         makeFlatVector<int64_t>(
+             kRowsPerBatch, [](vector_size_t row) { return row + 1; })}));
+  }
+  createDuckDbTable(vectors);
+
+  core::PlanNodeId partialAggId;
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .maxDrivers(1)
+                  .plan(
+                      PlanBuilder()
+                          .values(vectors)
+                          .partialAggregation({"c0"}, {"sum(c1)"})
+                          .capturePlanNodeId(partialAggId)
+                          .finalAggregation()
+                          .planNode())
+                  .assertResults("SELECT c0, sum(c1) FROM tmp GROUP BY c0");
+
+  const auto planStats = toPlanStats(task->taskStats());
+  const auto& stats = planStats.at(partialAggId).customStats;
+  std::string availableStats;
+  for (const auto& [nodeId, nodeStats] : planStats) {
+    for (const auto& [statName, unused] : nodeStats.customStats) {
+      availableStats += nodeId + ":" + statName + ",";
+    }
+  }
+  for (const auto* statName :
+       {"cudfIntermediateAggregationInputRuns",
+        "cudfIntermediateAggregationRunMerges",
+        "cudfIntermediateAggregationMergeRows"}) {
+    ASSERT_EQ(stats.count(statName), 1)
+        << "Missing runtime stat: " << statName
+        << "; available stats: " << availableStats;
+  }
+  EXPECT_EQ(stats.at("cudfIntermediateAggregationInputRuns").sum, kBatches);
+  EXPECT_EQ(stats.at("cudfIntermediateAggregationRunMerges").sum, kBatches - 1);
+  // With disjoint keys, balanced merges process 800 rows at each of the three
+  // levels. Repeatedly merging the complete accumulated state would process
+  // 3,500 rows for the same eight pages.
+  EXPECT_EQ(stats.at("cudfIntermediateAggregationMergeRows").sum, 2400);
+  EXPECT_EQ(stats.count("cudfIntermediateAggregationFinalizeMerges"), 0);
+}
+
 class FinalAggregationStreamingTest : public AggregationTest {
  protected:
   class ScopedStreamingCapacity {
@@ -1157,8 +1210,8 @@ TEST_F(FinalAggregationStreamingTest, finalAggregationStreamsOnAddInput) {
 TEST_F(FinalAggregationStreamingTest, finalAggregationLevelledRuns) {
   ScopedStreamingCapacity levelledCapacity{0};
   auto vectors = {
-      makeRowVector({makeFlatVector<int32_t>(
-          100, [](auto row) { return row % 17; })}),
+      makeRowVector(
+          {makeFlatVector<int32_t>(100, [](auto row) { return row % 17; })}),
       makeRowVector({makeFlatVector<int32_t>(
           110, [](auto row) { return (row + 7) % 17; })}),
       makeRowVector({makeFlatVector<int32_t>(
@@ -1179,8 +1232,8 @@ TEST_F(FinalAggregationStreamingTest, finalAggregationLevelledRuns) {
                   .assertResults("SELECT c0, sum(c0) FROM tmp GROUP BY c0");
 
   const auto planStats = toPlanStats(task->taskStats());
-  const auto finalStatsIt = std::find_if(
-      planStats.begin(), planStats.end(), [](const auto& entry) {
+  const auto finalStatsIt =
+      std::find_if(planStats.begin(), planStats.end(), [](const auto& entry) {
         return entry.second.customStats.contains(
             "cudfFinalAggregationInputRuns");
       });
@@ -1218,9 +1271,7 @@ TEST_F(
                   .values(vectors)
                   .partialAggregation({"c0"}, {"sum_partial(c1)"})
                   .finalAggregation(
-                      {"c0"},
-                      {"sum_merge_extract_BIGINT(a0)"},
-                      {{BIGINT()}})
+                      {"c0"}, {"sum_merge_extract_BIGINT(a0)"}, {{BIGINT()}})
                   .capturePlanNodeId(finalAggId)
                   .planNode())
           .assertResults("SELECT c0, sum(c1) FROM tmp GROUP BY c0");

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -41,10 +41,14 @@ class CudfBatchConcatTest : public OperatorTestBase {
     OperatorTestBase::TearDown();
   }
 
-  void updateCudfConfig(int32_t min, std::optional<int32_t> max) {
+  void updateCudfConfig(
+      int32_t min,
+      std::optional<int32_t> max,
+      uint64_t minBytes = 0) {
     auto& config = CudfConfig::getInstance();
     config.batchSizeMinThreshold = min;
     config.batchSizeMaxThreshold = max;
+    config.batchSizeMinThresholdBytes = minBytes;
   }
 
   template <typename T>
@@ -64,22 +68,6 @@ class CudfBatchConcatTest : public OperatorTestBase {
     return PlanBuilder(generator).localPartitionRoundRobin(sources).planNode();
   }
 
-  // Returns the per-operator-type stats for CudfBatchConcat within the given
-  // plan node, or nullptr if CudfBatchConcat wasn't inserted for that node.
-  const PlanNodeStats* getConcatStats(
-      const std::shared_ptr<Task>& task,
-      const core::PlanNodeId& aggNodeId) {
-    auto planStats = toPlanStats(task->taskStats());
-    auto nodeIt = planStats.find(aggNodeId);
-    if (nodeIt == planStats.end()) {
-      return nullptr;
-    }
-    auto opIt = nodeIt->second.operatorStats.find("CudfBatchConcat");
-    if (opIt == nodeIt->second.operatorStats.end()) {
-      return nullptr;
-    }
-    return opIt->second.get();
-  }
 };
 
 // Verifies that CudfBatchConcat is inserted before aggregation and reduces
@@ -124,6 +112,46 @@ TEST_F(CudfBatchConcatTest, concatReducesBatchesBeforeAggregation) {
       << "CudfBatchConcat should have received all 6 input batches";
   EXPECT_LT(concatStats.outputVectors, concatStats.inputVectors)
       << "CudfBatchConcat should produce fewer output batches than input";
+}
+
+TEST_F(CudfBatchConcatTest, concatFlushesAtByteThreshold) {
+  // Keep the row threshold out of reach. Six 10-row BIGINT batches are
+  // coalesced based only on their cumulative byte size.
+  updateCudfConfig(
+      /*min=*/std::numeric_limits<int32_t>::max(),
+      /*max=*/std::nullopt,
+      /*minBytes=*/100);
+  CudfConfig::getInstance().concatOptimizationEnabled = true;
+
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < 6; ++i) {
+    vectors.push_back(makeRowVector({makeFlatSequence<int64_t>(i * 10, 10)}));
+  }
+  createDuckDbTable(vectors);
+
+  auto generator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId aggNodeId;
+  auto plan = PlanBuilder(generator)
+                  .addNode([&](auto, auto) {
+                    return createFragmentedSource(vectors, generator);
+                  })
+                  .singleAggregation({}, {"sum(c0)"})
+                  .capturePlanNodeId(aggNodeId)
+                  .planNode();
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .plan(plan)
+                  .maxDrivers(1)
+                  .assertResults("SELECT sum(c0) FROM tmp");
+
+  const auto planStats = toPlanStats(task->taskStats());
+  const auto& nodeStats = planStats.at(aggNodeId);
+  const auto concatIt = nodeStats.operatorStats.find("CudfBatchConcat");
+  ASSERT_NE(concatIt, nodeStats.operatorStats.end());
+  const auto& concatStats = *concatIt->second;
+  EXPECT_EQ(concatStats.inputVectors, 6);
+  EXPECT_GT(concatStats.outputVectors, 1);
+  EXPECT_LT(concatStats.outputVectors, concatStats.inputVectors);
 }
 
 // Verifies that CudfBatchConcat is not inserted when the optimization is

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -67,7 +67,6 @@ class CudfBatchConcatTest : public OperatorTestBase {
     }
     return PlanBuilder(generator).localPartitionRoundRobin(sources).planNode();
   }
-
 };
 
 // Verifies that CudfBatchConcat is inserted before aggregation and reduces

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 
 velox_add_cudf_test(
   NAME velox_cudf_adapter_operator_test
-  SOURCES Main.cpp AdapterOperatorTest.cpp
+  SOURCES Main.cpp AdapterOperatorTest.cpp TaskOutputManagerTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib velox_window velox_functions_spark_window
 )
 

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -23,6 +23,12 @@
 namespace facebook::velox::cudf_velox::test {
 
 TEST(ConfigTest, CudfConfig) {
+  CudfConfig defaults;
+  EXPECT_FALSE(defaults.concatOptimizationEnabled);
+  EXPECT_TRUE(defaults.exchangeConcatOptimizationEnabled);
+  EXPECT_EQ(defaults.batchSizeMinThreshold, 100000);
+  EXPECT_EQ(defaults.exchangeBatchSizeMinThreshold, 32000000);
+
   std::unordered_map<std::string, std::string> options = {
       {CudfConfig::kCudfEnabled, "false"},
       {CudfConfig::kCudfDebugEnabled, "true"},
@@ -32,6 +38,9 @@ TEST(ConfigTest, CudfConfig) {
       {CudfConfig::kCudfAllowCpuFallback, "false"},
       {CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys, "16777216"},
       {CudfConfig::kCudfOrderBySortedRunBytes, "67108864"},
+      {CudfConfig::kCudfOrderByOutputChunkBytes, "134217728"},
+      {CudfConfig::kCudfOrderByMaxOutputRows, "1048576"},
+      {CudfConfig::kCudfExchangeConcatOptimizationEnabled, "false"},
       {CudfConfig::kCudfOrderByMergeFanIn, "7"},
       {CudfConfig::kCudfWindowSortedRunBytes, "134217728"}};
 
@@ -42,11 +51,14 @@ TEST(ConfigTest, CudfConfig) {
   ASSERT_EQ(config.memoryResource, "arena");
   ASSERT_EQ(config.memoryPercent, 25);
   ASSERT_EQ(config.functionNamePrefix, "presto");
+  ASSERT_EQ(config.exchangeConcatOptimizationEnabled, false);
   ASSERT_EQ(config.allowCpuFallback, false);
   ASSERT_EQ(config.groupbyStreamingMaxDistinctKeys, 16777216);
   ASSERT_EQ(config.orderBySortedRunBytes, 67108864);
   ASSERT_EQ(config.orderByMergeFanIn, 7);
   ASSERT_EQ(config.windowSortedRunBytes, 134217728);
+  ASSERT_EQ(config.orderByOutputChunkBytes, 134217728);
+  ASSERT_EQ(config.orderByMaxOutputRows, 1048576);
 }
 
 TEST(ConfigTest, WindowBounds) {
@@ -62,6 +74,8 @@ TEST(ConfigTest, OrderByBounds) {
   CudfConfig defaultConfig;
   EXPECT_EQ(defaultConfig.orderBySortedRunBytes, 256ULL << 20);
   EXPECT_EQ(defaultConfig.orderByMergeFanIn, 8);
+  EXPECT_EQ(defaultConfig.orderByOutputChunkBytes, 32ULL << 20);
+  EXPECT_EQ(defaultConfig.orderByMaxOutputRows, 262144);
 
   CudfConfig zeroRunBytes;
   EXPECT_ANY_THROW(
@@ -74,6 +88,18 @@ TEST(ConfigTest, OrderByBounds) {
   CudfConfig highFanIn;
   EXPECT_ANY_THROW(
       highFanIn.initialize({{CudfConfig::kCudfOrderByMergeFanIn, "65"}}));
+
+  CudfConfig zeroOutputBytes;
+  EXPECT_ANY_THROW(zeroOutputBytes.initialize(
+      {{CudfConfig::kCudfOrderByOutputChunkBytes, "0"}}));
+
+  CudfConfig zeroOutputRows;
+  EXPECT_ANY_THROW(zeroOutputRows.initialize(
+      {{CudfConfig::kCudfOrderByMaxOutputRows, "0"}}));
+
+  CudfConfig overflowOutputRows;
+  EXPECT_ANY_THROW(overflowOutputRows.initialize(
+      {{CudfConfig::kCudfOrderByMaxOutputRows, "2147483648"}}));
 }
 
 TEST(ConfigTest, GroupbyStreamingMaxDistinctKeysRange) {

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -28,6 +28,7 @@ TEST(ConfigTest, CudfConfig) {
   EXPECT_TRUE(defaults.exchangeConcatOptimizationEnabled);
   EXPECT_EQ(defaults.batchSizeMinThreshold, 100000);
   EXPECT_EQ(defaults.exchangeBatchSizeMinThreshold, 32000000);
+  EXPECT_EQ(defaults.exchangeBatchSizeMinThresholdBytes, 0);
 
   std::unordered_map<std::string, std::string> options = {
       {CudfConfig::kCudfEnabled, "false"},
@@ -41,6 +42,7 @@ TEST(ConfigTest, CudfConfig) {
       {CudfConfig::kCudfOrderByOutputChunkBytes, "134217728"},
       {CudfConfig::kCudfOrderByMaxOutputRows, "1048576"},
       {CudfConfig::kCudfExchangeConcatOptimizationEnabled, "false"},
+      {CudfConfig::kCudfExchangeBatchSizeMinThresholdBytes, "8388608"},
       {CudfConfig::kCudfOrderByMergeFanIn, "7"},
       {CudfConfig::kCudfWindowSortedRunBytes, "134217728"}};
 
@@ -52,6 +54,7 @@ TEST(ConfigTest, CudfConfig) {
   ASSERT_EQ(config.memoryPercent, 25);
   ASSERT_EQ(config.functionNamePrefix, "presto");
   ASSERT_EQ(config.exchangeConcatOptimizationEnabled, false);
+  ASSERT_EQ(config.exchangeBatchSizeMinThresholdBytes, 8388608);
   ASSERT_EQ(config.allowCpuFallback, false);
   ASSERT_EQ(config.groupbyStreamingMaxDistinctKeys, 16777216);
   ASSERT_EQ(config.orderBySortedRunBytes, 67108864);

--- a/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
@@ -32,6 +32,8 @@
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 
+#include <cudf/column/column_factories.hpp>
+
 #include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
 
@@ -183,6 +185,24 @@ TEST_F(
   auto leadingNullField = compileExecExpr(
       "row_constructor(cast(null as bigint), b).c1", rowType_, execCtx_.get());
   ASSERT_TRUE(canBeEvaluatedByCudf(leadingNullField, /*deep=*/true));
+
+  auto untypedNullRow =
+      compileExecExpr("row_constructor(a, null)", rowType_, execCtx_.get());
+  ASSERT_EQ(untypedNullRow->type()->childAt(1)->kind(), TypeKind::UNKNOWN);
+  ASSERT_TRUE(canBeEvaluatedByCudf(untypedNullRow, /*deep=*/true));
+
+  auto cudfExpr = createCudfExpression(untypedNullRow, rowType_);
+  auto input =
+      cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT64}, 3);
+  auto result = cudfExpr->eval(
+      {input->view()},
+      cudf::get_default_stream(),
+      cudf::get_current_device_resource_ref());
+  auto resultView = asView(result);
+  ASSERT_EQ(resultView.type().id(), cudf::type_id::STRUCT);
+  ASSERT_EQ(resultView.num_children(), 2);
+  EXPECT_EQ(resultView.child(1).type().id(), cudf::type_id::INT8);
+  EXPECT_EQ(resultView.child(1).null_count(), 3);
 
   auto nestedField = compileExecExpr(
       "row_constructor(row_constructor(a, cast(null as bigint)), b).c1.c2",

--- a/velox/experimental/cudf/tests/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/FilterProjectTest.cpp
@@ -1792,6 +1792,19 @@ TEST_F(CudfFilterProjectTest, dereferenceWithLiteralAndNullFields) {
   assertQuery(plan, "SELECT c0, CAST(NULL AS INTEGER), 'x' FROM tmp");
 }
 
+TEST_F(CudfFilterProjectTest, rowConstructorWithUntypedNullField) {
+  auto vectors = makeVectors(rowType_, 2, 128);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .project({"row_constructor(c0, null) AS r"})
+                  .project({"r.c1"})
+                  .planNode();
+
+  assertQuery(plan, "SELECT c0 FROM tmp");
+}
+
 TEST_F(CudfFilterProjectTest, cardinality) {
   auto input = makeArrayVector<int64_t>({{1, 2, 3}, {1, 2}, {}});
   auto data = makeRowVector({input});

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -2775,15 +2775,12 @@ TEST_F(HashJoinTest, nullAwareRightSemiProjectOverScan) {
         {buildScanId, {buildFile->getPath()}},
     };
 
-    // right semi project not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .planNode(plan)
-            .inputSplits(splitPaths)
-            .checkSpillStats(false)
-            .referenceQuery("SELECT u0, u0 IN (SELECT t0 FROM t) FROM u")
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .planNode(plan)
+        .inputSplits(splitPaths)
+        .checkSpillStats(false)
+        .referenceQuery("SELECT u0, u0 IN (SELECT t0 FROM t) FROM u")
+        .run();
   }
 }
 
@@ -2885,6 +2882,156 @@ TEST_F(HashJoinTest, duplicateJoinKeys) {
   }
 }
 
+TEST_P(MultiThreadedHashJoinTest, rightSemiProjectBuildLeft) {
+  auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  const auto oldMaxBatchRows = cudfConfig.batchSizeMaxThreshold;
+  SCOPE_EXIT {
+    cudfConfig.batchSizeMaxThreshold = oldMaxBatchRows;
+  };
+  // Force the build into three independently hashed tables. This exercises
+  // flag indexing and final output across multiple build tables without
+  // requiring a cudf::size_type-sized test input.
+  cudfConfig.batchSizeMaxThreshold = 4;
+
+  auto probeVectors = std::vector<RowVectorPtr>{
+      makeRowVector(
+          {makeFlatVector<int64_t>({1, 2, 3, 4}),
+           makeFlatVector<int64_t>({10, 20, 30, 40})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({3, 4, 5, 6}),
+           makeFlatVector<int64_t>({31, 40, 50, 60})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({7, 8, 9, 10}),
+           makeFlatVector<int64_t>({70, 80, 90, 100})})};
+  auto buildVectors = std::vector<RowVectorPtr>{
+      makeRowVector(
+          {makeFlatVector<int64_t>({1, 2, 3, 4}),
+           makeFlatVector<int64_t>({10, 21, 30, 41})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({3, 4, 5, 6}),
+           makeFlatVector<int64_t>({32, 40, 51, 61})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({7, 8, 11, 12}),
+           makeFlatVector<int64_t>({71, 80, 110, 120})})};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId joinNodeId;
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .project({"c0 AS t0", "c1 AS t1"})
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .project({"c0 AS u0", "c1 AS u1"})
+                          .planNode(),
+                      "t1 <> u1",
+                      {"u0", "u1", "match"},
+                      core::JoinType::kRightSemiProject)
+                  .capturePlanNodeId(joinNodeId)
+                  .planNode();
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT u.c0, u.c1, EXISTS (SELECT * FROM t WHERE t.c0 = u.c0 AND t.c1 <> u.c1) FROM u")
+      .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+        // The last probe driver must emit multiple vectors, proving that this
+        // case exercised more than one independently hashed build chunk. The
+        // exact chunk count is an implementation detail of the batch splitter;
+        // DuckDB comparison above still verifies every output row and flag.
+        const auto planStats = toPlanStats(task->taskStats());
+        EXPECT_GT(planStats.at(joinNodeId).outputVectors, 1);
+      })
+      .run();
+}
+
+TEST_P(MultiThreadedHashJoinTest, rightSemiProjectNullableResidual) {
+  auto probeVectors = std::vector<RowVectorPtr>{makeRowVector(
+      {makeFlatVector<int64_t>({1, 1, 2, 2, 3}),
+       makeNullableFlatVector<int64_t>(
+           {10, std::nullopt, 21, std::nullopt, 30})})};
+  auto buildVectors = std::vector<RowVectorPtr>{makeRowVector(
+      {makeFlatVector<int64_t>({1, 1, 2, 2, 3, 4, 4}),
+       makeNullableFlatVector<int64_t>(
+           {10, std::nullopt, 20, std::nullopt, 30, std::nullopt, 41})})};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .project({"c0 AS t0", "c1 AS t1"})
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .project({"c0 AS u0", "c1 AS u1"})
+                          .planNode(),
+                      "t1 <> u1",
+                      {"u0", "u1", "match"},
+                      core::JoinType::kRightSemiProject)
+                  .planNode();
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          // DuckDB 0.8.1 can return NULL for this correlated EXISTS when the
+          // residual operands are NULL. SQL EXISTS and Velox ExistenceJoin are
+          // non-nullable: UNKNOWN residual rows are non-matches, hence false.
+          "SELECT u.c0, u.c1, COALESCE(EXISTS (SELECT * FROM t WHERE t.c0 = u.c0 AND t.c1 <> u.c1), false) FROM u")
+      .run();
+}
+
+TEST_P(MultiThreadedHashJoinTest, rightSemiProjectEmptyProbe) {
+  auto probeVectors = std::vector<RowVectorPtr>{makeRowVector(
+      {makeFlatVector<int64_t>(std::vector<int64_t>{}),
+       makeFlatVector<int64_t>(std::vector<int64_t>{})})};
+  auto buildVectors = std::vector<RowVectorPtr>{makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, 1, std::nullopt, 2, 2}),
+       makeFlatVector<int64_t>({10, 11, 12, 20, 20})})};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .project({"c0 AS t0", "c1 AS t1"})
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .project({"c0 AS u0", "c1 AS u1"})
+                          .planNode(),
+                      "",
+                      {"u0", "u1", "match"},
+                      core::JoinType::kRightSemiProject)
+                  .planNode();
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT u.c0, u.c1, EXISTS (SELECT * FROM t WHERE t.c0 = u.c0) FROM u")
+      .run();
+}
+
 TEST_F(HashJoinTest, semiProject) {
   // Some keys have multiple rows: 2, 3, 5.
   auto probeVectors = makeBatches(3, [&](int32_t /*unused*/) {
@@ -2931,16 +3078,13 @@ TEST_F(HashJoinTest, semiProject) {
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
+      .run();
 
   // With extra filter.
   planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -2967,16 +3111,13 @@ TEST_F(HashJoinTest, semiProject) {
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
+      .run();
 
   // Empty build side.
   planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -3006,19 +3147,16 @@ TEST_F(HashJoinTest, semiProject) {
       // build-side rows have been filtered out.
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE u.c0 < 0 AND t.c0 = u.c0) FROM t")
-          // NOTE: there is no spilling in empty build test case as all the
-          // build-side rows have been filtered out.
-          .checkSpillStats(false)
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE u.c0 < 0 AND t.c0 = u.c0) FROM t")
+      // NOTE: there is no spilling in empty build test case as all the
+      // build-side rows have been filtered out.
+      .checkSpillStats(false)
+      .run();
 }
 
 TEST_F(HashJoinTest, semiProjectWithNullKeys) {
@@ -3083,16 +3221,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t")
+      .run();
 
   plan = makePlan(true /*nullAware*/);
 
@@ -3104,15 +3239,12 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
       .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
+      .run();
 
   // Null join keys on build side-only.
   plan = makePlan(false /*nullAware*/, "t0 IS NOT NULL");
@@ -3125,16 +3257,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t WHERE t0 IS NOT NULL")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t WHERE t0 IS NOT NULL")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t WHERE t0 IS NOT NULL")
+      .run();
 
   plan = makePlan(true /*nullAware*/, "t0 IS NOT NULL");
 
@@ -3147,16 +3276,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
+      .run();
 
   // Null join keys on probe side-only.
   plan = makePlan(false /*nullAware*/, "", "u0 IS NOT NULL");
@@ -3169,16 +3295,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NOT NULL) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NOT NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NOT NULL) FROM t")
+      .run();
 
   plan = makePlan(true /*nullAware*/, "", "u0 IS NOT NULL");
 
@@ -3191,16 +3314,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
+      .run();
 
   // Empty build side.
   plan = makePlan(false /*nullAware*/, "", "u0 < 0");
@@ -3213,16 +3333,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 < 0) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(flipJoinSides(plan))
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 < 0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(flipJoinSides(plan))
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 < 0) FROM t")
+      .run();
 
   plan = makePlan(true /*nullAware*/, "", "u0 < 0");
 
@@ -3235,16 +3352,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(flipJoinSides(plan))
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(flipJoinSides(plan))
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
+      .run();
 
   // Build side with all rows having null join keys.
   plan = makePlan(false /*nullAware*/, "", "u0 IS NULL");
@@ -3257,16 +3371,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NULL) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(flipJoinSides(plan))
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(flipJoinSides(plan))
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NULL) FROM t")
+      .run();
 
   plan = makePlan(true /*nullAware*/, "", "u0 IS NULL");
 
@@ -3279,16 +3390,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NULL) FROM t")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(flipJoinSides(plan))
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(flipJoinSides(plan))
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NULL) FROM t")
+      .run();
 }
 
 TEST_F(HashJoinTest, semiProjectWithFilter) {
@@ -3936,15 +4044,12 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
       .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .planNode(flipJoinSides(plan))
-          .inputSplits(splitPaths)
-          .checkSpillStats(false)
-          .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .planNode(flipJoinSides(plan))
+      .inputSplits(splitPaths)
+      .checkSpillStats(false)
+      .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
+      .run();
 
   // With extra filter.
   planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -3971,16 +4076,13 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .planNode(flipJoinSides(plan))
-          .inputSplits(splitPaths)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .planNode(flipJoinSides(plan))
+      .inputSplits(splitPaths)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
+      .run();
 }
 
 // Tests for join filters that require precomputation (non-AST operations)

--- a/velox/experimental/cudf/tests/InteropTest.cpp
+++ b/velox/experimental/cudf/tests/InteropTest.cpp
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
 #include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <cudf/copying.hpp>
+#include <cudf/filling.hpp>
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -220,6 +224,123 @@ TEST_F(InteropTest, emptyBoolean) {
 TEST_F(InteropTest, emptyDouble) {
   auto input = makeRowVector({"c0"}, {makeFlatVector<double>({})});
   roundTrip(input);
+}
+
+TEST_F(InteropTest, emptyStructWithUntypedNullField) {
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto type =
+      ROW({"payload"}, {ROW({"value", "missing"}, {BIGINT(), UNKNOWN()})});
+  std::vector<CudfVectorPtr> inputs;
+
+  auto table = getConcatenatedTable(std::move(inputs), type, stream, mr);
+
+  ASSERT_EQ(table->num_rows(), 0);
+  ASSERT_EQ(table->num_columns(), 1);
+  const auto payload = table->view().column(0);
+  ASSERT_EQ(payload.type().id(), cudf::type_id::STRUCT);
+  ASSERT_EQ(payload.num_children(), 2);
+  EXPECT_EQ(payload.child(0).type().id(), cudf::type_id::INT64);
+  EXPECT_EQ(payload.child(1).type().id(), cudf::type_id::INT8);
+}
+
+TEST_F(InteropTest, restoresNestedUntypedNullAfterCudfRoundTrip) {
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto physicalInput = makeRowVector(
+      {"payload"},
+      {makeRowVector(
+          {"value", "missing"},
+          {makeFlatVector<int64_t>({11, 22, 33}),
+           makeNullableFlatVector<int8_t>(
+               {std::nullopt, std::nullopt, std::nullopt})})});
+  auto logicalType =
+      ROW({"payload"}, {ROW({"value", "missing"}, {BIGINT(), UNKNOWN()})});
+
+  auto table = cudf_velox::with_arrow::toCudfTable(
+      physicalInput, pool_.get(), stream, mr);
+  auto result = cudf_velox::with_arrow::toVeloxColumn(
+      table->view(), pool_.get(), logicalType, stream, mr);
+  stream.synchronize();
+
+  ASSERT_TRUE(logicalType->equivalent(*result->type()));
+  auto payload = result->childAt(0)->as<RowVector>();
+  ASSERT_EQ(payload->childAt(1)->typeKind(), TypeKind::UNKNOWN);
+  ASSERT_EQ(payload->childAt(1)->size(), 3);
+  for (vector_size_t i = 0; i < payload->childAt(1)->size(); ++i) {
+    EXPECT_TRUE(payload->childAt(1)->isNullAt(i));
+  }
+  test::assertEqualVectors(
+      physicalInput->childAt(0)->as<RowVector>()->childAt(0),
+      payload->childAt(0));
+}
+
+TEST_F(InteropTest, transportsNestedUntypedNullThroughCudfGather) {
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto payloadType = ROW({"value", "missing"}, {BIGINT(), UNKNOWN()});
+  auto payload = std::make_shared<RowVector>(
+      pool_.get(),
+      payloadType,
+      nullptr,
+      3,
+      std::vector<VectorPtr>{
+          makeFlatVector<int64_t>({11, 22, 33}),
+          BaseVector::createNullConstant(UNKNOWN(), 3, pool_.get())});
+  auto input = makeRowVector({"payload"}, {payload});
+
+  auto table =
+      cudf_velox::with_arrow::toCudfTable(input, pool_.get(), stream, mr);
+  const auto payloadView = table->view().column(0);
+  ASSERT_EQ(payloadView.type().id(), cudf::type_id::STRUCT);
+  ASSERT_EQ(payloadView.num_children(), 2);
+  EXPECT_EQ(payloadView.child(1).type().id(), cudf::type_id::INT8);
+  EXPECT_EQ(payloadView.child(1).null_count(), 3);
+
+  cudf::numeric_scalar<cudf::size_type> start(0, true, stream, mr);
+  cudf::numeric_scalar<cudf::size_type> step(1, true, stream, mr);
+  auto indices = cudf::sequence(3, start, step, stream, mr);
+  auto gathered = cudf::gather(
+      table->view(),
+      indices->view(),
+      cudf::out_of_bounds_policy::DONT_CHECK,
+      stream,
+      mr);
+  auto result = cudf_velox::with_arrow::toVeloxColumn(
+      gathered->view(), pool_.get(), input->type(), stream, mr);
+  stream.synchronize();
+
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(InteropTest, restoresTypedNullAfterUntypedTransport) {
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto physicalInput = makeRowVector(
+      {"payload"},
+      {makeRowVector(
+          {"value", "missing"},
+          {makeFlatVector<int64_t>({11, 22, 33}),
+           makeNullableFlatVector<int8_t>(
+               {std::nullopt, std::nullopt, std::nullopt})})});
+  auto logicalType =
+      ROW({"payload"}, {ROW({"value", "missing"}, {BIGINT(), VARCHAR()})});
+
+  auto table = cudf_velox::with_arrow::toCudfTable(
+      physicalInput, pool_.get(), stream, mr);
+  auto result = cudf_velox::with_arrow::toVeloxColumn(
+      table->view(), pool_.get(), logicalType, stream, mr);
+  stream.synchronize();
+
+  ASSERT_TRUE(logicalType->equivalent(*result->type()));
+  const auto payload = result->childAt(0)->as<RowVector>();
+  test::assertEqualVectors(
+      physicalInput->childAt(0)->as<RowVector>()->childAt(0),
+      payload->childAt(0));
+  ASSERT_EQ(payload->childAt(1)->typeKind(), TypeKind::VARCHAR);
+  for (vector_size_t i = 0; i < payload->childAt(1)->size(); ++i) {
+    EXPECT_TRUE(payload->childAt(1)->isNullAt(i));
+  }
 }
 
 TEST_F(InteropTest, emptyTimestamp) {

--- a/velox/experimental/cudf/tests/LocalPartitionTest.cpp
+++ b/velox/experimental/cudf/tests/LocalPartitionTest.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 #include "velox/experimental/cudf/exec/CudfConversion.h"
+#include "velox/experimental/cudf/exec/CudfLocalPartition.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/ucx-exchange/RangePartitionFunction.h"
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -158,6 +160,37 @@ TEST_F(LocalPartitionTest, partition) {
 
   auto task =
       queryBuilder.assertResults("SELECT c0, max(c0) FROM tmp GROUP BY 1");
+}
+
+TEST_F(LocalPartitionTest, rangePartition) {
+  auto data = makeRowVector({makeNullableFlatVector<int32_t>(
+      {std::nullopt, -5, 0, 1, 9, 10, 11, 20, 21})});
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto source = PlanBuilder(planNodeIdGenerator).values({data}).planNode();
+  constexpr auto kBounds = R"json({
+    "version": 1,
+    "keys": [{"sparkType":"int","ascending":true,"nullsFirst":true}],
+    "bounds": [
+      [{"isNull":false,"value":0}],
+      [{"isNull":false,"value":10}],
+      [{"isNull":false,"value":20}]
+    ]
+  })json";
+  auto spec = std::make_shared<ucx_exchange::RangePartitionFunctionSpec>(
+      source->outputType(), std::vector<column_index_t>{0}, kBounds);
+  auto op = std::make_shared<core::LocalPartitionNode>(
+      planNodeIdGenerator->next(),
+      core::LocalPartitionNode::Type::kRepartition,
+      false,
+      std::move(spec),
+      std::vector<core::PlanNodePtr>{source});
+
+  ASSERT_TRUE(cudf_velox::CudfLocalPartition::shouldReplace(op));
+  createDuckDbTable({data});
+  AssertQueryBuilder(op, duckDbQueryRunner_)
+      .maxDrivers(4)
+      .config(core::QueryConfig::kMaxLocalExchangePartitionCount, "4")
+      .assertResults("SELECT c0 FROM tmp");
 }
 
 TEST_F(LocalPartitionTest, unionAllLocalExchange) {

--- a/velox/experimental/cudf/tests/Main.cpp
+++ b/velox/experimental/cudf/tests/Main.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/memory/Memory.h"
 #include "velox/common/process/ThreadDebugInfo.h"
 
 #include <folly/Unit.h>
@@ -25,5 +26,9 @@ int main(int argc, char** argv) {
   // Signal handler required for ThreadDebugInfoTest
   facebook::velox::process::addDefaultFatalSignalHandler();
   folly::Init init(&argc, &argv, false);
+  // Match the regular Velox exec test main. Without an initialized global
+  // memory manager, fixtures that create vectors fail before SetUp() on their
+  // first small allocation, so no cuDF operator code is exercised.
+  facebook::velox::memory::MemoryManager::initialize({});
   return RUN_ALL_TESTS();
 }

--- a/velox/experimental/cudf/tests/OrderByTest.cpp
+++ b/velox/experimental/cudf/tests/OrderByTest.cpp
@@ -29,6 +29,8 @@
 
 #include <fmt/format.h>
 
+#include <limits>
+
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
@@ -563,6 +565,33 @@ TEST_F(OrderByTest, boundedExternalSortMapPayload) {
   EXPECT_GE(OrderByTestHelper::sourceChunks(), kNumRuns);
   EXPECT_GT(OrderByTestHelper::mergeOutputBatches(), 0);
   EXPECT_EQ(OrderByTestHelper::spillCleanups(), 1);
+}
+
+TEST_F(OrderByTest, inMemoryResultMovesWithoutChunkCopies) {
+  constexpr uint64_t kLargeByteLimit = 1ULL << 40;
+  OrderByTestHelper::setMemoryLimits(
+      kLargeByteLimit,
+      4096,
+      kLargeByteLimit,
+      std::numeric_limits<cudf::size_type>::max());
+
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t batch = 0; batch < 4; ++batch) {
+    vectors.push_back(makeRowVector(
+        {makeFlatVector<int64_t>(1024, [batch](vector_size_t row) {
+          return 4096 - batch * 1024 - row;
+        })}));
+  }
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy({"c0 ASC NULLS LAST"}, false)
+                  .planNode();
+  assertQueryOrdered(plan, "SELECT * FROM tmp ORDER BY c0", {0});
+
+  EXPECT_EQ(OrderByTestHelper::emittedChunks(), 1);
+  EXPECT_EQ(OrderByTestHelper::spillCleanups(), 0);
 }
 
 /// Verifies output batch rows of OrderBy

--- a/velox/experimental/cudf/tests/OrderByTest.cpp
+++ b/velox/experimental/cudf/tests/OrderByTest.cpp
@@ -262,6 +262,26 @@ TEST_F(OrderByTest, externalSpillSchemaEligibility) {
   ASSERT_NE(safeNestedPayload, nullptr);
   EXPECT_TRUE(cudf_velox::CudfOrderBy::isSupported(safeNestedPayload));
 
+  const auto safeMapPayload =
+      std::dynamic_pointer_cast<const core::OrderByNode>(
+          PlanBuilder()
+              .tableScan(ROW(
+                  {"key", "payload"}, {INTEGER(), MAP(VARCHAR(), VARCHAR())}))
+              .orderBy({"key ASC NULLS LAST"}, false)
+              .planNode());
+  ASSERT_NE(safeMapPayload, nullptr);
+  EXPECT_TRUE(cudf_velox::CudfOrderBy::isSupported(safeMapPayload));
+
+  const auto unsupportedMapKey =
+      std::dynamic_pointer_cast<const core::OrderByNode>(
+          PlanBuilder()
+              .tableScan(ROW(
+                  {"key", "payload"}, {MAP(VARCHAR(), VARCHAR()), INTEGER()}))
+              .orderBy({"key ASC NULLS LAST"}, false)
+              .planNode());
+  ASSERT_NE(unsupportedMapKey, nullptr);
+  EXPECT_FALSE(cudf_velox::CudfOrderBy::isSupported(unsupportedMapKey));
+
   const auto unsupportedBinaryPayload =
       std::dynamic_pointer_cast<const core::OrderByNode>(
           PlanBuilder()
@@ -504,6 +524,44 @@ TEST_F(OrderByTest, boundedExternalSortManyRuns) {
   EXPECT_GE(
       OrderByTestHelper::emittedChunks(),
       (kNumRuns * kRowsPerRun + kMaxOutputRows - 1) / kMaxOutputRows);
+  EXPECT_EQ(OrderByTestHelper::spillCleanups(), 1);
+}
+
+TEST_F(OrderByTest, boundedExternalSortMapPayload) {
+  constexpr int32_t kNumRuns = 7;
+  constexpr vector_size_t kRowsPerRun = 31;
+  OrderByTestHelper::setMemoryLimits(1, 2048, 2048, 13);
+
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(kNumRuns);
+  for (int32_t run = 0; run < kNumRuns; ++run) {
+    auto key = makeFlatVector<int64_t>(kRowsPerRun, [run](vector_size_t row) {
+      return run * kRowsPerRun + row;
+    });
+    auto map = makeMapVector<std::string, std::string>(
+        kRowsPerRun,
+        [](vector_size_t row) { return row % 4; },
+        [run](vector_size_t index) {
+          return fmt::format("key-{}-{}", run, index);
+        },
+        [run](vector_size_t index) {
+          return fmt::format("value-{}-{}", run, index);
+        },
+        [run](vector_size_t row) { return (run + row) % 17 == 0; },
+        [run](vector_size_t index) { return (run + index) % 11 == 0; });
+    vectors.push_back(makeRowVector({key, map}));
+  }
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy({"c0 DESC NULLS LAST"}, false)
+                  .planNode();
+  assertQueryOrdered(
+      plan, "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST", {0});
+
+  EXPECT_GE(OrderByTestHelper::sourceChunks(), kNumRuns);
+  EXPECT_GT(OrderByTestHelper::mergeOutputBatches(), 0);
   EXPECT_EQ(OrderByTestHelper::spillCleanups(), 1);
 }
 

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -722,8 +722,8 @@ TEST_F(TableScanTest, splitOffsetAndLengthWithChunkedOutput) {
           cudf_velox::connector::hive::CudfHiveConfig::
               kMaxChunkReadLimitSession,
           "1024")
-      .splits({Split(makeCudfHiveConnectorSplit(
-          filePath->getPath(), 0, halfFileSize))})
+      .splits({Split(
+          makeCudfHiveConnectorSplit(filePath->getPath(), 0, halfFileSize))})
       .assertResults("SELECT * FROM tmp OFFSET 0 LIMIT 6000");
 
   AssertQueryBuilder(plan, duckDbQueryRunner_)
@@ -732,8 +732,8 @@ TEST_F(TableScanTest, splitOffsetAndLengthWithChunkedOutput) {
           cudf_velox::connector::hive::CudfHiveConfig::
               kMaxChunkReadLimitSession,
           "1024")
-      .splits({Split(makeCudfHiveConnectorSplit(
-          filePath->getPath(), halfFileSize))})
+      .splits({Split(
+          makeCudfHiveConnectorSplit(filePath->getPath(), halfFileSize))})
       .assertResults("SELECT * FROM tmp OFFSET 6000 LIMIT 4000");
 }
 

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -708,6 +708,35 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
       "SELECT * FROM tmp LIMIT 0");
 }
 
+TEST_F(TableScanTest, splitOffsetAndLengthWithChunkedOutput) {
+  auto vectors = makeVectors(10, 1'000);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+  createDuckDbTable(vectors);
+
+  const auto halfFileSize = fs::file_size(filePath->getPath()) / 2;
+  auto plan = tableScanNode();
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .connectorSessionProperty(
+          kCudfHiveConnectorId,
+          cudf_velox::connector::hive::CudfHiveConfig::
+              kMaxChunkReadLimitSession,
+          "1024")
+      .splits({Split(makeCudfHiveConnectorSplit(
+          filePath->getPath(), 0, halfFileSize))})
+      .assertResults("SELECT * FROM tmp OFFSET 0 LIMIT 6000");
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .connectorSessionProperty(
+          kCudfHiveConnectorId,
+          cudf_velox::connector::hive::CudfHiveConfig::
+              kMaxChunkReadLimitSession,
+          "1024")
+      .splits({Split(makeCudfHiveConnectorSplit(
+          filePath->getPath(), halfFileSize))})
+      .assertResults("SELECT * FROM tmp OFFSET 6000 LIMIT 4000");
+}
+
 // Verify that extractFiltersFromRemainingFilter extracts simple single-column
 // filters from the remaining filter into subfield filters for pushdown.
 // When a filter like "c0 = 1" is fully extracted, remainingFilterExprSet_ is

--- a/velox/experimental/cudf/tests/TaskOutputManagerTest.cpp
+++ b/velox/experimental/cudf/tests/TaskOutputManagerTest.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
+
+#include "velox/exec/Task.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+#include <folly/ScopeGuard.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+class TaskOutputManagerTest : public HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    auto& config = cudf_velox::CudfConfig::getInstance();
+    previousEnabled_ = config.enabled;
+    previousExchange_ = config.exchange;
+    previousAllowCpuFallback_ = config.allowCpuFallback;
+    previousMemoryResource_ = config.memoryResource;
+    config.enabled = true;
+    config.exchange = true;
+    config.allowCpuFallback = true;
+    config.memoryResource = "async";
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    auto& config = cudf_velox::CudfConfig::getInstance();
+    config.enabled = previousEnabled_;
+    config.exchange = previousExchange_;
+    config.allowCpuFallback = previousAllowCpuFallback_;
+    config.memoryResource = previousMemoryResource_;
+    HiveConnectorTestBase::TearDown();
+  }
+
+  std::shared_ptr<Task> startTask(
+      const std::string& taskId,
+      core::PartitionedOutputNode::TransportType transport,
+      core::QueryConfig queryConfig = core::QueryConfig{{}}) {
+    auto output = std::dynamic_pointer_cast<const core::PartitionedOutputNode>(
+        PlanBuilder()
+            .tableScan(ROW({"c0"}, {BIGINT()}))
+            .partitionedOutputBroadcast()
+            .planNode());
+    auto plan = core::PartitionedOutputNode::Builder(*output)
+                    .transportType(transport)
+                    .build();
+    auto task = Task::create(
+        taskId,
+        core::PlanFragment{std::move(plan)},
+        0,
+        core::QueryCtx::create(driverExecutor_.get(), std::move(queryConfig)),
+        Task::ExecutionMode::kParallel,
+        Consumer{});
+    task->start(1, 1);
+    return task;
+  }
+
+ private:
+  bool previousEnabled_{true};
+  bool previousExchange_{false};
+  bool previousAllowCpuFallback_{true};
+  std::string previousMemoryResource_;
+};
+
+TEST_F(TaskOutputManagerTest, selectionAndCancellationCleanup) {
+  auto queueManager = ucx_exchange::UcxOutputQueueManager::getInstanceRef();
+  const std::string ucxTaskId = "ucx-output-manager-lifecycle";
+  queueManager->removeTask(ucxTaskId);
+  auto cleanup =
+      folly::makeGuard([&]() { queueManager->removeTask(ucxTaskId); });
+
+  auto ucxTask =
+      startTask(ucxTaskId, core::PartitionedOutputNode::TransportType::kUcx);
+  ASSERT_TRUE(queueManager->stats(ucxTaskId).has_value());
+
+  std::atomic_bool cancellationDelivered{false};
+  queueManager->getData(
+      ucxTaskId,
+      0,
+      [&](std::shared_ptr<cudf::packed_columns> data, std::vector<int64_t>) {
+        EXPECT_EQ(data, nullptr);
+        cancellationDelivered = true;
+      });
+  ucxTask->requestAbort().wait();
+  EXPECT_TRUE(cancellationDelivered);
+  EXPECT_FALSE(queueManager->stats(ucxTaskId).has_value());
+  queueManager->removeTask(ucxTaskId);
+  cleanup.dismiss();
+
+  const std::string httpTaskId = "http-output-manager-lifecycle";
+  auto httpTask =
+      startTask(httpTaskId, core::PartitionedOutputNode::TransportType::kHttp);
+  EXPECT_FALSE(queueManager->stats(httpTaskId).has_value());
+  httpTask->requestAbort().wait();
+
+  const std::string disabledTaskId = "disabled-ucx-output-manager-lifecycle";
+  auto disabledTask = startTask(
+      disabledTaskId,
+      core::PartitionedOutputNode::TransportType::kUcx,
+      core::QueryConfig(
+          std::unordered_map<std::string, std::string>{
+              {cudf_velox::CudfConfig::kCudfEnabled, "false"}}));
+  EXPECT_FALSE(queueManager->stats(disabledTaskId).has_value());
+  disabledTask->requestAbort().wait();
+}
+
+} // namespace

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -546,6 +546,56 @@ TEST_F(CudfIcebergReadTest, coalescedMultipleFiles) {
   assertQuery(plan, splits, "SELECT * FROM tmp", 0);
 }
 
+/// Fall back to per-file readers when a coalesced split contains physical
+/// schemas from different Iceberg schema versions.
+TEST_F(CudfIcebergReadTest, coalescedSchemaEvolution) {
+  auto oldData = makeRowVector(
+      {"c0"}, {makeFlatVector<int64_t>({1, 2})});
+  auto newData = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int64_t>({3, 4}),
+       makeFlatVector<int64_t>({30, 40})});
+
+  auto oldFile = TempFilePath::create();
+  auto newFile = TempFilePath::create();
+  writeToFile(oldFile->getPath(), oldData);
+  writeToFile(newFile->getPath(), newData);
+
+  std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
+      splits{std::make_shared<HiveIcebergSplit>(
+          kCudfIcebergConnectorId,
+          oldFile->getPath(),
+          dwio::common::FileFormat::PARQUET,
+          0,
+          getFileSize(oldFile->getPath()),
+          std::unordered_map<std::string, std::optional<std::string>>{},
+          std::nullopt,
+          std::unordered_map<std::string, std::string>{},
+          nullptr,
+          /*cacheable=*/true,
+          std::vector<IcebergDeleteFile>{},
+          std::unordered_map<std::string, std::string>{},
+          std::nullopt,
+          /*dataSequenceNumber=*/0,
+          std::vector<IcebergCoalescedFile>{
+              {newFile->getPath(), getFileSize(newFile->getPath())}})};
+
+  auto outputType = ROW({"c0", "c1"}, {BIGINT(), BIGINT()});
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(outputType)
+                  .endTableScan()
+                  .planNode();
+  auto expected = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int64_t>({1, 2, 3, 4}),
+       makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt, 30, 40})});
+
+  AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+}
+
 TEST_F(CudfIcebergReadTest, multiFileChunkReadLimit) {
   using connector::hive::kDefaultMultiFileChunkReadLimit;
   using connector::hive::multiFileChunkReadLimit;

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -504,6 +504,47 @@ TEST_F(CudfIcebergReadTest, multipleSplits) {
   assertQuery(plan, allSplits, "SELECT * FROM tmp", 0);
 }
 
+/// Read multiple whole data files through one cuDF parquet reader.
+TEST_F(CudfIcebergReadTest, coalescedMultipleFiles) {
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto data1 = makeRowVector({makeFlatVector<int64_t>({1, 2, 3})});
+  auto data2 = makeRowVector({makeFlatVector<int64_t>({4, 5, 6})});
+
+  auto filePath1 = TempFilePath::create();
+  auto filePath2 = TempFilePath::create();
+  writeToFile(filePath1->getPath(), data1);
+  writeToFile(filePath2->getPath(), data2);
+
+  std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
+      splits{std::make_shared<HiveIcebergSplit>(
+          kCudfIcebergConnectorId,
+          filePath1->getPath(),
+          dwio::common::FileFormat::PARQUET,
+          0,
+          getFileSize(filePath1->getPath()),
+          std::unordered_map<std::string, std::optional<std::string>>{},
+          std::nullopt,
+          std::unordered_map<std::string, std::string>{},
+          nullptr,
+          /*cacheable=*/true,
+          std::vector<IcebergDeleteFile>{},
+          std::unordered_map<std::string, std::string>{},
+          std::nullopt,
+          /*dataSequenceNumber=*/0,
+          std::vector<IcebergCoalescedFile>{
+              {filePath2->getPath(), getFileSize(filePath2->getPath())}})};
+
+  createDuckDbTable({data1, data2});
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  assertQuery(plan, splits, "SELECT * FROM tmp", 0);
+}
+
 /// Read multiple byte-range splits from the same data file.
 TEST_F(CudfIcebergReadTest, byteRangeSplits) {
   auto rowType = ROW({"c0"}, {BIGINT()});

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -30,6 +30,7 @@
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/TimestampConversion.h"
 
@@ -543,6 +544,17 @@ TEST_F(CudfIcebergReadTest, coalescedMultipleFiles) {
                   .planNode();
 
   assertQuery(plan, splits, "SELECT * FROM tmp", 0);
+}
+
+TEST_F(CudfIcebergReadTest, multiFileChunkReadLimit) {
+  using connector::hive::kDefaultMultiFileChunkReadLimit;
+  using connector::hive::multiFileChunkReadLimit;
+
+  EXPECT_EQ(
+      multiFileChunkReadLimit(0, 8UL << 20),
+      kDefaultMultiFileChunkReadLimit);
+  EXPECT_EQ(multiFileChunkReadLimit(0, 512UL << 20), 512UL << 20);
+  EXPECT_EQ(multiFileChunkReadLimit(64UL << 20, 8UL << 20), 64UL << 20);
 }
 
 /// Read multiple byte-range splits from the same data file.

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -18,6 +18,7 @@
 /// Deletion vector and equality delete tests live in their own files
 /// (CudfDeletionVectorReaderTest.cpp and CudfEqualityDeleteFileReaderTest.cpp).
 
+#include "velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h"
 #include "velox/experimental/cudf/tests/iceberg/CudfIcebergTestBase.h"
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -30,7 +31,6 @@
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/TimestampConversion.h"
 
@@ -551,8 +551,7 @@ TEST_F(CudfIcebergReadTest, multiFileChunkReadLimit) {
   using connector::hive::multiFileChunkReadLimit;
 
   EXPECT_EQ(
-      multiFileChunkReadLimit(0, 8UL << 20),
-      kDefaultMultiFileChunkReadLimit);
+      multiFileChunkReadLimit(0, 8UL << 20), kDefaultMultiFileChunkReadLimit);
   EXPECT_EQ(multiFileChunkReadLimit(0, 512UL << 20), 512UL << 20);
   EXPECT_EQ(multiFileChunkReadLimit(64UL << 20, 8UL << 20), 64UL << 20);
 }

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -549,12 +549,10 @@ TEST_F(CudfIcebergReadTest, coalescedMultipleFiles) {
 /// Fall back to per-file readers when a coalesced split contains physical
 /// schemas from different Iceberg schema versions.
 TEST_F(CudfIcebergReadTest, coalescedSchemaEvolution) {
-  auto oldData = makeRowVector(
-      {"c0"}, {makeFlatVector<int64_t>({1, 2})});
+  auto oldData = makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 2})});
   auto newData = makeRowVector(
       {"c0", "c1"},
-      {makeFlatVector<int64_t>({3, 4}),
-       makeFlatVector<int64_t>({30, 40})});
+      {makeFlatVector<int64_t>({3, 4}), makeFlatVector<int64_t>({30, 40})});
 
   auto oldFile = TempFilePath::create();
   auto newFile = TempFilePath::create();

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<Communicator> Communicator::initAndGet(
     uint16_t port,
     std::string_view coordinatorURL,
     ContinueFuture* future) {
-  if (!FLAGS_velox_ucx_exchange) {
+  if (!CudfConfig::getInstance().exchange) {
     return nullptr;
   }
   std::call_once(onceFlag, [&] {

--- a/velox/experimental/ucx-exchange/Communicator.h
+++ b/velox/experimental/ucx-exchange/Communicator.h
@@ -27,10 +27,6 @@
 #include "velox/experimental/ucx-exchange/CommElement.h"
 #include "velox/experimental/ucx-exchange/WorkQueue.h"
 
-#include <gflags/gflags.h>
-
-DECLARE_bool(velox_ucx_exchange);
-
 namespace facebook::velox::ucx_exchange {
 
 struct HostPort {

--- a/velox/experimental/ucx-exchange/RangePartitionFunction.cpp
+++ b/velox/experimental/ucx-exchange/RangePartitionFunction.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "velox/experimental/ucx-exchange/RangePartitionFunction.h"
+#include "velox/vector/FlatVector.h"
+
+#include <folly/json.h>
 
 #include <sstream>
 
@@ -31,6 +34,114 @@ class UcxOnlyRangePartitionFunction final : public core::PartitionFunction {
 };
 
 } // namespace
+
+RowVectorPtr buildRangeBoundaryVector(
+    const std::string& boundsJson,
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    memory::MemoryPool* pool,
+    std::vector<cudf::order>& orders,
+    std::vector<cudf::null_order>& nullOrders) {
+  const auto descriptor = folly::parseJson(boundsJson);
+  VELOX_CHECK_EQ(
+      descriptor["version"].asInt(),
+      1,
+      "Unsupported RANGE_PID descriptor version");
+  const auto& keys = descriptor["keys"];
+  const auto& bounds = descriptor["bounds"];
+  VELOX_CHECK(keys.isArray(), "RANGE_PID keys must be an array");
+  VELOX_CHECK(bounds.isArray(), "RANGE_PID bounds must be an array");
+  VELOX_CHECK_EQ(
+      keys.size(),
+      keyChannels.size(),
+      "RANGE_PID key metadata/channel mismatch");
+
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  names.reserve(keyChannels.size());
+  types.reserve(keyChannels.size());
+  orders.clear();
+  nullOrders.clear();
+  for (size_t key = 0; key < keyChannels.size(); ++key) {
+    const auto channel = keyChannels[key];
+    VELOX_CHECK_LT(
+        channel, inputType->size(), "RANGE_PID key channel out of bounds");
+    names.push_back(inputType->nameOf(channel));
+    types.push_back(inputType->childAt(channel));
+    orders.push_back(
+        keys[key]["ascending"].asBool() ? cudf::order::ASCENDING
+                                        : cudf::order::DESCENDING);
+    nullOrders.push_back(
+        keys[key]["nullsFirst"].asBool() ? cudf::null_order::BEFORE
+                                         : cudf::null_order::AFTER);
+  }
+
+  auto boundaryType = ROW(std::move(names), std::move(types));
+  auto vector = std::dynamic_pointer_cast<RowVector>(
+      BaseVector::create(boundaryType, bounds.size(), pool));
+  VELOX_CHECK_NOT_NULL(vector);
+
+  for (size_t row = 0; row < bounds.size(); ++row) {
+    VELOX_CHECK(bounds[row].isArray(), "RANGE_PID boundary must be an array");
+    VELOX_CHECK_EQ(
+        bounds[row].size(),
+        keyChannels.size(),
+        "RANGE_PID boundary width mismatch");
+    for (size_t key = 0; key < keyChannels.size(); ++key) {
+      const auto& encoded = bounds[row][key];
+      auto child = vector->childAt(key);
+      if (encoded["isNull"].asBool()) {
+        child->setNull(row, true);
+        continue;
+      }
+
+      const auto& value = encoded["value"];
+      const auto& type = boundaryType->childAt(key);
+      if (type->isDate()) {
+        child->asFlatVector<int32_t>()->set(row, value.asInt());
+      } else if (type->isTimestamp()) {
+        child->asFlatVector<Timestamp>()->set(
+            row, Timestamp::fromMicros(value.asInt()));
+      } else {
+        switch (type->kind()) {
+          case TypeKind::BOOLEAN:
+            child->asFlatVector<bool>()->set(row, value.asBool());
+            break;
+          case TypeKind::TINYINT:
+            child->asFlatVector<int8_t>()->set(row, value.asInt());
+            break;
+          case TypeKind::SMALLINT:
+            child->asFlatVector<int16_t>()->set(row, value.asInt());
+            break;
+          case TypeKind::INTEGER:
+            child->asFlatVector<int32_t>()->set(row, value.asInt());
+            break;
+          case TypeKind::BIGINT:
+            child->asFlatVector<int64_t>()->set(row, value.asInt());
+            break;
+          case TypeKind::REAL:
+            child->asFlatVector<float>()->set(
+                row, static_cast<float>(value.asDouble()));
+            break;
+          case TypeKind::DOUBLE:
+            child->asFlatVector<double>()->set(row, value.asDouble());
+            break;
+          case TypeKind::VARCHAR: {
+            const auto stringValue = value.asString();
+            child->asFlatVector<StringView>()->set(
+                row, StringView(stringValue));
+            break;
+          }
+          default:
+            VELOX_UNSUPPORTED(
+                "RANGE_PID D1 does not support native key type {}",
+                type->toString());
+        }
+      }
+    }
+  }
+  return vector;
+}
 
 std::unique_ptr<core::PartitionFunction> RangePartitionFunctionSpec::create(
     int,

--- a/velox/experimental/ucx-exchange/RangePartitionFunction.h
+++ b/velox/experimental/ucx-exchange/RangePartitionFunction.h
@@ -17,16 +17,19 @@
 
 #include "velox/core/PlanNode.h"
 
+#include <cudf/types.hpp>
+
 namespace facebook::velox::ucx_exchange {
 
 /**
- * An explicit range-partition contract for UCX output.
+ * An explicit range-partition contract for GPU output and local exchange.
  *
  * The JSON payload contains Spark RangePartitioner boundaries plus ascending
- * and null-order flags. UcxPartitionedOutput evaluates those boundaries into
- * an INT32 partition-id column before routing. The ordinary Velox CPU
- * PartitionedOutput path is intentionally unsupported: using it would make a
- * RANGE exchange silently change semantics when the GPU adapter is absent.
+ * and null-order flags. UcxPartitionedOutput and CudfLocalPartition evaluate
+ * those boundaries into an INT32 partition-id column before routing. The
+ * ordinary Velox CPU partition path is intentionally unsupported: using it
+ * would make a RANGE exchange silently change semantics when the GPU adapter
+ * is absent.
  */
 class RangePartitionFunctionSpec final : public core::PartitionFunctionSpec {
  public:
@@ -71,5 +74,19 @@ class RangePartitionFunctionSpec final : public core::PartitionFunctionSpec {
   const std::vector<column_index_t> keyChannels_;
   const std::string boundsJson_;
 };
+
+/**
+ * Materializes Spark's serialized RANGE boundaries as a Velox row vector and
+ * returns the matching libcudf sort/null ordering. Shared by UCX
+ * PartitionedOutput and single-task CudfLocalPartition so both paths apply
+ * exactly the same boundary semantics.
+ */
+RowVectorPtr buildRangeBoundaryVector(
+    const std::string& boundsJson,
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    memory::MemoryPool* pool,
+    std::vector<cudf::order>& orders,
+    std::vector<cudf::null_order>& nullOrders);
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -298,6 +298,24 @@ void UcxExchangeServer::process() {
                         << " getData callback called after close, ignoring";
                 return;
               }
+              if (sequence != static_cast<int64_t>(self->sequenceNumber_)) {
+                // The destination queue has already advanced beyond this
+                // duplicate/retried server.  Close only this stale server.
+                // In particular, do not deleteResults(): another active
+                // server owns the already-advanced queue and may still need
+                // its remaining pages.
+                LOG(WARNING)
+                    << "Closing stale UCX exchange server for task="
+                    << self->partitionKey_.taskId
+                    << " destination=" << self->partitionKey_.destination
+                    << " requestedSequence=" << self->sequenceNumber_
+                    << " acknowledgedSequence=" << sequence;
+                self->skipQueueDeleteOnClose_.store(
+                    true, std::memory_order_release);
+                self->setState(ServerState::Done);
+                self->wakeCommunicator();
+                return;
+              }
               // This upcall may be called from another thread than the
               // communicator thread. It is called
               // when data on the queue becomes available.
@@ -381,7 +399,7 @@ void UcxExchangeServer::close() {
           << " hasDataRequest=" << (dataRequest_ != nullptr)
           << " hasDataPtr=" << (dataPtr_ != nullptr);
 
-  if (queueMgr_) {
+  if (queueMgr_ && !skipQueueDeleteOnClose_.load(std::memory_order_acquire)) {
     queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
   }
 

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.h
@@ -133,6 +133,10 @@ class UcxExchangeServer
   /// thread while the lock is still held.
   std::recursive_mutex dataMutex_;
   std::atomic<bool> closed_{false};
+  // A duplicate server may reconnect at an already-acknowledged sequence.
+  // Its close must not clear the destination queue owned by the active
+  // server.
+  std::atomic<bool> skipQueueDeleteOnClose_{false};
 
   /// Future for intra-node transfer - signaled when source retrieves data.
   std::future<void> intraNodeRetrieveFuture_;

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -102,12 +102,15 @@ int64_t maxInFlightRecvHostBytes() {
 std::atomic<int64_t> inFlightRecvHostBytes{0};
 
 rmm::mr::statistics_resource_adaptor& receiveDeviceMemoryResource() {
-  // Keep UCX receive allocations on a synchronous, fresh cudaMalloc resource,
-  // but wrap it with RMM statistics so queued packed pages are visible in
-  // diagnostics even after ownership moves out of UcxExchangeSource.
+  // Allocate UCX receive pages from the same async resource as cuDF operators.
+  // A separate cuda_memory_resource cannot reuse blocks cached by the async
+  // pool and can therefore fail cudaMalloc while scan/aggregation has ample
+  // reusable memory in that pool. Keep a dedicated statistics adaptor so
+  // receive credit continues to account for packed pages after ownership moves
+  // out of UcxExchangeSource.
   static rmm::mr::statistics_resource_adaptor resource{
       cuda::mr::any_resource<cuda::mr::device_accessible>{
-          rmm::mr::cuda_memory_resource{}}};
+          rmm::mr::get_current_device_resource_ref()}};
   return resource;
 }
 
@@ -785,13 +788,10 @@ bool UcxExchangeSource::tryStartDataReceive(
   ptr->stream = stream;
 
   // UCX writes receive buffers from its progress thread, outside CUDA stream
-  // ordering. Keep these buffers on a dedicated synchronous resource so UCX
-  // can never write into a block that a stream-ordered pool has recycled while
-  // work on another stream is still in flight. This also avoids waiting on an
-  // unrelated compute stream in the single UCX progress thread.
-  //
-  // Only transports without CUDA support stage through host memory and use a
-  // fresh synchronous device allocation for the final copy.
+  // ordering. Allocate from the shared async pool, then synchronize this
+  // allocation stream before exposing the pointer to UCX. Receive completion
+  // transfers ownership to a packed table that retains the same stream, so
+  // downstream work and eventual deallocation remain stream ordered.
   try {
     auto& recvMemoryResource = receiveDeviceMemoryResource();
     ptr->dataBuf = std::make_unique<rmm::device_buffer>(
@@ -799,6 +799,7 @@ bool UcxExchangeSource::tryStartDataReceive(
         stream,
         cuda::mr::any_resource<cuda::mr::device_accessible>{
             recvMemoryResource});
+    CUDF_CUDA_TRY(cudaStreamSynchronize(stream.value()));
     if (facebook::velox::cudf_velox::deviceMemoryDiagnosticsEnabled()) {
       constexpr int64_t kReportStep = 512LL << 20;
       const auto bytes = recvMemoryResource.get_bytes_counter();

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -792,14 +792,44 @@ bool UcxExchangeSource::tryStartDataReceive(
   // allocation stream before exposing the pointer to UCX. Receive completion
   // transfers ownership to a packed table that retains the same stream, so
   // downstream work and eventual deallocation remain stream ordered.
-  try {
-    auto& recvMemoryResource = receiveDeviceMemoryResource();
+  auto& recvMemoryResource = receiveDeviceMemoryResource();
+  const auto allocateReceiveBuffer = [&]() {
     ptr->dataBuf = std::make_unique<rmm::device_buffer>(
         ptr->metadata.dataSizeBytes,
         stream,
         cuda::mr::any_resource<cuda::mr::device_accessible>{
             recvMemoryResource});
     CUDF_CUDA_TRY(cudaStreamSynchronize(stream.value()));
+  };
+  try {
+    allocateReceiveBuffer();
+  } catch (const rmm::bad_alloc& firstError) {
+    // On the allocation-failure slow path, wait for stream-ordered frees and
+    // let the shared async pool reclaim completed blocks, then retry once.
+    cudaGetLastError();
+    const auto syncStatus = cudaDeviceSynchronize();
+    if (syncStatus == cudaSuccess) {
+      try {
+        allocateReceiveBuffer();
+        LOG(WARNING)
+            << toString()
+            << " recovered UCX receive allocation after device synchronize: "
+            << ptr->metadata.dataSizeBytes
+            << " bytes; first error: " << firstError.what();
+      } catch (const rmm::bad_alloc& retryError) {
+        VLOG(0) << toString() << " *** RMM failed to allocate "
+                << ptr->metadata.dataSizeBytes
+                << " bytes after device synchronize retry: "
+                << retryError.what();
+      }
+    } else {
+      VLOG(0) << toString()
+              << " *** cudaDeviceSynchronize failed while recovering "
+                 "receive allocation: "
+              << cudaGetErrorString(syncStatus);
+    }
+  }
+  if (ptr->dataBuf != nullptr) {
     if (facebook::velox::cudf_velox::deviceMemoryDiagnosticsEnabled()) {
       constexpr int64_t kReportStep = 512LL << 20;
       const auto bytes = recvMemoryResource.get_bytes_counter();
@@ -837,10 +867,8 @@ bool UcxExchangeSource::tryStartDataReceive(
                 maxInFlightRecvBytes()));
       }
     }
-  } catch (const rmm::bad_alloc& e) {
+  } else {
     releaseReceiveReservation();
-    VLOG(0) << toString() << " *** RMM failed to allocate "
-            << ptr->metadata.dataSizeBytes << " bytes: " << e.what();
     queue_->setError("Failed to alloc GPU memory");
     deliverEndMarker();
     setState(ReceiverState::Done);

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
@@ -82,6 +82,16 @@ bool UcxOutputQueueManager::updateOutputBuffersIfExists(
   return false;
 }
 
+bool UcxOutputQueueManager::updateNumDriversIfExists(
+    std::string_view taskId,
+    uint32_t newNumDrivers) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->updateNumDrivers(newNumDrivers);
+    return true;
+  }
+  return false;
+}
+
 void UcxOutputQueueManager::enqueue(
     std::string_view taskId,
     int destination,

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
@@ -65,6 +65,10 @@ class UcxOutputQueueManager {
       int numBuffers,
       bool noMoreBuffers);
 
+  bool updateNumDriversIfExists(
+      std::string_view taskId,
+      uint32_t newNumDrivers);
+
   /// @brief Enqueues a cudf packed column into the queue.
   /// @param taskId The unique task Id.
   /// @param destination The destination (partition, queue number) into which

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -15,7 +15,6 @@
  */
 #include "velox/experimental/ucx-exchange/UcxPartitionedOutput.h"
 #include <fmt/format.h>
-#include <folly/json.h>
 #include <algorithm>
 #include <cstdlib>
 #include <limits>
@@ -64,114 +63,6 @@ int64_t targetRowsPerUcxChunk(const core::QueryConfig& queryConfig) {
     }
   }
   return queryConfig.ucxPartitionedOutputBatchRows();
-}
-
-RowVectorPtr buildRangeBoundaryVector(
-    const std::string& boundsJson,
-    const RowTypePtr& inputType,
-    const std::vector<column_index_t>& keyChannels,
-    memory::MemoryPool* pool,
-    std::vector<cudf::order>& orders,
-    std::vector<cudf::null_order>& nullOrders) {
-  const auto descriptor = folly::parseJson(boundsJson);
-  VELOX_CHECK_EQ(
-      descriptor["version"].asInt(),
-      1,
-      "Unsupported RANGE_PID descriptor version");
-  const auto& keys = descriptor["keys"];
-  const auto& bounds = descriptor["bounds"];
-  VELOX_CHECK(keys.isArray(), "RANGE_PID keys must be an array");
-  VELOX_CHECK(bounds.isArray(), "RANGE_PID bounds must be an array");
-  VELOX_CHECK_EQ(
-      keys.size(),
-      keyChannels.size(),
-      "RANGE_PID key metadata/channel mismatch");
-
-  std::vector<std::string> names;
-  std::vector<TypePtr> types;
-  names.reserve(keyChannels.size());
-  types.reserve(keyChannels.size());
-  orders.clear();
-  nullOrders.clear();
-  for (size_t key = 0; key < keyChannels.size(); ++key) {
-    const auto channel = keyChannels[key];
-    VELOX_CHECK_LT(
-        channel, inputType->size(), "RANGE_PID key channel out of bounds");
-    names.push_back(inputType->nameOf(channel));
-    types.push_back(inputType->childAt(channel));
-    orders.push_back(
-        keys[key]["ascending"].asBool() ? cudf::order::ASCENDING
-                                        : cudf::order::DESCENDING);
-    nullOrders.push_back(
-        keys[key]["nullsFirst"].asBool() ? cudf::null_order::BEFORE
-                                         : cudf::null_order::AFTER);
-  }
-
-  auto boundaryType = ROW(std::move(names), std::move(types));
-  auto vector = std::dynamic_pointer_cast<RowVector>(
-      BaseVector::create(boundaryType, bounds.size(), pool));
-  VELOX_CHECK_NOT_NULL(vector);
-
-  for (size_t row = 0; row < bounds.size(); ++row) {
-    VELOX_CHECK(bounds[row].isArray(), "RANGE_PID boundary must be an array");
-    VELOX_CHECK_EQ(
-        bounds[row].size(),
-        keyChannels.size(),
-        "RANGE_PID boundary width mismatch");
-    for (size_t key = 0; key < keyChannels.size(); ++key) {
-      const auto& encoded = bounds[row][key];
-      auto child = vector->childAt(key);
-      if (encoded["isNull"].asBool()) {
-        child->setNull(row, true);
-        continue;
-      }
-
-      const auto& value = encoded["value"];
-      const auto& type = boundaryType->childAt(key);
-      if (type->isDate()) {
-        child->asFlatVector<int32_t>()->set(row, value.asInt());
-      } else if (type->isTimestamp()) {
-        child->asFlatVector<Timestamp>()->set(
-            row, Timestamp::fromMicros(value.asInt()));
-      } else {
-        switch (type->kind()) {
-          case TypeKind::BOOLEAN:
-            child->asFlatVector<bool>()->set(row, value.asBool());
-            break;
-          case TypeKind::TINYINT:
-            child->asFlatVector<int8_t>()->set(row, value.asInt());
-            break;
-          case TypeKind::SMALLINT:
-            child->asFlatVector<int16_t>()->set(row, value.asInt());
-            break;
-          case TypeKind::INTEGER:
-            child->asFlatVector<int32_t>()->set(row, value.asInt());
-            break;
-          case TypeKind::BIGINT:
-            child->asFlatVector<int64_t>()->set(row, value.asInt());
-            break;
-          case TypeKind::REAL:
-            child->asFlatVector<float>()->set(
-                row, static_cast<float>(value.asDouble()));
-            break;
-          case TypeKind::DOUBLE:
-            child->asFlatVector<double>()->set(row, value.asDouble());
-            break;
-          case TypeKind::VARCHAR: {
-            const auto stringValue = value.asString();
-            child->asFlatVector<StringView>()->set(
-                row, StringView(stringValue));
-            break;
-          }
-          default:
-            VELOX_UNSUPPORTED(
-                "RANGE_PID D1 does not support native key type {}",
-                type->toString());
-        }
-      }
-    }
-  }
-  return vector;
 }
 
 void normalizePartitionOffsets(

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -41,6 +41,17 @@ using facebook::velox::exec::Task;
 namespace facebook::velox::ucx_exchange {
 
 namespace {
+// libcudf's hash-partition exclusive scan can exceed the CUDA kernel launch
+// resource limit on very large tables before memory pressure is visible. Keep
+// an engine-level call-size ceiling even when the caller does not provide one;
+// explicit per-query limits remain authoritative and may be smaller.
+constexpr int64_t kDefaultMaxRowsPerHashPartitionCall = 128'000'000;
+
+// Admission is cooperative and can lose a race to another output driver.
+// When no reservation can be obtained, cap this driver's estimated transient
+// hash-partition peak so concurrent unadmitted fallbacks remain bounded.
+constexpr uint64_t kMaxUnadmittedHashPartitionPeakBytes = uint64_t{1} << 30;
+
 int64_t targetRowsPerUcxChunk(const core::QueryConfig& queryConfig) {
   if (const char* value =
           std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_ROWS")) {
@@ -178,6 +189,53 @@ void normalizePartitionOffsets(
   }
 }
 
+int64_t positiveEnvironmentOverride(const char* name) {
+  if (const char* value = std::getenv(name)) {
+    try {
+      const auto parsed = std::stoll(value);
+      if (parsed > 0) {
+        return static_cast<int64_t>(parsed);
+      }
+    } catch (...) {
+    }
+  }
+  return 0;
+}
+
+int64_t maxRowsPerHashPartitionCall(const core::QueryConfig& queryConfig) {
+  const auto environmentRows =
+      positiveEnvironmentOverride("GLUTEN_UCX_HASH_PARTITION_INPUT_BATCH_ROWS");
+  if (environmentRows > 0) {
+    return environmentRows;
+  }
+  const auto configuredRows = queryConfig.ucxHashPartitionInputBatchRows();
+  return configuredRows > 0 ? configuredRows
+                            : kDefaultMaxRowsPerHashPartitionCall;
+}
+
+int64_t maxRowsPerHashPartitionWindow(const core::QueryConfig& queryConfig) {
+  const auto environmentRows =
+      positiveEnvironmentOverride("GLUTEN_UCX_HASH_PARTITION_WINDOW_ROWS");
+  return environmentRows > 0 ? environmentRows
+                             : queryConfig.ucxHashPartitionWindowRows();
+}
+
+bool partialAggregationBehindProjects(
+    std::shared_ptr<const core::PlanNode> source) {
+  while (source) {
+    if (const auto aggregation =
+            std::dynamic_pointer_cast<const core::AggregationNode>(source)) {
+      return aggregation->step() == core::AggregationNode::Step::kPartial ||
+          aggregation->step() == core::AggregationNode::Step::kIntermediate;
+    }
+    if (!std::dynamic_pointer_cast<const core::ProjectNode>(source) ||
+        source->sources().size() != 1) {
+      return false;
+    }
+    source = source->sources().front();
+  }
+  return false;
+}
 uint64_t targetBytesPerUcxChunk(const core::QueryConfig& queryConfig) {
   if (const char* value =
           std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_BYTES")) {
@@ -204,8 +262,7 @@ cudf::size_type rowsPerUcxChunk(
     rowsPerChunk = std::min<cudf::size_type>(
         rowsPerChunk,
         static_cast<cudf::size_type>(std::min<uint64_t>(
-            byteLimitedRows,
-            std::numeric_limits<cudf::size_type>::max())));
+            byteLimitedRows, std::numeric_limits<cudf::size_type>::max())));
   }
   return std::max<cudf::size_type>(1, rowsPerChunk);
 }
@@ -262,8 +319,15 @@ UcxPartitionedOutput::UcxPartitionedOutput(
       numPartitions_(planNode->numPartitions()),
       pipelineId_(ctx->pipelineId),
       driverId_(ctx->driverId),
+      sourceNeedsOwnerBoundaryBackpressure_(
+          partialAggregationBehindProjects(planNode->sources().front())),
+      maxOutputBufferSize_(ctx->queryConfig().maxOutputBufferSize()),
       targetRowsPerChunk_(targetRowsPerUcxChunk(ctx->queryConfig())),
-      targetBytesPerChunk_(targetBytesPerUcxChunk(ctx->queryConfig())) {
+      targetBytesPerChunk_(targetBytesPerUcxChunk(ctx->queryConfig())),
+      hashPartitionInputBatchRows_(
+          maxRowsPerHashPartitionCall(ctx->queryConfig())),
+      hashPartitionWindowRows_(
+          maxRowsPerHashPartitionWindow(ctx->queryConfig())) {
   this->initPartitionKeys(planNode);
   auto sources = planNode->sources();
   std::vector<std::string> inNames, outNames;
@@ -291,20 +355,22 @@ void UcxPartitionedOutput::addInput(RowVectorPtr input) {
   VELOX_CHECK(
       !future_.valid() || future_.hasValue(),
       "addInput with outstanding future!");
+  VELOX_CHECK(!hasActiveFlush(), "addInput while a flush is still active");
 
+  const auto inputFlatBytes = input->estimateFlatSize();
   // Record stats per-input (before buffering).
   {
     auto lockedStats = stats_.wlock();
-    lockedStats->addOutputVector(input->estimateFlatSize(), input->size());
+    lockedStats->addOutputVector(inputFlatBytes, input->size());
   }
 
   pendingRows_ += cudfVector->getTableView().num_rows();
-  pendingBytes_ += cudfVector->estimateFlatSize();
+  pendingFlatBytes_ += inputFlatBytes;
   pendingInputs_.push_back(std::move(cudfVector));
 
   if ((targetRowsPerChunk_ <= 0 && targetBytesPerChunk_ == 0) ||
       (targetRowsPerChunk_ > 0 && pendingRows_ >= targetRowsPerChunk_) ||
-      (targetBytesPerChunk_ > 0 && pendingBytes_ >= targetBytesPerChunk_)) {
+      (targetBytesPerChunk_ > 0 && pendingFlatBytes_ >= targetBytesPerChunk_)) {
     flushPending();
   }
 }
@@ -313,102 +379,18 @@ void UcxPartitionedOutput::flushPending() {
   CudaAllocationTraceScope allocationTrace(
       fmt::format(
           "UcxPartitionedOutput task={} method=flushPending", taskId()));
-  if (pendingInputs_.empty()) {
+  if (!hasActiveFlush() && pendingInputs_.empty()) {
     return;
   }
 
   try {
-    const auto pendingBytes = pendingBytes_;
-    cudf::table_view tableView;
-    rmm::cuda_stream_view stream = pendingInputs_.back()->stream();
-    // Keeps the merged table alive while tableView references it.
-    std::unique_ptr<cudf::table> mergedTable;
-
-    if (pendingInputs_.size() == 1) {
-      // Fast path: use the single input's view directly (no GPU alloc).
-      auto& cv = pendingInputs_[0];
-      stream = cv->stream();
-      tableView = remap_.empty()
-          ? cv->getTableView()
-          : cv->getTableView().select(remap_.begin(), remap_.end());
-    } else {
-      // Collect (remapped) table views.
-      std::vector<cudf::table_view> views;
-      std::vector<rmm::cuda_stream_view> inputStreams;
-      views.reserve(pendingInputs_.size());
-      inputStreams.reserve(pendingInputs_.size());
-      for (auto& v : pendingInputs_) {
-        inputStreams.push_back(v->stream());
-        views.push_back(
-            remap_.empty()
-                ? v->getTableView()
-                : v->getTableView().select(remap_.begin(), remap_.end()));
-      }
-
-      cudf::detail::join_streams(inputStreams, stream);
-      mergedTable = cudf::concatenate(
-          views, stream, cudf::get_current_device_resource_ref());
-
-      orderCudfVectorDeallocationsAfterStream(
-          pendingInputs_, inputStreams, stream);
-
-      // Free input GPU memory before partitioning (peak = 2x -> 1x).
-      pendingInputs_.clear();
-
-      tableView = mergedTable->view();
+    if (!hasActiveFlush()) {
+      preparePendingFlush();
     }
-
-    // Partition + enqueue (identical to previous addInput logic).
-    auto queueManager = sharedQueueManager();
-    if (numPartitions_ > 1) {
-      if (!rangeBoundsJson_.empty()) {
-        rangePartition(tableView, stream);
-      } else if (partitionKeyIndices_.size() > 0 || spec_ == "gather") {
-        hashPartition(tableView, stream);
-      } else {
-        equalPartition(tableView, stream);
-      }
-    } else {
-      const auto tableRows = tableView.num_rows();
-      const auto rowsPerChunk = rowsPerUcxChunk(
-          tableRows,
-          pendingBytes,
-          targetRowsPerChunk_,
-          targetBytesPerChunk_);
-      // SINGLE/gather exchanges must obey the same chunk bound as HASH and
-      // RANGE.  Packing the whole input here bypassed splitAndEnqueue and let
-      // a global sort/gather create tens-of-GiB host-staging transfers.
-      for (cudf::size_type start = 0; start < tableRows;
-           start += rowsPerChunk) {
-        const auto end =
-            std::min<cudf::size_type>(tableRows, start + rowsPerChunk);
-        auto slicedTables = cudf::slice(tableView, {start, end});
-        VELOX_CHECK_EQ(slicedTables.size(), 1);
-        auto packedCols = cudf::pack(
-            slicedTables[0], stream, cudf::get_current_device_resource_ref());
-        stream.synchronize();
-        auto packedColsPtr = std::make_unique<cudf::packed_columns>(
-            std::move(packedCols.metadata), std::move(packedCols.gpu_data));
-        queueManager->enqueue(
-            this->taskId(),
-            0,
-            std::move(packedColsPtr),
-            slicedTables[0].num_rows());
-      }
-    }
-
-    // Check backpressure after enqueue.
-    auto blocked = queueManager->checkBlocked(this->taskId(), &future_);
-    if (blocked) {
-      VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
-              << " is blocked, can no longer write to output!";
-    }
-    blockingReason_ = blocked ? exec::BlockingReason::kWaitForConsumer
-                              : exec::BlockingReason::kNotBlocked;
-
-    pendingInputs_.clear();
-    pendingRows_ = 0;
-    pendingBytes_ = 0;
+    do {
+      advanceActiveFlush();
+    } while (hasActiveFlush() && activeDrainBeforeBackpressure_ &&
+             blockingReason_ == exec::BlockingReason::kNotBlocked);
 
   } catch (const rmm::bad_alloc& e) {
     VLOG(1)
@@ -416,12 +398,309 @@ void UcxPartitionedOutput::flushPending() {
         << " caught memory alloc error, removing all memory in output queues";
     pendingInputs_.clear();
     pendingRows_ = 0;
-    pendingBytes_ = 0;
+    pendingFlatBytes_ = 0;
+    clearActiveFlush();
     for (int i = 0; i < numPartitions_; i++) {
       sharedQueueManager()->deleteResults(this->taskId(), i);
     }
     throw;
   }
+}
+
+void UcxPartitionedOutput::preparePendingFlush() {
+  VELOX_CHECK(!hasActiveFlush());
+  VELOX_CHECK(!pendingInputs_.empty());
+
+  activeInputs_ = std::move(pendingInputs_);
+  activeSourceFlatBytes_ = pendingFlatBytes_;
+  pendingInputs_.clear();
+  pendingRows_ = 0;
+  pendingFlatBytes_ = 0;
+
+  auto stream = activeInputs_.back()->stream();
+  if (activeInputs_.size() > 1) {
+    std::vector<cudf::table_view> views;
+    std::vector<rmm::cuda_stream_view> inputStreams;
+    views.reserve(activeInputs_.size());
+    inputStreams.reserve(activeInputs_.size());
+    for (auto& input : activeInputs_) {
+      inputStreams.push_back(input->stream());
+      views.push_back(
+          remap_.empty()
+              ? input->getTableView()
+              : input->getTableView().select(remap_.begin(), remap_.end()));
+    }
+
+    cudf::detail::join_streams(inputStreams, stream);
+    activeMergedTable_ = cudf::concatenate(
+        views, stream, cudf::get_current_device_resource_ref());
+    orderCudfVectorDeallocationsAfterStream(
+        activeInputs_, inputStreams, stream);
+    // The concatenated table is now the source owner. Releasing the input
+    // vectors here preserves the old 2x -> 1x peak-memory behavior.
+    activeInputs_.clear();
+  }
+
+  activeStream_ = stream;
+  activeNextRow_ = 0;
+  const auto tableRows = activeTableView().num_rows();
+  if (numPartitions_ > 1 && rangeBoundsJson_.empty() &&
+      (partitionKeyIndices_.size() > 0 || spec_ == "gather") &&
+      hashPartitionInputBatchRows_ > 0) {
+    const auto configuredWindowRows = hashPartitionWindowRows_ > 0
+        ? hashPartitionWindowRows_
+        : (targetRowsPerChunk_ > 0 ? targetRowsPerChunk_
+                                   : hashPartitionInputBatchRows_);
+    const auto configuredRows = static_cast<uint64_t>(
+        std::max<int64_t>(hashPartitionInputBatchRows_, configuredWindowRows));
+    activeRowsPerWindow_ = rowsPerUcxChunk(
+        tableRows,
+        activeSourceFlatBytes_,
+        static_cast<int64_t>(std::min<uint64_t>(
+            configuredRows,
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))),
+        targetBytesPerChunk_);
+  } else if (numPartitions_ == 1) {
+    // SINGLE/gather exchanges yield after each output-sized chunk as well.
+    activeRowsPerWindow_ = rowsPerUcxChunk(
+        tableRows,
+        activeSourceFlatBytes_,
+        targetRowsPerChunk_,
+        targetBytesPerChunk_);
+  } else {
+    // Bound HASH/RANGE residency by the output byte target even when no
+    // explicit hash-call row limit is configured.
+    activeRowsPerWindow_ = rowsPerUcxChunk(
+        tableRows,
+        activeSourceFlatBytes_,
+        targetRowsPerChunk_,
+        targetBytesPerChunk_);
+  }
+
+  activeDrainBeforeBackpressure_ = sourceNeedsOwnerBoundaryBackpressure_ &&
+      maxOutputBufferSize_ > 0 &&
+      activeSourceFlatBytes_ > maxOutputBufferSize_ &&
+      activeRowsPerWindow_ < tableRows;
+  if (activeDrainBeforeBackpressure_) {
+    VLOG(2) << "UcxPartitionedOutput will drain oversized source before "
+               "backpressure task="
+            << taskId() << " sourceRows=" << tableRows
+            << " sourceFlatBytes=" << activeSourceFlatBytes_
+            << " rowsPerWindow=" << activeRowsPerWindow_
+            << " maxOutputBufferBytes=" << maxOutputBufferSize_;
+  }
+}
+
+bool UcxPartitionedOutput::hasActiveFlush() const {
+  return activeMergedTable_ != nullptr || !activeInputs_.empty();
+}
+
+cudf::table_view UcxPartitionedOutput::activeTableView() {
+  VELOX_CHECK(hasActiveFlush());
+  if (activeMergedTable_) {
+    return activeMergedTable_->view();
+  }
+  VELOX_CHECK_EQ(activeInputs_.size(), 1);
+  auto tableView = activeInputs_.front()->getTableView();
+  return remap_.empty() ? tableView
+                        : tableView.select(remap_.begin(), remap_.end());
+}
+
+void UcxPartitionedOutput::clearActiveFlush() {
+  activeInputs_.clear();
+  activeMergedTable_.reset();
+  activeStream_.reset();
+  activeSourceFlatBytes_ = 0;
+  activeNextRow_ = 0;
+  activeRowsPerWindow_ = 0;
+  activeDrainBeforeBackpressure_ = false;
+}
+
+void UcxPartitionedOutput::updateBackpressure() {
+  // The queue is shared by every output driver in this task. Checking after
+  // each residency window bounds overshoot to at most one window per driver,
+  // instead of allowing one addInput() to enqueue every remaining window.
+  // P0 deliberately checks after enqueue: exact packed bytes are only known
+  // then, and pre-reserving a window larger than maxSize would deadlock unless
+  // the credit protocol also grew a special oversized-window grant.
+  auto blocked = sharedQueueManager()->checkBlocked(this->taskId(), &future_);
+  if (blocked) {
+    VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
+            << " is blocked after output window";
+  }
+  blockingReason_ = blocked ? exec::BlockingReason::kWaitForConsumer
+                            : exec::BlockingReason::kNotBlocked;
+}
+
+void UcxPartitionedOutput::advanceActiveFlush() {
+  VELOX_CHECK(hasActiveFlush());
+  VELOX_CHECK(activeStream_.has_value());
+  VELOX_CHECK_EQ(blockingReason_, exec::BlockingReason::kNotBlocked);
+
+  auto tableView = activeTableView();
+  const auto tableRows = tableView.num_rows();
+  if (activeNextRow_ >= tableRows) {
+    clearActiveFlush();
+    return;
+  }
+
+  auto stream = *activeStream_;
+  auto rowsThisWindow = std::min<cudf::size_type>(
+      activeRowsPerWindow_, tableRows - activeNextRow_);
+  std::optional<cudf_velox::DeviceMemoryAdmissionReservation> memoryAdmission;
+
+  if (numPartitions_ > 1 && rangeBoundsJson_.empty() &&
+      (partitionKeyIndices_.size() > 0 || spec_ == "gather") &&
+      hashPartitionInputBatchRows_ > 0 && rowsThisWindow > 0 &&
+      activeSourceFlatBytes_ > 0 && tableRows > 0) {
+    const auto sourceRows = static_cast<uint64_t>(tableRows);
+    const auto averageRowBytes = activeSourceFlatBytes_ / sourceRows +
+        static_cast<uint64_t>(activeSourceFlatBytes_ % sourceRows != 0);
+    const auto candidateRows = static_cast<uint64_t>(rowsThisWindow);
+    const auto estimatePeakBytes = [&](uint64_t rows) {
+      const auto sourceBytes = averageRowBytes * rows;
+      const auto scratchBytes = rows * uint64_t{12} +
+          static_cast<uint64_t>(numPartitions_) * uint64_t{4096};
+      const auto workingBytes =
+          std::max(sourceBytes + scratchBytes, sourceBytes * uint64_t{2});
+      return workingBytes + workingBytes / uint64_t{4};
+    };
+    const auto fallbackRows = maxOutputBufferSize_ == 0
+        ? candidateRows
+        : std::max<uint64_t>(
+              1,
+              std::min(candidateRows, maxOutputBufferSize_ / averageRowBytes));
+    const auto headroom = cudf_velox::captureDeviceAllocationHeadroom();
+    const auto allocatableBytes = headroom.allocatableBytes();
+    const auto reserveBytes = headroom.totalBytes == 0
+        ? uint64_t{1} << 30
+        : std::max<uint64_t>(
+              uint64_t{1} << 30,
+              static_cast<uint64_t>(headroom.totalBytes) / uint64_t{50});
+    const auto admissionCapacity = allocatableBytes > reserveBytes
+        ? allocatableBytes - reserveBytes
+        : allocatableBytes / uint64_t{2};
+    const auto alreadyReserved =
+        cudf_velox::deviceMemoryAdmissionReservedBytes(headroom.device);
+    const auto availableCapacity = admissionCapacity > alreadyReserved
+        ? admissionCapacity - alreadyReserved
+        : uint64_t{0};
+    const auto candidatePeakBytes = estimatePeakBytes(candidateRows);
+
+    uint64_t selectedRows = candidateRows;
+    if (!headroom.cudaValid || candidatePeakBytes > availableCapacity) {
+      const auto pressureRows = candidatePeakBytes == 0
+          ? candidateRows
+          : std::max<uint64_t>(
+                1,
+                static_cast<uint64_t>(
+                    static_cast<long double>(candidateRows) *
+                    static_cast<long double>(availableCapacity) /
+                    static_cast<long double>(candidatePeakBytes)));
+      // The 1GiB queue-derived bound is no longer the normal workspace cap.
+      // It is retained as the proven emergency floor when a snapshot is
+      // unavailable or severely pressured; Q10 passed 10/10 at this size.
+      selectedRows =
+          std::min(candidateRows, std::max(fallbackRows, pressureRows));
+    }
+
+    auto selectedPeakBytes = estimatePeakBytes(selectedRows);
+    memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
+        headroom.device, selectedPeakBytes, admissionCapacity);
+    bool admissionRetried = false;
+    if (!memoryAdmission && fallbackRows < selectedRows) {
+      // The initial size used a non-atomic reservation snapshot. Another
+      // driver may have acquired capacity before this atomic attempt, so
+      // shrink to the proven queue-sized fallback and retry the reservation.
+      selectedRows = fallbackRows;
+      selectedPeakBytes = estimatePeakBytes(selectedRows);
+      memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
+          headroom.device, selectedPeakBytes, admissionCapacity);
+      admissionRetried = true;
+    }
+    if (!memoryAdmission &&
+        selectedPeakBytes > kMaxUnadmittedHashPartitionPeakBytes) {
+      // Admission can still be unavailable when every byte is temporarily
+      // reserved, or when CUDA headroom could not be sampled. A driver must
+      // not then execute the original large window unaccounted. Find the
+      // largest row count whose estimated peak is at most the explicit 1 GiB
+      // fallback bound, and give that smaller window one final admission try.
+      uint64_t lower = 1;
+      uint64_t upper = selectedRows;
+      if (estimatePeakBytes(lower) <= kMaxUnadmittedHashPartitionPeakBytes) {
+        while (lower < upper) {
+          const auto middle = lower + (upper - lower + 1) / 2;
+          if (estimatePeakBytes(middle) <=
+              kMaxUnadmittedHashPartitionPeakBytes) {
+            lower = middle;
+          } else {
+            upper = middle - 1;
+          }
+        }
+      }
+      selectedRows = lower;
+      selectedPeakBytes = estimatePeakBytes(selectedRows);
+      memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
+          headroom.device, selectedPeakBytes, admissionCapacity);
+      admissionRetried = true;
+    }
+    const bool unadmittedFallback = !memoryAdmission;
+    rowsThisWindow = static_cast<cudf::size_type>(selectedRows);
+    VLOG(2) << "UcxPartitionedOutput pressure-aware hash window task="
+            << taskId() << " sourceRows=" << tableRows
+            << " sourceFlatBytes=" << activeSourceFlatBytes_
+            << " averageRowBytes=" << averageRowBytes
+            << " candidateRows=" << candidateRows
+            << " selectedRows=" << selectedRows
+            << " estimatedPeakBytes=" << selectedPeakBytes
+            << " cudaFreeBytes=" << headroom.freeBytes
+            << " poolReusableBytes=" << headroom.reusablePoolBytes()
+            << " admissionCapacityBytes=" << admissionCapacity
+            << " alreadyReservedBytes=" << alreadyReserved
+            << " admissionRetried=" << admissionRetried
+            << " admitted=" << memoryAdmission.has_value()
+            << " unadmittedFallback=" << unadmittedFallback;
+  }
+
+  const auto end = activeNextRow_ + rowsThisWindow;
+  auto slices = cudf::slice(tableView, {activeNextRow_, end}, stream);
+  VELOX_CHECK_EQ(slices.size(), 1);
+
+  if (numPartitions_ > 1) {
+    if (!rangeBoundsJson_.empty()) {
+      rangePartition(slices[0], stream);
+    } else if (partitionKeyIndices_.size() > 0 || spec_ == "gather") {
+      // hashPartition() may internally split this residency window into safe
+      // libcudf call-size chunks, but it cannot cross into the next window.
+      hashPartition(slices[0], stream);
+    } else {
+      equalPartition(slices[0], stream);
+    }
+  } else {
+    auto packedCols =
+        cudf::pack(slices[0], stream, cudf::get_current_device_resource_ref());
+    stream.synchronize();
+    auto packedColsPtr = std::make_unique<cudf::packed_columns>(
+        std::move(packedCols.metadata), std::move(packedCols.gpu_data));
+    sharedQueueManager()->enqueue(
+        this->taskId(), 0, std::move(packedColsPtr), slices[0].num_rows());
+  }
+
+  activeNextRow_ = end;
+  const bool drainBeforeBackpressure = activeDrainBeforeBackpressure_;
+  if (activeNextRow_ == tableRows) {
+    // Every enqueue above synchronizes its stream before publication, so the
+    // source owner can be released even if the queue check below blocks.
+    clearActiveFlush();
+  }
+  if (drainBeforeBackpressure && hasActiveFlush()) {
+    // Retaining an oversized source behind a queue future can starve its
+    // upstream operator of the memory needed to produce the next batch. Keep
+    // draining this one source; consumers may concurrently retire published
+    // buffers. Backpressure is checked after the source owner is released.
+    return;
+  }
+  updateBackpressure();
 }
 
 exec::BlockingReason UcxPartitionedOutput::isBlocked(ContinueFuture* future) {
@@ -438,8 +717,18 @@ RowVectorPtr UcxPartitionedOutput::getOutput() {
   if (finished_) {
     return nullptr;
   }
-  if (noMoreInput_) {
-    flushPending(); // drain any remaining buffered inputs
+  // Driver calls isBlocked() before getOutput(). Keep this guard for direct
+  // test drivers and to ensure an outstanding future is never overwritten.
+  if (blockingReason_ != exec::BlockingReason::kNotBlocked) {
+    return nullptr;
+  }
+  if (hasActiveFlush() || (noMoreInput_ && !pendingInputs_.empty())) {
+    flushPending();
+  }
+  // A final work unit may have completed but filled the queue. Defer EOS until
+  // its future has been moved by isBlocked() and resumed by the Driver.
+  if (noMoreInput_ && !hasActiveFlush() && pendingInputs_.empty() &&
+      blockingReason_ == exec::BlockingReason::kNotBlocked) {
     sharedQueueManager()->noMoreData(this->taskId());
     finished_ = true;
   }
@@ -523,6 +812,167 @@ void UcxPartitionedOutput::initPartitionKeys(
 void UcxPartitionedOutput::hashPartition(
     cudf::table_view tableView,
     rmm::cuda_stream_view stream) {
+  const auto maxRows = hashPartitionInputBatchRows_;
+  if (maxRows > 0 && tableView.num_rows() > maxRows) {
+    VLOG(2) << "UcxPartitionedOutput pre-slicing hash input task=" << taskId()
+            << " rows=" << tableView.num_rows()
+            << " maxRowsPerCall=" << maxRows;
+
+    struct PartitionedChunk {
+      std::unique_ptr<cudf::table> table;
+      std::vector<cudf::size_type> offsets;
+    };
+    struct PackedPartition {
+      int32_t rows;
+      std::unique_ptr<cudf::packed_columns> data;
+    };
+    auto queueManager = sharedQueueManager();
+
+    // Bound the temporary residency of the safe hash path.  Keeping every
+    // 500K-row partitioned chunk for the full input, followed by all 32
+    // recombined destinations and all packed buffers, amplified a wide Q10
+    // customer batch by several times before output-buffer backpressure could
+    // run.  Work on one output-sized row window and one destination at a time
+    // instead.  The source vector remains alive, but all hash, concatenate,
+    // and pack temporaries for a window are released before the next window.
+    const auto configuredWindowRows = hashPartitionWindowRows_ > 0
+        ? hashPartitionWindowRows_
+        : (targetRowsPerChunk_ > 0 ? targetRowsPerChunk_ : maxRows);
+    const auto rowsPerWindow = static_cast<cudf::size_type>(
+        std::max<int64_t>(maxRows, configuredWindowRows));
+
+    // When the safety call size and residency window are identical, every
+    // window contains exactly one partitioned table.  Use contiguous_split's
+    // single bulk operation instead of packing 32 destinations one at a time.
+    // Besides avoiding needless concatenate bookkeeping, this changes Q10
+    // from one stream synchronization per destination to one per 8M-row
+    // window while preserving the same hard peak-memory bound.  Q21 uses a
+    // larger recombination window than its 500K call size and therefore keeps
+    // the multi-chunk path below.
+    if (rowsPerWindow == maxRows) {
+      std::vector<cudf::size_type> partitionKeyIndices;
+      partitionKeyIndices.reserve(partitionKeyIndices_.size());
+      for (const auto& idx : partitionKeyIndices_) {
+        partitionKeyIndices.push_back(static_cast<cudf::size_type>(idx));
+      }
+      for (cudf::size_type start = 0; start < tableView.num_rows();
+           start += rowsPerWindow) {
+        const auto end = std::min<cudf::size_type>(
+            tableView.num_rows(), start + rowsPerWindow);
+        auto slices = cudf::slice(tableView, {start, end}, stream);
+        VELOX_CHECK_EQ(slices.size(), 1);
+        auto [partitionedTable, partitionOffsets] = cudf::hash_partition(
+            slices[0],
+            partitionKeyIndices,
+            numPartitions_,
+            cudf::hash_id::HASH_MURMUR3,
+            cudf::DEFAULT_HASH_SEED,
+            stream);
+        VELOX_CHECK_EQ(partitionOffsets.size(), numPartitions_ + 1);
+        VELOX_CHECK_EQ(partitionOffsets.front(), 0);
+        partitionOffsets.erase(partitionOffsets.begin());
+        partitionOffsets.pop_back();
+        splitAndEnqueue(
+            partitionedTable->view(), std::move(partitionOffsets), stream);
+      }
+      return;
+    }
+
+    for (cudf::size_type windowStart = 0; windowStart < tableView.num_rows();
+         windowStart += rowsPerWindow) {
+      const auto windowEnd = std::min<cudf::size_type>(
+          tableView.num_rows(), windowStart + rowsPerWindow);
+      std::vector<PartitionedChunk> chunks;
+      chunks.reserve((windowEnd - windowStart + maxRows - 1) / maxRows);
+
+      for (cudf::size_type start = windowStart; start < windowEnd;) {
+        const auto end = std::min<cudf::size_type>(
+            windowEnd, start + static_cast<cudf::size_type>(maxRows));
+        auto slices = cudf::slice(tableView, {start, end}, stream);
+        VELOX_CHECK_EQ(slices.size(), 1);
+
+        std::vector<cudf::size_type> partitionKeyIndices;
+        partitionKeyIndices.reserve(partitionKeyIndices_.size());
+        for (const auto& idx : partitionKeyIndices_) {
+          partitionKeyIndices.push_back(static_cast<cudf::size_type>(idx));
+        }
+        auto [partitionedTable, partitionOffsets] = cudf::hash_partition(
+            slices[0],
+            partitionKeyIndices,
+            numPartitions_,
+            cudf::hash_id::HASH_MURMUR3,
+            cudf::DEFAULT_HASH_SEED,
+            stream);
+        VELOX_CHECK_EQ(partitionOffsets.size(), numPartitions_ + 1);
+        VELOX_CHECK_EQ(partitionOffsets.front(), 0);
+        chunks.push_back(
+            {std::move(partitionedTable), std::move(partitionOffsets)});
+        start = end;
+      }
+
+      for (int destination = 0; destination < numPartitions_; ++destination) {
+        std::vector<cudf::table_view> destinationViews;
+        destinationViews.reserve(chunks.size());
+        for (const auto& chunk : chunks) {
+          const auto begin = chunk.offsets[destination];
+          const auto end = chunk.offsets[destination + 1];
+          if (begin == end) {
+            continue;
+          }
+          auto slices = cudf::slice(chunk.table->view(), {begin, end}, stream);
+          VELOX_CHECK_EQ(slices.size(), 1);
+          destinationViews.push_back(slices[0]);
+        }
+        if (destinationViews.empty()) {
+          continue;
+        }
+
+        std::unique_ptr<cudf::table> combinedOwner;
+        cudf::table_view destinationView;
+        if (destinationViews.size() == 1) {
+          destinationView = destinationViews.front();
+        } else {
+          combinedOwner = cudf::concatenate(
+              destinationViews,
+              stream,
+              cudf::get_current_device_resource_ref());
+          destinationView = combinedOwner->view();
+        }
+
+        std::vector<PackedPartition> packedPartitions;
+        const auto rowsPerMessage = std::max<cudf::size_type>(
+            1,
+            targetRowsPerChunk_ > 0
+                ? std::min<cudf::size_type>(
+                      destinationView.num_rows(),
+                      static_cast<cudf::size_type>(targetRowsPerChunk_))
+                : destinationView.num_rows());
+        for (cudf::size_type begin = 0; begin < destinationView.num_rows();
+             begin += rowsPerMessage) {
+          const auto end = std::min<cudf::size_type>(
+              destinationView.num_rows(), begin + rowsPerMessage);
+          auto slices = cudf::slice(destinationView, {begin, end}, stream);
+          VELOX_CHECK_EQ(slices.size(), 1);
+          auto packed = cudf::pack(
+              slices[0], stream, cudf::get_current_device_resource_ref());
+          packedPartitions.push_back(
+              {slices[0].num_rows(),
+               std::make_unique<cudf::packed_columns>(
+                   std::move(packed.metadata), std::move(packed.gpu_data))});
+        }
+
+        // UCXX/UCX is not stream-aware.  Publish only completed buffers, then
+        // release this destination's concatenate/pack temporaries immediately.
+        stream.synchronize();
+        for (auto& packed : packedPartitions) {
+          queueManager->enqueue(
+              this->taskId(), destination, std::move(packed.data), packed.rows);
+        }
+      }
+    }
+    return;
+  }
+
   VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
           << " Hashing and partitioning into " << numPartitions_ << " chunks";
 
@@ -653,8 +1103,7 @@ void UcxPartitionedOutput::splitAndEnqueue(
     if (rowsPerChunk < partitionRows) {
       VLOG(2) << "UcxPartitionedOutput chunking task=" << taskId()
               << " destination=" << i << " rows=" << partitionRows
-              << " bytes=" << partitionBytes
-              << " rowsPerChunk=" << rowsPerChunk
+              << " bytes=" << partitionBytes << " rowsPerChunk=" << rowsPerChunk
               << " targetRowsPerChunk=" << targetRowsPerChunk_
               << " targetBytesPerChunk=" << targetBytesPerChunk_;
       for (cudf::size_type start = 0; start < partitionRows;

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -365,13 +365,22 @@ void UcxPartitionedOutput::preparePendingFlush() {
                                    : hashPartitionInputBatchRows_);
     const auto configuredRows = static_cast<uint64_t>(
         std::max<int64_t>(hashPartitionInputBatchRows_, configuredWindowRows));
+    // Source residency and destination message size are different bounds.
+    // A hash window is distributed across all destinations, so callers with
+    // sufficient receive credit may explicitly use a larger source window
+    // without increasing the per-destination chunk limit below.
+    const auto configuredWindowBytes = positiveEnvironmentOverride(
+        "GLUTEN_UCX_HASH_PARTITION_WINDOW_BYTES");
+    const auto sourceWindowBytes = configuredWindowBytes > 0
+        ? static_cast<uint64_t>(configuredWindowBytes)
+        : targetBytesPerChunk_;
     activeRowsPerWindow_ = rowsPerUcxChunk(
         tableRows,
         activeSourceFlatBytes_,
         static_cast<int64_t>(std::min<uint64_t>(
             configuredRows,
             static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))),
-        targetBytesPerChunk_);
+        sourceWindowBytes);
   } else if (numPartitions_ == 1) {
     // SINGLE/gather exchanges yield after each output-sized chunk as well.
     activeRowsPerWindow_ = rowsPerUcxChunk(
@@ -473,105 +482,118 @@ void UcxPartitionedOutput::advanceActiveFlush() {
       const auto sourceBytes = averageRowBytes * rows;
       const auto scratchBytes = rows * uint64_t{12} +
           static_cast<uint64_t>(numPartitions_) * uint64_t{4096};
-      const auto workingBytes =
-          std::max(sourceBytes + scratchBytes, sourceBytes * uint64_t{2});
+      // activeTableView() already owns the source and headroom excludes that
+      // live allocation. Admission reserves only the new partitioned output,
+      // hash scratch, and allocator headroom.
+      const auto workingBytes = sourceBytes + scratchBytes;
       return workingBytes + workingBytes / uint64_t{4};
     };
-    const auto fallbackRows = maxOutputBufferSize_ == 0
-        ? candidateRows
-        : std::max<uint64_t>(
-              1,
-              std::min(candidateRows, maxOutputBufferSize_ / averageRowBytes));
-    const auto headroom = cudf_velox::captureDeviceAllocationHeadroom();
-    const auto allocatableBytes = headroom.allocatableBytes();
-    const auto reserveBytes = headroom.totalBytes == 0
-        ? uint64_t{1} << 30
-        : std::max<uint64_t>(
-              uint64_t{1} << 30,
-              static_cast<uint64_t>(headroom.totalBytes) / uint64_t{50});
-    const auto admissionCapacity = allocatableBytes > reserveBytes
-        ? allocatableBytes - reserveBytes
-        : allocatableBytes / uint64_t{2};
-    const auto alreadyReserved =
-        cudf_velox::deviceMemoryAdmissionReservedBytes(headroom.device);
-    const auto availableCapacity = admissionCapacity > alreadyReserved
-        ? admissionCapacity - alreadyReserved
-        : uint64_t{0};
     const auto candidatePeakBytes = estimatePeakBytes(candidateRows);
-
-    uint64_t selectedRows = candidateRows;
-    if (!headroom.cudaValid || candidatePeakBytes > availableCapacity) {
-      const auto pressureRows = candidatePeakBytes == 0
+    // The unadmitted fallback below already proves that at most 1 GiB of new
+    // hash workspace is safe. Avoid a global CUDA/RMM headroom snapshot for
+    // windows inside that bound; sampling every normal batch serializes the
+    // producer pipeline and caused a measurable exchange regression.
+    if (candidatePeakBytes <= kMaxUnadmittedHashPartitionPeakBytes) {
+      VLOG(2) << "UcxPartitionedOutput bounded hash fast path task="
+              << taskId() << " sourceRows=" << tableRows
+              << " sourceFlatBytes=" << activeSourceFlatBytes_
+              << " selectedRows=" << candidateRows
+              << " estimatedPeakBytes=" << candidatePeakBytes;
+    } else {
+      const auto fallbackRows = maxOutputBufferSize_ == 0
           ? candidateRows
           : std::max<uint64_t>(
                 1,
-                static_cast<uint64_t>(
-                    static_cast<long double>(candidateRows) *
-                    static_cast<long double>(availableCapacity) /
-                    static_cast<long double>(candidatePeakBytes)));
-      // The 1GiB queue-derived bound is no longer the normal workspace cap.
-      // It is retained as the proven emergency floor when a snapshot is
-      // unavailable or severely pressured; Q10 passed 10/10 at this size.
-      selectedRows =
-          std::min(candidateRows, std::max(fallbackRows, pressureRows));
-    }
+                std::min(candidateRows, maxOutputBufferSize_ / averageRowBytes));
+      const auto headroom = cudf_velox::captureDeviceAllocationHeadroom();
+      const auto allocatableBytes = headroom.allocatableBytes();
+      const auto reserveBytes = headroom.totalBytes == 0
+          ? uint64_t{1} << 30
+          : std::max<uint64_t>(
+                uint64_t{1} << 30,
+                static_cast<uint64_t>(headroom.totalBytes) / uint64_t{50});
+      const auto admissionCapacity = allocatableBytes > reserveBytes
+          ? allocatableBytes - reserveBytes
+          : allocatableBytes / uint64_t{2};
+      const auto alreadyReserved =
+          cudf_velox::deviceMemoryAdmissionReservedBytes(headroom.device);
+      const auto availableCapacity = admissionCapacity > alreadyReserved
+          ? admissionCapacity - alreadyReserved
+          : uint64_t{0};
+      uint64_t selectedRows = candidateRows;
+      if (!headroom.cudaValid || candidatePeakBytes > availableCapacity) {
+        const auto pressureRows = candidatePeakBytes == 0
+            ? candidateRows
+            : std::max<uint64_t>(
+                  1,
+                  static_cast<uint64_t>(
+                      static_cast<long double>(candidateRows) *
+                      static_cast<long double>(availableCapacity) /
+                      static_cast<long double>(candidatePeakBytes)));
+        // The 1GiB queue-derived bound is no longer the normal workspace cap.
+        // It is retained as the proven emergency floor when a snapshot is
+        // unavailable or severely pressured; Q10 passed 10/10 at this size.
+        selectedRows =
+            std::min(candidateRows, std::max(fallbackRows, pressureRows));
+      }
 
-    auto selectedPeakBytes = estimatePeakBytes(selectedRows);
-    memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
-        headroom.device, selectedPeakBytes, admissionCapacity);
-    bool admissionRetried = false;
-    if (!memoryAdmission && fallbackRows < selectedRows) {
-      // The initial size used a non-atomic reservation snapshot. Another
-      // driver may have acquired capacity before this atomic attempt, so
-      // shrink to the proven queue-sized fallback and retry the reservation.
-      selectedRows = fallbackRows;
-      selectedPeakBytes = estimatePeakBytes(selectedRows);
+      auto selectedPeakBytes = estimatePeakBytes(selectedRows);
       memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
           headroom.device, selectedPeakBytes, admissionCapacity);
-      admissionRetried = true;
-    }
-    if (!memoryAdmission &&
-        selectedPeakBytes > kMaxUnadmittedHashPartitionPeakBytes) {
-      // Admission can still be unavailable when every byte is temporarily
-      // reserved, or when CUDA headroom could not be sampled. A driver must
-      // not then execute the original large window unaccounted. Find the
-      // largest row count whose estimated peak is at most the explicit 1 GiB
-      // fallback bound, and give that smaller window one final admission try.
-      uint64_t lower = 1;
-      uint64_t upper = selectedRows;
-      if (estimatePeakBytes(lower) <= kMaxUnadmittedHashPartitionPeakBytes) {
-        while (lower < upper) {
-          const auto middle = lower + (upper - lower + 1) / 2;
-          if (estimatePeakBytes(middle) <=
-              kMaxUnadmittedHashPartitionPeakBytes) {
-            lower = middle;
-          } else {
-            upper = middle - 1;
+      bool admissionRetried = false;
+      if (!memoryAdmission && fallbackRows < selectedRows) {
+        // The initial size used a non-atomic reservation snapshot. Another
+        // driver may have acquired capacity before this atomic attempt, so
+        // shrink to the proven queue-sized fallback and retry the reservation.
+        selectedRows = fallbackRows;
+        selectedPeakBytes = estimatePeakBytes(selectedRows);
+        memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
+            headroom.device, selectedPeakBytes, admissionCapacity);
+        admissionRetried = true;
+      }
+      if (!memoryAdmission &&
+          selectedPeakBytes > kMaxUnadmittedHashPartitionPeakBytes) {
+        // Admission can still be unavailable when every byte is temporarily
+        // reserved, or when CUDA headroom could not be sampled. A driver must
+        // not then execute the original large window unaccounted. Find the
+        // largest row count whose estimated peak is at most the explicit 1 GiB
+        // fallback bound, and give that smaller window one final admission try.
+        uint64_t lower = 1;
+        uint64_t upper = selectedRows;
+        if (estimatePeakBytes(lower) <= kMaxUnadmittedHashPartitionPeakBytes) {
+          while (lower < upper) {
+            const auto middle = lower + (upper - lower + 1) / 2;
+            if (estimatePeakBytes(middle) <=
+                kMaxUnadmittedHashPartitionPeakBytes) {
+              lower = middle;
+            } else {
+              upper = middle - 1;
+            }
           }
         }
+        selectedRows = lower;
+        selectedPeakBytes = estimatePeakBytes(selectedRows);
+        memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
+            headroom.device, selectedPeakBytes, admissionCapacity);
+        admissionRetried = true;
       }
-      selectedRows = lower;
-      selectedPeakBytes = estimatePeakBytes(selectedRows);
-      memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
-          headroom.device, selectedPeakBytes, admissionCapacity);
-      admissionRetried = true;
+      const bool unadmittedFallback = !memoryAdmission;
+      rowsThisWindow = static_cast<cudf::size_type>(selectedRows);
+      VLOG(2) << "UcxPartitionedOutput pressure-aware hash window task="
+              << taskId() << " sourceRows=" << tableRows
+              << " sourceFlatBytes=" << activeSourceFlatBytes_
+              << " averageRowBytes=" << averageRowBytes
+              << " candidateRows=" << candidateRows
+              << " selectedRows=" << selectedRows
+              << " estimatedPeakBytes=" << selectedPeakBytes
+              << " cudaFreeBytes=" << headroom.freeBytes
+              << " poolReusableBytes=" << headroom.reusablePoolBytes()
+              << " admissionCapacityBytes=" << admissionCapacity
+              << " alreadyReservedBytes=" << alreadyReserved
+              << " admissionRetried=" << admissionRetried
+              << " admitted=" << memoryAdmission.has_value()
+              << " unadmittedFallback=" << unadmittedFallback;
     }
-    const bool unadmittedFallback = !memoryAdmission;
-    rowsThisWindow = static_cast<cudf::size_type>(selectedRows);
-    VLOG(2) << "UcxPartitionedOutput pressure-aware hash window task="
-            << taskId() << " sourceRows=" << tableRows
-            << " sourceFlatBytes=" << activeSourceFlatBytes_
-            << " averageRowBytes=" << averageRowBytes
-            << " candidateRows=" << candidateRows
-            << " selectedRows=" << selectedRows
-            << " estimatedPeakBytes=" << selectedPeakBytes
-            << " cudaFreeBytes=" << headroom.freeBytes
-            << " poolReusableBytes=" << headroom.reusablePoolBytes()
-            << " admissionCapacityBytes=" << admissionCapacity
-            << " alreadyReservedBytes=" << alreadyReserved
-            << " admissionRetried=" << admissionRetried
-            << " admitted=" << memoryAdmission.has_value()
-            << " unadmittedFallback=" << unadmittedFallback;
   }
 
   const auto end = activeNextRow_ + rowsThisWindow;

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -369,8 +369,8 @@ void UcxPartitionedOutput::preparePendingFlush() {
     // A hash window is distributed across all destinations, so callers with
     // sufficient receive credit may explicitly use a larger source window
     // without increasing the per-destination chunk limit below.
-    const auto configuredWindowBytes = positiveEnvironmentOverride(
-        "GLUTEN_UCX_HASH_PARTITION_WINDOW_BYTES");
+    const auto configuredWindowBytes =
+        positiveEnvironmentOverride("GLUTEN_UCX_HASH_PARTITION_WINDOW_BYTES");
     const auto sourceWindowBytes = configuredWindowBytes > 0
         ? static_cast<uint64_t>(configuredWindowBytes)
         : targetBytesPerChunk_;
@@ -494,8 +494,8 @@ void UcxPartitionedOutput::advanceActiveFlush() {
     // windows inside that bound; sampling every normal batch serializes the
     // producer pipeline and caused a measurable exchange regression.
     if (candidatePeakBytes <= kMaxUnadmittedHashPartitionPeakBytes) {
-      VLOG(2) << "UcxPartitionedOutput bounded hash fast path task="
-              << taskId() << " sourceRows=" << tableRows
+      VLOG(2) << "UcxPartitionedOutput bounded hash fast path task=" << taskId()
+              << " sourceRows=" << tableRows
               << " sourceFlatBytes=" << activeSourceFlatBytes_
               << " selectedRows=" << candidateRows
               << " estimatedPeakBytes=" << candidatePeakBytes;
@@ -504,7 +504,8 @@ void UcxPartitionedOutput::advanceActiveFlush() {
           ? candidateRows
           : std::max<uint64_t>(
                 1,
-                std::min(candidateRows, maxOutputBufferSize_ / averageRowBytes));
+                std::min(
+                    candidateRows, maxOutputBufferSize_ / averageRowBytes));
       const auto headroom = cudf_velox::captureDeviceAllocationHeadroom();
       const auto allocatableBytes = headroom.allocatableBytes();
       const auto reserveBytes = headroom.totalBytes == 0

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -51,6 +51,27 @@ constexpr int64_t kDefaultMaxRowsPerHashPartitionCall = 128'000'000;
 // hash-partition peak so concurrent unadmitted fallbacks remain bounded.
 constexpr uint64_t kMaxUnadmittedHashPartitionPeakBytes = uint64_t{1} << 30;
 
+bool containsStructColumn(const cudf::column_view& column) {
+  if (column.type().id() == cudf::type_id::STRUCT) {
+    return true;
+  }
+  for (cudf::size_type child = 0; child < column.num_children(); ++child) {
+    if (containsStructColumn(column.child(child))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool containsStructColumn(const cudf::table_view& table) {
+  for (cudf::size_type column = 0; column < table.num_columns(); ++column) {
+    if (containsStructColumn(table.column(column))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 int64_t targetRowsPerUcxChunk(const core::QueryConfig& queryConfig) {
   if (const char* value =
           std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_ROWS")) {
@@ -557,15 +578,25 @@ void UcxPartitionedOutput::advanceActiveFlush() {
   auto slices = cudf::slice(tableView, {activeNextRow_, end}, stream);
   VELOX_CHECK_EQ(slices.size(), 1);
 
+  auto partitionInput = slices[0];
+  std::unique_ptr<cudf::table> materializedPartitionInput;
+  if (numPartitions_ > 1 && containsStructColumn(partitionInput)) {
+    // libcudf partition requires STRUCT children to align with their sliced
+    // parent. Materialize this bounded window to normalize nested offsets.
+    materializedPartitionInput = std::make_unique<cudf::table>(
+        partitionInput, stream, cudf::get_current_device_resource_ref());
+    partitionInput = materializedPartitionInput->view();
+  }
+
   if (numPartitions_ > 1) {
     if (!rangeBoundsJson_.empty()) {
-      rangePartition(slices[0], stream);
+      rangePartition(partitionInput, stream);
     } else if (partitionKeyIndices_.size() > 0 || spec_ == "gather") {
       // hashPartition() may internally split this residency window into safe
       // libcudf call-size chunks, but it cannot cross into the next window.
-      hashPartition(slices[0], stream);
+      hashPartition(partitionInput, stream);
     } else {
-      equalPartition(slices[0], stream);
+      equalPartition(partitionInput, stream);
     }
   } else {
     auto packedCols =

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -18,6 +18,7 @@
 #include <folly/json.h>
 #include <algorithm>
 #include <cstdlib>
+#include <limits>
 #include "velox/core/PlanNode.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/Driver.h"
@@ -176,6 +177,38 @@ void normalizePartitionOffsets(
     offsets.pop_back();
   }
 }
+
+uint64_t targetBytesPerUcxChunk(const core::QueryConfig& queryConfig) {
+  if (const char* value =
+          std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_BYTES")) {
+    try {
+      return std::stoull(value);
+    } catch (...) {
+    }
+  }
+  return queryConfig.ucxPartitionedOutputBatchBytes();
+}
+
+cudf::size_type rowsPerUcxChunk(
+    cudf::size_type rows,
+    uint64_t bytes,
+    int64_t targetRows,
+    uint64_t targetBytes) {
+  auto rowsPerChunk = rows;
+  if (targetRows > 0) {
+    rowsPerChunk = std::min<cudf::size_type>(rowsPerChunk, targetRows);
+  }
+  if (targetBytes > 0 && bytes > targetBytes && rows > 0) {
+    const auto byteLimitedRows = std::max<uint64_t>(
+        1, static_cast<uint64_t>(rows) * targetBytes / bytes);
+    rowsPerChunk = std::min<cudf::size_type>(
+        rowsPerChunk,
+        static_cast<cudf::size_type>(std::min<uint64_t>(
+            byteLimitedRows,
+            std::numeric_limits<cudf::size_type>::max())));
+  }
+  return std::max<cudf::size_type>(1, rowsPerChunk);
+}
 } // namespace
 
 // Computes a mapping from names in n2 to names in n1
@@ -229,7 +262,8 @@ UcxPartitionedOutput::UcxPartitionedOutput(
       numPartitions_(planNode->numPartitions()),
       pipelineId_(ctx->pipelineId),
       driverId_(ctx->driverId),
-      targetRowsPerChunk_(targetRowsPerUcxChunk(ctx->queryConfig())) {
+      targetRowsPerChunk_(targetRowsPerUcxChunk(ctx->queryConfig())),
+      targetBytesPerChunk_(targetBytesPerUcxChunk(ctx->queryConfig())) {
   this->initPartitionKeys(planNode);
   auto sources = planNode->sources();
   std::vector<std::string> inNames, outNames;
@@ -265,9 +299,12 @@ void UcxPartitionedOutput::addInput(RowVectorPtr input) {
   }
 
   pendingRows_ += cudfVector->getTableView().num_rows();
+  pendingBytes_ += cudfVector->estimateFlatSize();
   pendingInputs_.push_back(std::move(cudfVector));
 
-  if (targetRowsPerChunk_ <= 0 || pendingRows_ >= targetRowsPerChunk_) {
+  if ((targetRowsPerChunk_ <= 0 && targetBytesPerChunk_ == 0) ||
+      (targetRowsPerChunk_ > 0 && pendingRows_ >= targetRowsPerChunk_) ||
+      (targetBytesPerChunk_ > 0 && pendingBytes_ >= targetBytesPerChunk_)) {
     flushPending();
   }
 }
@@ -281,6 +318,7 @@ void UcxPartitionedOutput::flushPending() {
   }
 
   try {
+    const auto pendingBytes = pendingBytes_;
     cudf::table_view tableView;
     rmm::cuda_stream_view stream = pendingInputs_.back()->stream();
     // Keeps the merged table alive while tableView references it.
@@ -332,13 +370,11 @@ void UcxPartitionedOutput::flushPending() {
       }
     } else {
       const auto tableRows = tableView.num_rows();
-      const auto rowsPerChunk = std::max<cudf::size_type>(
-          1,
-          targetRowsPerChunk_ > 0
-              ? std::min<cudf::size_type>(
-                    tableRows,
-                    static_cast<cudf::size_type>(targetRowsPerChunk_))
-              : tableRows);
+      const auto rowsPerChunk = rowsPerUcxChunk(
+          tableRows,
+          pendingBytes,
+          targetRowsPerChunk_,
+          targetBytesPerChunk_);
       // SINGLE/gather exchanges must obey the same chunk bound as HASH and
       // RANGE.  Packing the whole input here bypassed splitAndEnqueue and let
       // a global sort/gather create tens-of-GiB host-staging transfers.
@@ -372,6 +408,7 @@ void UcxPartitionedOutput::flushPending() {
 
     pendingInputs_.clear();
     pendingRows_ = 0;
+    pendingBytes_ = 0;
 
   } catch (const rmm::bad_alloc& e) {
     VLOG(1)
@@ -379,6 +416,7 @@ void UcxPartitionedOutput::flushPending() {
         << " caught memory alloc error, removing all memory in output queues";
     pendingInputs_.clear();
     pendingRows_ = 0;
+    pendingBytes_ = 0;
     for (int i = 0; i < numPartitions_; i++) {
       sharedQueueManager()->deleteResults(this->taskId(), i);
     }
@@ -606,20 +644,28 @@ void UcxPartitionedOutput::splitAndEnqueue(
       continue;
     }
 
-    const bool rowChunkingNeeded =
-        targetRowsPerChunk_ > 0 && partitionRows > targetRowsPerChunk_;
-    if (rowChunkingNeeded) {
-      cudf::size_type rowsPerChunk = std::min<cudf::size_type>(
-          partitionRows, static_cast<cudf::size_type>(targetRowsPerChunk_));
+    const auto partitionBytes = partitionTable.data.gpu_data->size();
+    const auto rowsPerChunk = rowsPerUcxChunk(
+        partitionRows,
+        partitionBytes,
+        targetRowsPerChunk_,
+        targetBytesPerChunk_);
+    if (rowsPerChunk < partitionRows) {
       VLOG(2) << "UcxPartitionedOutput chunking task=" << taskId()
               << " destination=" << i << " rows=" << partitionRows
+              << " bytes=" << partitionBytes
               << " rowsPerChunk=" << rowsPerChunk
-              << " targetRowsPerChunk=" << targetRowsPerChunk_;
+              << " targetRowsPerChunk=" << targetRowsPerChunk_
+              << " targetBytesPerChunk=" << targetBytesPerChunk_;
       for (cudf::size_type start = 0; start < partitionRows;
            start += rowsPerChunk) {
         const auto end =
             std::min<cudf::size_type>(partitionRows, start + rowsPerChunk);
-        auto slicedTables = cudf::slice(partitionTable.table, {start, end});
+        auto slicedTables = cudf::slice(
+            partitionTable.table,
+            {static_cast<cudf::size_type>(start),
+             static_cast<cudf::size_type>(end)},
+            stream);
         VELOX_CHECK_EQ(slicedTables.size(), 1);
         auto packedCols = cudf::pack(slicedTables[0], stream);
         stream.synchronize();

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <optional>
+
 #include "velox/exec/Operator.h"
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
@@ -47,18 +49,16 @@ class UcxPartitionedOutput : public exec::Operator,
   /// a non-blocked state, otherwise blocked.
   RowVectorPtr getOutput() override;
 
-  /// always true but the caller will check isBlocked before adding input, hence
-  /// the blocked state does not accumulate input.
+  /// Do not accept another input while a large input is being partitioned a
+  /// window at a time. The driver calls getOutput() to resume that work.
   bool needsInput() const override {
-    return true;
+    return !noMoreInput_ && !hasActiveFlush();
   }
 
-  // the operator is blocked if the queues are full, we are ignoring this so
-  // always return kNotBlocked
+  /// Moves the shared output queue's backpressure future to the Driver.
   exec::BlockingReason isBlocked(ContinueFuture* future) override;
 
-  // The operaor is finished when the queue manager say the queues have all been
-  // drained ?
+  /// Finished after all input windows have been enqueued and EOS published.
   bool isFinished() override;
 
  private:
@@ -101,8 +101,12 @@ class UcxPartitionedOutput : public exec::Operator,
 
   const int pipelineId_;
   const int driverId_;
+  /// Partial aggregation may need a large transient allocation to produce its
+  /// next batch. Do not retain one of its oversized outputs across a queue
+  /// wait; scan/join producers keep normal mid-source backpressure.
+  const bool sourceNeedsOwnerBoundaryBackpressure_;
 
-  exec::BlockingReason blockingReason_;
+  exec::BlockingReason blockingReason_{exec::BlockingReason::kNotBlocked};
   ContinueFuture future_;
 
   bool finished_{false};
@@ -113,18 +117,55 @@ class UcxPartitionedOutput : public exec::Operator,
   std::vector<uint32_t> remap_;
 
   /// Concatenates pending inputs and partitions/enqueues the merged result.
+  /// Each invocation advances at most one hash-partition residency window (or
+  /// one SINGLE chunk), allowing the Driver to observe queue backpressure in
+  /// between windows.
   void flushPending();
+
+  /// Moves pending inputs into resumable flush state. For multiple inputs,
+  /// owns the concatenated table; for one input, activeInputs_ owns the vector
+  /// referenced by the active table view.
+  void preparePendingFlush();
+
+  /// Processes and enqueues one resumable work unit from the active flush.
+  void advanceActiveFlush();
+
+  /// Checks task-wide output queue pressure immediately after a work unit.
+  void updateBackpressure();
+
+  bool hasActiveFlush() const;
+  cudf::table_view activeTableView();
+  void clearActiveFlush();
 
   /// Accumulated CudfVectors awaiting flush.
   std::vector<cudf_velox::CudfVectorPtr> pendingInputs_;
   /// Total rows across pendingInputs_.
   int64_t pendingRows_{0};
-  /// Estimated bytes across pendingInputs_.
-  uint64_t pendingBytes_{0};
+  /// Source GPU bytes across pendingInputs_, captured before owners are freed.
+  uint64_t pendingFlatBytes_{0};
+
+  /// Ownership and cursor for a flush that yielded between partition windows.
+  std::vector<cudf_velox::CudfVectorPtr> activeInputs_;
+  std::unique_ptr<cudf::table> activeMergedTable_;
+  std::optional<rmm::cuda_stream_view> activeStream_;
+  uint64_t activeSourceFlatBytes_{0};
+  cudf::size_type activeNextRow_{0};
+  cudf::size_type activeRowsPerWindow_{0};
+  /// A source larger than the task queue cap must not remain pinned while the
+  /// producer is blocked. Such an oversized, multi-window source is drained
+  /// before observing backpressure so its owner can be released promptly.
+  bool activeDrainBeforeBackpressure_{false};
+  /// Task-wide queue byte cap. Normal window sizing uses device headroom;
+  /// this supplies only the emergency schema-width fallback under pressure.
+  const uint64_t maxOutputBufferSize_;
   /// Configured row threshold for flushing (from QueryConfig).
   const int64_t targetRowsPerChunk_;
   /// Configured byte threshold for flushing and destination chunking.
   const uint64_t targetBytesPerChunk_;
+  /// Optional libcudf hash_partition safety limit. Zero disables slicing.
+  const int64_t hashPartitionInputBatchRows_;
+  /// Source-row window for recombining safely sliced hash output.
+  const int64_t hashPartitionWindowRows_;
 };
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
@@ -119,8 +119,12 @@ class UcxPartitionedOutput : public exec::Operator,
   std::vector<cudf_velox::CudfVectorPtr> pendingInputs_;
   /// Total rows across pendingInputs_.
   int64_t pendingRows_{0};
+  /// Estimated bytes across pendingInputs_.
+  uint64_t pendingBytes_{0};
   /// Configured row threshold for flushing (from QueryConfig).
   const int64_t targetRowsPerChunk_;
+  /// Configured byte threshold for flushing and destination chunking.
+  const uint64_t targetBytesPerChunk_;
 };
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -121,8 +121,26 @@ UcxDestinationQueue::Data UcxDestinationQueue::getData(
     uint64_t maxBytes,
     int64_t sequence,
     UcxDataAvailableCallbackV2 notify) {
-  VELOX_CHECK_GE(
-      sequence, sequence_, "Get received for an already acknowledged item");
+  if (sequence < sequence_) {
+    // A retried/duplicate UCX connection can race with task abort after the
+    // original server has already advanced this destination queue.  Treat
+    // that request as stale instead of throwing on the communicator thread
+    // (an uncaught VeloxException there terminates the whole Spark executor).
+    // Returning the current sequence lets UcxExchangeServer identify and
+    // close only the stale connection without dequeuing or clearing data.
+    LOG(WARNING) << "Ignoring stale UCX queue request: requestedSequence="
+                 << sequence << " acknowledgedSequence=" << sequence_;
+    return {nullptr, sequence_, {}, true};
+  }
+  if (notifyV2_ != nullptr && notify != nullptr) {
+    // A second server for the same task/destination/sequence must not replace
+    // the active server's waiter.  Return a deliberately different sequence
+    // so the duplicate UcxExchangeServer follows its stale-connection close
+    // path while the original callback remains installed.
+    LOG(WARNING) << "Ignoring duplicate UCX queue waiter: sequence=" << sequence
+                 << " acknowledgedSequence=" << sequence_;
+    return {nullptr, sequence_ + 1, {}, true};
+  }
   VELOX_CHECK(
       notify_ == nullptr && notifyV2_ == nullptr,
       "UcxDestinationQueue already has a pending data notification");

--- a/velox/experimental/ucx-exchange/tests/Main.cpp
+++ b/velox/experimental/ucx-exchange/tests/Main.cpp
@@ -34,7 +34,6 @@ int main(int argc, char** argv) {
   // Signal handler required for ThreadDebugInfoTest
   facebook::velox::process::addDefaultFatalSignalHandler();
   folly::Init init(&argc, &argv, false);
-  FLAGS_velox_ucx_exchange = true;
   facebook::velox::Type::registerSerDe();
   facebook::velox::cudf_velox::CudfConfig::getInstance().exchangeLogLevel =
       FLAGS_exchange_log_level;

--- a/velox/experimental/ucx-exchange/tests/Main.cpp
+++ b/velox/experimental/ucx-exchange/tests/Main.cpp
@@ -38,5 +38,6 @@ int main(int argc, char** argv) {
   facebook::velox::Type::registerSerDe();
   facebook::velox::cudf_velox::CudfConfig::getInstance().exchangeLogLevel =
       FLAGS_exchange_log_level;
+  facebook::velox::cudf_velox::CudfConfig::getInstance().exchange = true;
   return RUN_ALL_TESTS();
 }

--- a/velox/experimental/ucx-exchange/tests/SourceDriverMock.cpp
+++ b/velox/experimental/ucx-exchange/tests/SourceDriverMock.cpp
@@ -82,22 +82,30 @@ void SourceDriverMock::sendAllData(UcxPartitionedOutput* partitionedOutput) {
   auto* pool = partitionedOutput->pool();
 
   for (uint32_t chunk = 0; chunk < numChunks_; ++chunk) {
-    // 1. Create CudfVector with test data using makeCudfVector helper
-    auto cudfVector = makeCudfVector(
-        pool, numRowsPerChunk_, rowType, tableGenerator_, stream);
-
-    // 2. Check isBlocked() - if blocked, wait on future
+    // 1. Drain resumable output work and wait for backpressure before adding
+    // another input. A real Driver checks both isBlocked() and needsInput().
+    // Keep this mock on the same contract now that UcxPartitionedOutput can
+    // yield between hash-partition residency windows.
     while (true) {
       ContinueFuture future;
       auto blocked = partitionedOutput->isBlocked(&future);
-      if (blocked == exec::BlockingReason::kNotBlocked) {
+      if (blocked != exec::BlockingReason::kNotBlocked) {
+        future.wait();
+        continue;
+      }
+      if (partitionedOutput->needsInput()) {
         break;
       }
-      // Wait for the operator to become unblocked
-      future.wait();
+      partitionedOutput->getOutput();
     }
 
-    // 3. Call addInput() now that we're not blocked
+    // 2. Create the next CudfVector only after the operator can accept it, as
+    // a real upstream operator would. This avoids retaining an extra large
+    // source batch while the prior batch is blocked in output.
+    auto cudfVector = makeCudfVector(
+        pool, numRowsPerChunk_, rowType, tableGenerator_, stream);
+
+    // 3. Call addInput() now that we're not blocked and need input.
     partitionedOutput->addInput(cudfVector);
 
     // 4. Call getOutput() to advance operator state

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -1483,6 +1483,63 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
 
     queueManager_->removeTask(srcTaskId);
   }
+
+  // --- Scenario 5: Byte-only threshold via QueryConfig ---
+  {
+    const int numChunks = 20;
+    // Use a one-row repeated pattern so validation remains independent of
+    // byte-based output slice boundaries.
+    const int numRowsPerChunk = 1;
+    const int numPartitions = 1;
+    const int numDrivers = 1;
+    const std::string taskPrefix = getUniqueTaskPrefix();
+    const std::string srcTaskId = taskPrefix + "sourceTask0";
+
+    auto dataToSend = std::make_shared<UcxTestData>();
+    dataToSend->initialize(numRowsPerChunk);
+
+    std::unordered_map<std::string, std::string> extraConfig{
+        {core::QueryConfig::kUcxPartitionedOutputBatchRows, "0"},
+        {core::QueryConfig::kUcxPartitionedOutputBatchBytes, "256"}};
+    auto srcTask = createPartitionedOutputTask(
+        srcTaskId,
+        pool_,
+        UcxTestData::kTestRowType,
+        numPartitions,
+        {},
+        FOUR_GBYTES,
+        extraConfig);
+    queueManager_->initializeTask(
+        srcTask,
+        core::PartitionedOutputNode::Kind::kPartitioned,
+        numPartitions,
+        numDrivers);
+
+    auto sourceDriver = std::make_shared<SourceDriverMock>(
+        srcTask, numDrivers, numChunks, numRowsPerChunk, dataToSend);
+    const std::string sinkTaskId = taskPrefix + "sinkTask0";
+    core::PlanNodeId exchangeNodeId;
+    auto sinkTask = createExchangeTask(
+        sinkTaskId, UcxTestData::kTestRowType, 0, exchangeNodeId);
+    auto sinkDriver =
+        std::make_shared<SinkDriverMock>(sinkTask, numDrivers, dataToSend);
+    std::vector<exec::Split> splits{remoteSplit(srcTaskId, 0)};
+    sinkDriver->addSplits(splits);
+
+    sourceDriver->run();
+    sinkDriver->run();
+    sourceDriver->joinThreads();
+    sinkDriver->joinThreads();
+
+    EXPECT_EQ(
+        sinkDriver->numRows(),
+        static_cast<size_t>(numChunks) * numRowsPerChunk);
+    EXPECT_TRUE(sinkDriver->dataIsValid());
+    EXPECT_GT(sinkDriver->numChunksReceived(), 1);
+    EXPECT_LT(
+        sinkDriver->numChunksReceived(), static_cast<uint64_t>(numChunks));
+    queueManager_->removeTask(srcTaskId);
+  }
 }
 
 // Regression test: aborting a source task while UCXX tagRecv requests are

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -40,6 +40,7 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
+#include "velox/experimental/ucx-exchange/RangePartitionFunction.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
 #include "velox/experimental/ucx-exchange/tests/SinkDriverMock.h"
@@ -1563,6 +1564,83 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
         sinkDriver->numChunksReceived(), static_cast<uint64_t>(numChunks));
     queueManager_->removeTask(srcTaskId);
   }
+}
+
+TEST_P(UcxExchangeTest, rangePartitionSupportsSlicedStructs) {
+  const auto p = GetParam();
+  if (p.numSrcDrivers != 1 || p.numDstDrivers != 1 || p.numPartitions != 1 ||
+      p.numChunks != 100 || p.numUpstreamTasks != 1 ||
+      p.tableType != TableType::NARROW) {
+    GTEST_SKIP() << "rangePartitionSupportsSlicedStructs: runs only once";
+  }
+
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  const bool originalIntraNode = config.intraNodeExchange;
+  config.intraNodeExchange = true;
+  SCOPE_EXIT {
+    config.intraNodeExchange = originalIntraNode;
+  };
+
+  constexpr int kRows = 20'000;
+  constexpr int kWindowRows = 10'000;
+  constexpr int kNumPartitions = 2;
+  const std::string taskPrefix = getUniqueTaskPrefix();
+  const std::string sourceTaskId = taskPrefix + "sourceTask0";
+
+  auto data = std::make_shared<WideComplexTestTable>();
+  data->initialize(kRows);
+  auto rowType = data->getRowType();
+  auto rangeSpec = std::make_shared<RangePartitionFunctionSpec>(
+      rowType,
+      std::vector<column_index_t>{2},
+      R"({"version":1,"keys":[{"ascending":true,"nullsFirst":true}],"bounds":[[{"isNull":false,"value":0}]]})");
+  std::unordered_map<std::string, std::string> extraConfig{
+      {core::QueryConfig::kUcxPartitionedOutputBatchRows,
+       std::to_string(kWindowRows)}};
+  auto sourceTask = createPartitionedOutputTask(
+      sourceTaskId,
+      pool_,
+      rowType,
+      kNumPartitions,
+      {"int32_col"},
+      FOUR_GBYTES,
+      extraConfig,
+      rangeSpec);
+  queueManager_->initializeTask(
+      sourceTask,
+      core::PartitionedOutputNode::Kind::kPartitioned,
+      kNumPartitions,
+      1);
+
+  auto source =
+      std::make_shared<SourceDriverMock>(sourceTask, 1, 1, kRows, data);
+  std::vector<std::shared_ptr<SinkDriverMock>> sinks;
+  for (int partition = 0; partition < kNumPartitions; ++partition) {
+    core::PlanNodeId exchangeNodeId;
+    auto sinkTask = createExchangeTask(
+        taskPrefix + "sinkTask" + std::to_string(partition),
+        rowType,
+        partition,
+        exchangeNodeId);
+    auto sink = std::make_shared<SinkDriverMock>(sinkTask, 1, nullptr);
+    std::vector<exec::Split> splits{remoteSplit(sourceTaskId, partition)};
+    sink->addSplits(splits);
+    sinks.push_back(std::move(sink));
+  }
+
+  for (auto& sink : sinks) {
+    sink->run();
+  }
+  source->run();
+  source->joinThreads();
+  uint64_t totalRows = 0;
+  for (auto& sink : sinks) {
+    sink->joinThreads();
+    totalRows += sink->numRows();
+  }
+
+  EXPECT_EQ(totalRows, kRows);
+  queueManager_->removeTask(sourceTaskId);
 }
 
 // Regression test for resumable hash output. With no consumer, each producer

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -23,6 +23,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <folly/Executor.h>
+#include <folly/ScopeGuard.h>
 #include <folly/synchronization/EventCount.h>
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
@@ -30,12 +31,14 @@
 #include <chrono>
 #include <future>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <vector>
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
@@ -847,6 +850,16 @@ TEST_P(UcxExchangeTest, sharedClientSurvivesOneExchangeClose) {
     GTEST_SKIP() << "sharedClientSurvivesOneExchangeClose: runs only once";
   }
 
+  // This test isolates ownership of a client shared by two operators. Avoid
+  // coupling that contract to loopback UCX TCP behavior by using the
+  // same-process transfer registry for the data path.
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  const bool origIntraNode = config.intraNodeExchange;
+  config.intraNodeExchange = true;
+  SCOPE_EXIT {
+    config.intraNodeExchange = origIntraNode;
+  };
+
   const std::string taskPrefix = getUniqueTaskPrefix();
   const std::string srcTaskId = taskPrefix + "sharedClientSrc";
   const std::string sinkTaskId = taskPrefix + "sharedClientSink";
@@ -1197,6 +1210,16 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
     }
   }
 
+  // This test exercises accumulation and chunk-boundary semantics, not the
+  // UCX TCP transport. Use the same-process registry so loopback transport
+  // failures cannot mask row-count, integrity, or chunk-count regressions.
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  const bool origIntraNode = config.intraNodeExchange;
+  config.intraNodeExchange = true;
+  SCOPE_EXIT {
+    config.intraNodeExchange = origIntraNode;
+  };
+
   const int kTargetRows = UcxPartitionedOutput::kDefaultTargetRowsPerChunk;
 
   // --- Scenario 1: Small chunks that SHOULD be accumulated ---
@@ -1540,6 +1563,147 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
         sinkDriver->numChunksReceived(), static_cast<uint64_t>(numChunks));
     queueManager_->removeTask(srcTaskId);
   }
+}
+
+// Regression test for resumable hash output. With no consumer, each producer
+// must stop after its first configured residency window instead of enqueueing
+// every remaining window from a single addInput(). Starting the consumers then
+// verifies that saved cursors resume and EOS is delivered. Pressure-aware
+// sizing keeps this full window while device headroom is healthy.
+TEST_P(UcxExchangeTest, hashWindowBackpressureIsResumable) {
+  ExchangeTestParams p = GetParam();
+  if (p.numSrcDrivers != 1 || p.numDstDrivers != 1 || p.numPartitions != 1 ||
+      p.numChunks != 100 || p.numUpstreamTasks != 1 ||
+      p.tableType != TableType::NARROW) {
+    GTEST_SKIP() << "hashWindowBackpressureIsResumable: runs only once";
+  }
+
+  // The behavior under test is producer-side queue backpressure and cursor
+  // resumption. Use the deterministic same-process transport so loopback UCX
+  // TCP failures cannot mask that contract.
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  const bool origIntraNode = config.intraNodeExchange;
+  config.intraNodeExchange = true;
+  SCOPE_EXIT {
+    config.intraNodeExchange = origIntraNode;
+  };
+
+  const auto headroom = cudf_velox::captureDeviceAllocationHeadroom();
+  ASSERT_TRUE(headroom.cudaValid);
+  auto admission =
+      cudf_velox::tryAcquireDeviceMemoryAdmission(headroom.device, 96, 128);
+  ASSERT_TRUE(admission.has_value());
+  EXPECT_EQ(
+      cudf_velox::deviceMemoryAdmissionReservedBytes(headroom.device), 96);
+  EXPECT_FALSE(
+      cudf_velox::tryAcquireDeviceMemoryAdmission(headroom.device, 64, 128));
+  admission.reset();
+  EXPECT_EQ(cudf_velox::deviceMemoryAdmissionReservedBytes(headroom.device), 0);
+
+  constexpr int kRowsPerDriver = 300;
+  constexpr int kWindowRows = 200;
+  constexpr int kHashCallRows = 20;
+  constexpr int kNumPartitions = 2;
+  constexpr int kNumDrivers = 2;
+  // One source fits in the queue cap, but the first window from both drivers
+  // exceeds it. This exercises the ordinary resumable path; oversized
+  // multi-window sources intentionally drain before observing backpressure.
+  constexpr uint64_t kQueueCapacityRows = kRowsPerDriver;
+  const std::string taskPrefix = getUniqueTaskPrefix();
+  const std::string srcTaskId = taskPrefix + "sourceTask0";
+  auto rowType = WideTestTable::kRowType;
+  auto tableGenerator = std::make_shared<WideTestTable>();
+  tableGenerator->initialize(kRowsPerDriver);
+
+  uint64_t averageRowBytes;
+  {
+    auto sizingVector = makeCudfVector(
+        pool_.get(),
+        kRowsPerDriver,
+        rowType,
+        tableGenerator,
+        cudf::get_default_stream());
+    const auto flatBytes = sizingVector->estimateFlatSize();
+    averageRowBytes = flatBytes / kRowsPerDriver +
+        static_cast<uint64_t>(flatBytes % kRowsPerDriver != 0);
+  }
+  cudf::get_default_stream().synchronize();
+  ASSERT_GT(averageRowBytes, 0);
+  const auto maxOutputBufferBytes = averageRowBytes * kQueueCapacityRows;
+
+  std::unordered_map<std::string, std::string> extraConfig{
+      {core::QueryConfig::kUcxPartitionedOutputBatchRows,
+       std::to_string(kRowsPerDriver)},
+      {core::QueryConfig::kUcxHashPartitionInputBatchRows,
+       std::to_string(kHashCallRows)},
+      {core::QueryConfig::kUcxHashPartitionWindowRows,
+       std::to_string(kWindowRows)}};
+  auto srcTask = createPartitionedOutputTask(
+      srcTaskId,
+      pool_,
+      rowType,
+      kNumPartitions,
+      {"int32_col"},
+      maxOutputBufferBytes,
+      extraConfig);
+  queueManager_->initializeTask(
+      srcTask,
+      core::PartitionedOutputNode::Kind::kPartitioned,
+      kNumPartitions,
+      kNumDrivers);
+
+  auto sourceDriver = std::make_shared<SourceDriverMock>(
+      srcTask, kNumDrivers, 1, kRowsPerDriver, tableGenerator);
+  sourceDriver->run();
+
+  // Do not start a consumer yet. Once the first adaptive window reaches the
+  // byte cap, SourceDriverMock must be waiting on the shared queue future.
+  bool sawFirstWindow = false;
+  std::optional<exec::OutputBuffer::Stats> blockedStats;
+  for (int attempt = 0; attempt < 200; ++attempt) {
+    blockedStats = queueManager_->stats(srcTaskId);
+    if (blockedStats &&
+        blockedStats->totalRowsSent == kNumDrivers * kWindowRows) {
+      sawFirstWindow = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  EXPECT_TRUE(sawFirstWindow);
+  if (blockedStats) {
+    EXPECT_EQ(blockedStats->totalRowsSent, kNumDrivers * kWindowRows)
+        << "producers crossed the one-window-per-driver backpressure bound";
+  }
+
+  std::vector<std::shared_ptr<SinkDriverMock>> sinkDrivers;
+  for (int partition = 0; partition < kNumPartitions; ++partition) {
+    core::PlanNodeId exchangeNodeId;
+    auto sinkTask = createExchangeTask(
+        taskPrefix + "sinkTask" + std::to_string(partition),
+        rowType,
+        partition,
+        exchangeNodeId);
+    auto sinkDriver = std::make_shared<SinkDriverMock>(sinkTask, 1);
+    std::vector<exec::Split> splits;
+    splits.push_back(remoteSplit(srcTaskId, partition));
+    sinkDriver->addSplits(splits);
+    sinkDriver->run();
+    sinkDrivers.push_back(std::move(sinkDriver));
+  }
+
+  sourceDriver->joinThreads();
+  uint64_t receivedRows = 0;
+  for (auto& sinkDriver : sinkDrivers) {
+    sinkDriver->joinThreads();
+    receivedRows += sinkDriver->numRows();
+  }
+  EXPECT_EQ(receivedRows, kNumDrivers * kRowsPerDriver);
+
+  auto finalStats = queueManager_->stats(srcTaskId);
+  ASSERT_TRUE(finalStats.has_value());
+  EXPECT_TRUE(finalStats->noMoreData);
+  EXPECT_EQ(finalStats->totalRowsSent, kNumDrivers * kRowsPerDriver);
+  queueManager_->removeTask(srcTaskId);
 }
 
 // Regression test: aborting a source task while UCXX tagRecv requests are

--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -442,6 +442,93 @@ TEST_F(UcxOutputQueueManagerTest, v2OversizeRequestReturnsOneChunk) {
   queueManager_->removeTask(taskId);
 }
 
+TEST_F(UcxOutputQueueManagerTest, v2StaleSequenceDoesNotDequeue) {
+  const std::string taskId = "v2StaleSequence";
+  const int destination = 0;
+  const auto maxBytes = std::numeric_limits<uint64_t>::max();
+
+  initializeTask(taskId, 1 /* numDestinations */, 1 /* numDrivers */);
+
+  enqueue(taskId, destination, 10);
+  enqueue(taskId, destination, 20);
+  noMoreData(taskId);
+
+  auto first = fetchV2Data(taskId, destination, maxBytes, 0);
+  ASSERT_NE(first.data, nullptr);
+  EXPECT_EQ(first.sequence, 0);
+
+  // Simulate a duplicate server reconnecting from sequence zero. It should
+  // be told that sequence one is current, without consuming sequence one.
+  auto stale = fetchV2Data(taskId, destination, maxBytes, 0);
+  EXPECT_EQ(stale.data, nullptr);
+  EXPECT_EQ(stale.sequence, 1);
+
+  auto second = fetchV2Data(taskId, destination, maxBytes, 1);
+  ASSERT_NE(second.data, nullptr);
+  EXPECT_EQ(second.sequence, 1);
+
+  auto end = fetchV2Data(taskId, destination, maxBytes, 2);
+  EXPECT_EQ(end.data, nullptr);
+  EXPECT_EQ(end.sequence, 2);
+
+  queueManager_->deleteResults(taskId, destination);
+  EXPECT_TRUE(queueManager_->isFinished(taskId));
+  queueManager_->removeTask(taskId);
+}
+
+TEST_F(UcxOutputQueueManagerTest, v2DuplicateWaiterPreservesOriginal) {
+  const std::string taskId = "v2DuplicateWaiter";
+  const int destination = 0;
+  const auto maxBytes = std::numeric_limits<uint64_t>::max();
+
+  initializeTask(taskId, 1 /* numDestinations */, 1 /* numDrivers */);
+
+  bool originalFired = false;
+  std::shared_ptr<cudf::packed_columns> originalData;
+  queueManager_->getData(
+      taskId,
+      destination,
+      maxBytes,
+      0,
+      [&](std::shared_ptr<cudf::packed_columns> data,
+          int64_t sequence,
+          std::vector<int64_t>) {
+        EXPECT_EQ(sequence, 0);
+        originalData = std::move(data);
+        originalFired = true;
+      });
+  EXPECT_FALSE(originalFired);
+
+  bool duplicateFired = false;
+  queueManager_->getData(
+      taskId,
+      destination,
+      maxBytes,
+      0,
+      [&](std::shared_ptr<cudf::packed_columns> data,
+          int64_t sequence,
+          std::vector<int64_t>) {
+        EXPECT_EQ(data, nullptr);
+        EXPECT_EQ(sequence, 1);
+        duplicateFired = true;
+      });
+  EXPECT_TRUE(duplicateFired);
+  EXPECT_FALSE(originalFired);
+
+  enqueue(taskId, destination, 10);
+  EXPECT_TRUE(originalFired);
+  EXPECT_NE(originalData, nullptr);
+
+  noMoreData(taskId);
+  auto end = fetchV2Data(taskId, destination, maxBytes, 1);
+  EXPECT_EQ(end.data, nullptr);
+  EXPECT_EQ(end.sequence, 1);
+
+  queueManager_->deleteResults(taskId, destination);
+  EXPECT_TRUE(queueManager_->isFinished(taskId));
+  queueManager_->removeTask(taskId);
+}
+
 TEST_F(UcxOutputQueueManagerTest, v2RemovedTaskReturnsNullAtRequestedSequence) {
   const std::string taskId = "v2RemovedTask";
   const int destination = 0;

--- a/velox/experimental/ucx-exchange/tests/UcxTestHelpers.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxTestHelpers.cpp
@@ -105,7 +105,8 @@ std::shared_ptr<Task> createPartitionedOutputTask(
     int numPartitions,
     const std::vector<std::string>& partitionKeys,
     uint64_t kMaxOutputBufferSize,
-    const std::unordered_map<std::string, std::string>& extraConfig) {
+    const std::unordered_map<std::string, std::string>& extraConfig,
+    core::PartitionFunctionSpecPtr partitionFunctionSpec) {
   VLOG(3) << "Creating PartitionedOutput task with " << numPartitions
           << " partitions";
 
@@ -127,6 +128,15 @@ std::shared_ptr<Task> createPartitionedOutputTask(
                           .values({rowVector})
                           .partitionedOutput(partitionKeys, numPartitions)
                           .planFragment();
+  if (partitionFunctionSpec) {
+    auto output = std::dynamic_pointer_cast<const core::PartitionedOutputNode>(
+        planFragment.planNode);
+    VELOX_CHECK_NOT_NULL(output);
+    planFragment.planNode =
+        core::PartitionedOutputNode::Builder(*output)
+            .partitionFunctionSpec(std::move(partitionFunctionSpec))
+            .build();
+  }
 
   std::shared_ptr<folly::Executor> executor(
       std::make_shared<folly::CPUThreadPoolExecutor>(

--- a/velox/experimental/ucx-exchange/tests/UcxTestHelpers.h
+++ b/velox/experimental/ucx-exchange/tests/UcxTestHelpers.h
@@ -93,7 +93,8 @@ std::shared_ptr<facebook::velox::exec::Task> createPartitionedOutputTask(
     int numPartitions,
     const std::vector<std::string>& partitionKeys = {},
     uint64_t kMaxOutputBufferSize = FOUR_GBYTES,
-    const std::unordered_map<std::string, std::string>& extraConfig = {});
+    const std::unordered_map<std::string, std::string>& extraConfig = {},
+    core::PartitionFunctionSpecPtr partitionFunctionSpec = nullptr);
 
 /// @brief Helper function to create a CudfVector for testing.
 /// Uses makeTable when tableGenerator is null, or tableGenerator->makeTable()


### PR DESCRIPTION
## Summary

  This PR improves cuDF execution for MPP workloads by bounding GPU batch growth, reducing small-batch overhead, and improving UCX exchange memory
  management.

  It also includes the bounded cuDF OrderBy, Window, and FINAL aggregation changes required by the corresponding Gluten MPP integration.

  ## Changes

  ### Bounded cuDF execution

  - Add bounded-memory execution for cuDF OrderBy and Window operators.
  - Add streaming and levelled execution for FINAL aggregation.
  - Compact compatible aggregation batches incrementally.
  - Keep the legacy aggregation path when:
    - grouping keys are empty
    - companion aggregation steps do not match the plan step
  - Preserve accumulated state for all-null grouping-key batches.

  ### Byte-aware batch concatenation

  - Add `cudf.batch_size_min_threshold_bytes`.
  - Flush `CudfBatchConcat` when either the row or byte threshold is reached.
  - Avoid a redundant device-to-device concatenation when a single input batch already satisfies the threshold.
  - Add optional batch-count and byte-count diagnostics.
  - Add coverage for byte-triggered concatenation.

  This separates the GPU compute batch target from Spark file partitions and exchange partitions.

  ### UCX exchange

  - Add `cudf.partitioned_output_batch_bytes`.
  - Bound HASH and SINGLE/gather exchange chunks by both rows and estimated bytes.
  - Accumulate small exchange inputs until a configured row or byte threshold is reached.
  - Use the current shared RMM async memory resource for UCX receive buffers.
  - Synchronize the allocation stream before exposing a receive pointer to UCX.
  - Preserve receive-buffer accounting through the statistics memory-resource adaptor.

  Using the shared async pool allows UCX receives to reuse cached GPU memory instead of issuing independent synchronous CUDA allocations while scan and
  aggregation memory remains cached.

  ### Build and tests

  - Make cuDF task compilation and NVTX dependencies explicit.
  - Support the current RMM async resource-reference API in UCX tests.
  - Add coverage for:
    - byte-bounded batch concatenation
    - levelled FINAL aggregation
    - companion FINAL aggregation
    - byte-bounded UCX exchange
    - chunked table-scan split boundaries

  ## Motivation

  Nsight Systems profiling of Job 41 showed:

  - many small batches reaching aggregation
  - long GPU bubbles before FINAL aggregation
  - low effective SM utilization despite continuous GPU activity
  - UCX receive allocations competing with memory cached by the cuDF async pool

  The row-only batch threshold did not adequately control wide batches, while a separate synchronous receive allocator could report OOM even when reusable
  memory remained in the async pool.

  ## Validation

  Tested through the Gluten MPP integration on four GPUs.

  Job 41:

  - Gluten MPP: **45.403 seconds**
  - Spark RAPIDS: **79.844 seconds**
  - Speedup over Spark RAPIDS: approximately **1.76x**

  A repeated Gluten MPP run completed in **45.855 seconds**.

  Output validation against Spark RAPIDS:

  - 35,152,000 rows
  - matching row hashes
  - matching numeric aggregates

  ## Companion PR

  Requires the corresponding Gluten PR for:

  - Spark configuration forwarding
  - enabling byte-aware batch concatenation
  - MPP local RDD stream support
  - GPU backend link integration