### PR TITLE
feat(cudf): Add bounded cuDF OrderBy, Window, and FINAL aggregation

### DIFF
--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -49,6 +49,8 @@ struct CudfConfig {
       "cudf.batch_size_max_threshold"};
   static constexpr const char* kCudfConcatOptimizationEnabled{
       "cudf.concat_optimization_enabled"};
+  static constexpr const char* kCudfGroupbyStreamingMaxDistinctKeys{
+      "cudf.groupby_streaming_max_distinct_keys"};
   static constexpr const char* kCudfTimestampUnit{"cudf.timestamp_unit"};
   // The value could be either spark or presto.
   static constexpr const char* kCudfFunctionEngine{"cudf.function_engine"};
@@ -129,6 +131,11 @@ struct CudfConfig {
   /// This batch size is determined by batchSizeMinThreshold and
   /// batchSizeMaxThreshold
   bool concatOptimizationEnabled{false};
+
+  /// Maximum distinct keys retained by FINAL streaming groupby. Zero keeps
+  /// the all-GPU levelled aggregation path and does not construct streaming
+  /// state.
+  int32_t groupbyStreamingMaxDistinctKeys{0};
 
   /// Minimum rows to accumulate before GPU-side concatenation in
   /// `CudfBatchConcat` (default 100k).

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -51,6 +51,10 @@ struct CudfConfig {
       "cudf.concat_optimization_enabled"};
   static constexpr const char* kCudfGroupbyStreamingMaxDistinctKeys{
       "cudf.groupby_streaming_max_distinct_keys"};
+  static constexpr const char* kCudfOrderBySortedRunBytes{
+      "cudf.order_by_sorted_run_bytes"};
+  static constexpr const char* kCudfOrderByMergeFanIn{
+      "cudf.order_by_merge_fan_in"};
   static constexpr const char* kCudfTimestampUnit{"cudf.timestamp_unit"};
   // The value could be either spark or presto.
   static constexpr const char* kCudfFunctionEngine{"cudf.function_engine"};
@@ -136,6 +140,13 @@ struct CudfConfig {
   /// the all-GPU levelled aggregation path and does not construct streaming
   /// state.
   int32_t groupbyStreamingMaxDistinctKeys{0};
+
+  /// Approximate bytes buffered before OrderBy spills an independently sorted
+  /// run.
+  uint64_t orderBySortedRunBytes{256ULL << 20};
+
+  /// Number of sorted runs compacted by one OrderBy merge group.
+  int32_t orderByMergeFanIn{8};
 
   /// Minimum rows to accumulate before GPU-side concatenation in
   /// `CudfBatchConcat` (default 100k).

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -1621,6 +1621,20 @@ void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
   }
 }
 
+void CudfGroupby::prepareInputForStateStream(const CudfVectorPtr& input) {
+  const auto inputStream = input->stream();
+  if (inputStream.value() != stateStream_.value()) {
+    cudf::detail::join_streams(
+        std::vector<rmm::cuda_stream_view>{inputStream}, stateStream_);
+  }
+  // Rebind before taking a view: rebindStream may rebuild an owned table, and
+  // a packed buffer can retain a different deallocation stream even when the
+  // vector's logical stream already equals stateStream_.
+  VELOX_CHECK(
+      input->rebindStream(stateStream_),
+      "CudfGroupby cannot rebind its input to the state stream");
+}
+
 void CudfGroupby::doAddInput(RowVectorPtr input) {
   if (input->size() == 0) {
     return;
@@ -1631,15 +1645,8 @@ void CudfGroupby::doAddInput(RowVectorPtr input) {
   VELOX_CHECK_NOT_NULL(cudfInput);
   input.reset();
 
-  const auto inputStream = cudfInput->stream();
-  if (inputStream.value() != stateStream_.value()) {
-    cudf::detail::join_streams(
-        std::vector<rmm::cuda_stream_view>{inputStream}, stateStream_);
-    // Rebind before taking a view: rebindStream may rebuild the owned table.
-    // Destruction is then queued after all state-stream work using this input.
-    VELOX_CHECK(
-        cudfInput->rebindStream(stateStream_),
-        "CudfGroupby cannot rebind its input to the state stream");
+  if (!isPartialOutput_ && !isSingleStep_) {
+    prepareInputForStateStream(cudfInput);
   }
 
   if (streamingEnabled_) {

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -40,6 +40,8 @@
 #include <cudf/reduction.hpp>
 #include <cudf/unary.hpp>
 
+#include <limits>
+
 namespace {
 
 using namespace facebook::velox;
@@ -52,6 +54,42 @@ using cudf_velox::GroupbyAggregator;
 using cudf_velox::ResolvedAggregateInfo;
 using cudf_velox::serializeDecimalPartialOrIntermediateState;
 using cudf_velox::validateIntermediateColumnType;
+
+constexpr const char* kFinalAggregationInputRuns =
+    "cudfFinalAggregationInputRuns";
+constexpr const char* kFinalAggregationRunMerges =
+    "cudfFinalAggregationRunMerges";
+constexpr const char* kFinalAggregationFinalizeMerges =
+    "cudfFinalAggregationFinalizeMerges";
+constexpr const char* kFinalAggregationMergeRows =
+    "cudfFinalAggregationMergeRows";
+constexpr const char* kFinalAggregationMergeBytes =
+    "cudfFinalAggregationMergeBytes";
+constexpr const char* kFinalAggregationMaxLevel =
+    "cudfFinalAggregationMaxLevel";
+constexpr const char* kFinalStreamingBatches = "cudfFinalStreamingBatches";
+constexpr const char* kFinalStreamingInputRows =
+    "cudfFinalStreamingInputRows";
+constexpr const char* kFinalStreamingDistinctKeys =
+    "cudfFinalStreamingDistinctKeys";
+constexpr const char* kFinalStreamingOutputRows =
+    "cudfFinalStreamingOutputRows";
+constexpr const char* kFinalStreamingFallbackProbeColumnsReleased =
+    "cudfFinalStreamingFallbackProbeColumnsReleased";
+
+size_t aggregationRunLevel(uint64_t representedRows) {
+  VELOX_CHECK_GT(representedRows, 0);
+  size_t level = 0;
+  while (representedRows >>= 1) {
+    ++level;
+  }
+  return level;
+}
+
+uint64_t addRepresentedRows(uint64_t left, uint64_t right) {
+  VELOX_CHECK_LE(left, std::numeric_limits<uint64_t>::max() - right);
+  return left + right;
+}
 
 #define DEFINE_SIMPLE_GROUPBY_AGGREGATOR(Name, name, KIND)                \
   struct Groupby##Name##Aggregator : GroupbyAggregator {                  \
@@ -78,6 +116,12 @@ using cudf_velox::validateIntermediateColumnType;
       }                                                                   \
       request.aggregations.push_back(                                     \
           cudf::make_##name##_aggregation<cudf::groupby_aggregation>());  \
+    }                                                                     \
+                                                                          \
+    size_t releaseRequestState() override {                               \
+      const size_t released = constant_input == nullptr ? 0 : 1;          \
+      constant_input.reset();                                             \
+      return released;                                                    \
     }                                                                     \
                                                                           \
     std::unique_ptr<cudf::column> makeOutputColumn(                       \
@@ -246,6 +290,16 @@ struct GroupbyDecimalSumAggregator : GroupbyAggregator {
     }
   }
 
+  size_t releaseRequestState() override {
+    const size_t released = static_cast<size_t>(decodedSum_ != nullptr) +
+        static_cast<size_t>(decodedCount_ != nullptr) +
+        static_cast<size_t>(castedInput_ != nullptr);
+    decodedSum_.reset();
+    decodedCount_.reset();
+    castedInput_.reset();
+    return released;
+  }
+
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
       rmm::cuda_stream_view stream,
@@ -313,6 +367,16 @@ struct GroupbyDecimalAvgAggregator : GroupbyAggregator {
           sumIdx_,
           castedInput_);
     }
+  }
+
+  size_t releaseRequestState() override {
+    const size_t released = static_cast<size_t>(decodedSum_ != nullptr) +
+        static_cast<size_t>(decodedCount_ != nullptr) +
+        static_cast<size_t>(castedInput_ != nullptr);
+    decodedSum_.reset();
+    decodedCount_.reset();
+    castedInput_.reset();
+    return released;
   }
 
   std::unique_ptr<cudf::column> makeOutputColumn(
@@ -939,6 +1003,7 @@ CudfGroupby::CudfGroupby(
           aggregationNode),
       aggregationNode_(aggregationNode),
       diagnosticNodeId_(aggregationNode->id()),
+      stateStream_(cudfGlobalStreamPool().get_stream()),
       isPartialOutput_(
           exec::isPartialOutput(aggregationNode->step()) &&
           !hasFinalAggs(aggregationNode->aggregates())),
@@ -1090,89 +1155,428 @@ void CudfGroupby::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
 }
 
 void CudfGroupby::computeFinalGroupbyStreaming(CudfVectorPtr tbl) {
-  auto inputTableStream = tbl->stream();
+  VELOX_CHECK(tbl->stream().value() == stateStream_.value());
+  const auto representedRows = static_cast<uint64_t>(tbl->size());
   auto preparedInput = prepareAggregationInput(
       tbl->getTableView(),
       static_cast<cudf::size_type>(tbl->size()),
       precomputedInputEvaluators_,
-      inputTableStream,
+      stateStream_,
       get_temp_mr());
   auto permutedInputView = preparedInput.tableView.select(
       aggregationInputChannels_.begin(), aggregationInputChannels_.end());
 
-  if (!bufferedResult_) {
-    auto groupbyOnInput = doGroupByAggregation(
+  const auto addLevelledRun = [&]() {
+    // Reduce this page independently. Combining it with the entire prior state
+    // here made high-cardinality FINAL aggregation quadratic in the number of
+    // exchange pages. Binary levels only combine similarly sized runs.
+    auto run = doGroupByAggregation(
         permutedInputView,
         groupingKeyOutputChannels_,
         intermediateAggregators_,
         bufferedResultType_,
-        inputTableStream,
+        stateStream_,
         get_output_mr());
-    if (!groupbyOnInput) {
-      return;
+    if (run) {
+      addFinalAggregationRun(
+          FinalAggregationRun{std::move(run), representedRows});
     }
-    bufferedResult_ = groupbyOnInput;
+  };
+
+  if (finalAggregationMode_ == FinalAggregationMode::kUndecided) {
+    const auto configuredMaxDistinctKeys =
+        CudfConfig::getInstance().groupbyStreamingMaxDistinctKeys;
+    VELOX_CHECK_GE(configuredMaxDistinctKeys, 0);
+    finalStreamingMaxDistinctKeys_ =
+        static_cast<cudf::size_type>(configuredMaxDistinctKeys);
+    if (finalStreamingMaxDistinctKeys_ == 0) {
+      finalAggregationMode_ = FinalAggregationMode::kLevelled;
+      LOG(INFO) << "CUDF_GROUPBY_STREAMING node=" << diagnosticNodeId_
+                << " state=disabled maxDistinctKeys=0 mode=levelled_gpu";
+    }
+  }
+
+  if (finalAggregationMode_ == FinalAggregationMode::kLevelled) {
+    addLevelledRun();
     return;
   }
 
-  auto previousResult = std::exchange(bufferedResult_, nullptr);
-  std::vector<cudf::table_view> tablesToConcat;
-  tablesToConcat.push_back(previousResult->getTableView());
-  tablesToConcat.push_back(permutedInputView);
-
-  auto finalStream = previousResult->stream();
-  std::vector<CudfVectorPtr> inputOwners;
-  inputOwners.push_back(std::move(previousResult));
-  inputOwners.push_back(std::move(tbl));
-  std::vector<rmm::cuda_stream_view> inputStreams{
-      finalStream, inputTableStream};
-  cudf::detail::join_streams(inputStreams, finalStream);
-
-  std::unique_ptr<cudf::table> concatenatedTable;
-  try {
-    concatenatedTable =
-        cudf::concatenate(tablesToConcat, finalStream, get_temp_mr());
-
-    // The concatenation has consumed both views. Rebind their allocations to
-    // finalStream (or order their original streams after it for packed inputs)
-    // and drop the owners now. This queues stream-ordered frees before the
-    // intermediate groupby allocates its output and workspace. Keeping these
-    // shared_ptrs until the function returns overlaps the previous buffered
-    // result and incoming batch with both the concatenated table and the next
-    // groupby output, which creates a large transient peak for high-cardinality
-    // FINAL aggregations.
-    orderCudfVectorDeallocationsAfterStream(
-        inputOwners, inputStreams, finalStream);
-    inputOwners.clear();
-
-    // Materialized precomputed columns are owned separately by preparedInput
-    // and still deallocate on inputTableStream. Keep that stream ordered after
-    // the concatenate only when such an owner exists; views need no reverse
-    // fence and preserving their input-stream concurrency avoids a regression.
-    const auto hasOwnedPrecomputed = std::any_of(
-        preparedInput.precomputedColumns.begin(),
-        preparedInput.precomputedColumns.end(),
-        [](const auto& column) {
-          return std::holds_alternative<std::unique_ptr<cudf::column>>(column);
-        });
-    if (hasOwnedPrecomputed) {
-      cudf::detail::join_streams(
-          std::vector<rmm::cuda_stream_view>{finalStream}, inputTableStream);
-    }
-  } catch (...) {
-    // concatenate can enqueue work before a later column allocation fails.
-    // Complete it before input owners unwind on their original streams.
-    finalStream.synchronize();
-    throw;
+  // Build the real FINAL requests against this page. Their value views may be
+  // top-level columns, struct children, or temporary decoded columns owned by
+  // the aggregators. Pack those views next to the key views so
+  // streaming_groupby can address every value by a stable column index for
+  // this call.
+  std::vector<cudf::groupby::aggregation_request> regularRequests;
+  for (auto& aggregator : aggregators_) {
+    aggregator->addGroupbyRequest(
+        permutedInputView, regularRequests, stateStream_);
   }
-  auto compactedOutput = doGroupByAggregation(
-      concatenatedTable->view(),
+
+  std::vector<cudf::column_view> packedColumns;
+  packedColumns.reserve(
+      groupingKeyOutputChannels_.size() + regularRequests.size());
+  std::vector<cudf::size_type> keyIndices;
+  keyIndices.reserve(groupingKeyOutputChannels_.size());
+  for (const auto key : groupingKeyOutputChannels_) {
+    VELOX_CHECK_LT(
+        packedColumns.size(),
+        static_cast<size_t>(std::numeric_limits<cudf::size_type>::max()));
+    keyIndices.push_back(static_cast<cudf::size_type>(packedColumns.size()));
+    packedColumns.push_back(permutedInputView.column(key));
+  }
+
+  bool allRequestsSupported = !regularRequests.empty();
+  std::vector<size_t> requestAggregationCounts;
+  requestAggregationCounts.reserve(regularRequests.size());
+  std::vector<cudf::groupby::streaming_aggregation_request>
+      streamingRequests;
+  for (auto& request : regularRequests) {
+    VELOX_CHECK_LT(
+        packedColumns.size(),
+        static_cast<size_t>(std::numeric_limits<cudf::size_type>::max()));
+    const auto valueIndex =
+        static_cast<cudf::size_type>(packedColumns.size());
+    packedColumns.push_back(request.values);
+    requestAggregationCounts.push_back(request.aggregations.size());
+    for (auto& aggregation : request.aggregations) {
+      VELOX_CHECK_NOT_NULL(aggregation);
+      allRequestsSupported &= cudf::groupby::is_streaming_groupby_supported(
+          request.values.type(), aggregation->kind);
+      streamingRequests.push_back(
+          cudf::groupby::streaming_aggregation_request{
+              valueIndex, std::move(aggregation)});
+    }
+  }
+
+  if (finalAggregationMode_ == FinalAggregationMode::kUndecided) {
+    if (!allRequestsSupported) {
+      finalAggregationMode_ = FinalAggregationMode::kLevelled;
+      // The support probe above may have decoded page-sized intermediate
+      // columns (for example decimal SUM/AVG) into aggregator-owned request
+      // state. None of these views or aggregations are used by the levelled
+      // path. Drop all view holders first, then release the owning columns
+      // before the first levelled run is materialized.
+      streamingRequests.clear();
+      regularRequests.clear();
+      packedColumns.clear();
+      size_t releasedColumns = 0;
+      for (auto& aggregator : aggregators_) {
+        releasedColumns += aggregator->releaseRequestState();
+      }
+      if (releasedColumns > 0) {
+        auto lockedStats = stats_.wlock();
+        lockedStats->addRuntimeStat(
+            kFinalStreamingFallbackProbeColumnsReleased,
+            RuntimeCounter(static_cast<int64_t>(releasedColumns)));
+      }
+      addLevelledRun();
+      return;
+    }
+    finalStreamingRequestAggregationCounts_ = requestAggregationCounts;
+    finalStreamingGroupby_ =
+        std::make_unique<cudf::groupby::streaming_groupby>(
+            keyIndices,
+            streamingRequests,
+            finalStreamingMaxDistinctKeys_,
+            ignoreNullKeys_ ? cudf::null_policy::EXCLUDE
+                            : cudf::null_policy::INCLUDE);
+    finalAggregationMode_ = FinalAggregationMode::kStreaming;
+    LOG(INFO) << "CUDF_GROUPBY_STREAMING node=" << diagnosticNodeId_
+              << " state=selected maxDistinctKeys="
+              << finalStreamingMaxDistinctKeys_ << " keys="
+              << keyIndices.size() << " requests=" << streamingRequests.size();
+  } else {
+    VELOX_CHECK(
+        finalAggregationMode_ == FinalAggregationMode::kStreaming);
+    VELOX_CHECK(
+        allRequestsSupported,
+        "CudfGroupby FINAL request support changed after streaming state "
+        "was initialized; refusing an unsafe mid-stream fallback");
+    VELOX_CHECK(
+        requestAggregationCounts == finalStreamingRequestAggregationCounts_,
+        "CudfGroupby FINAL request shape changed after streaming state "
+        "was initialized");
+  }
+
+  VELOX_CHECK_NOT_NULL(finalStreamingGroupby_);
+  const auto batchSize = permutedInputView.num_rows();
+  VELOX_USER_CHECK_LE(
+      batchSize,
+      finalStreamingMaxDistinctKeys_,
+      "CudfGroupby streaming batch size ({}) exceeds configured capacity "
+      "{} ({})",
+      batchSize,
+      CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys,
+      finalStreamingMaxDistinctKeys_);
+  VELOX_USER_CHECK_LE(
+      static_cast<int64_t>(finalStreamingMaxDistinctKeys_) +
+          static_cast<int64_t>(batchSize),
+      static_cast<int64_t>(std::numeric_limits<cudf::size_type>::max()),
+      "CudfGroupby streaming capacity ({}) plus batch size ({}) exceeds "
+      "cuDF size_type max ({})",
+      finalStreamingMaxDistinctKeys_,
+      batchSize,
+      std::numeric_limits<cudf::size_type>::max());
+  finalStreamingGroupby_->aggregate(
+      cudf::table_view{packedColumns}, stateStream_);
+  ++finalStreamingBatchCount_;
+  const auto distinctKeys = finalStreamingGroupby_->distinct_keys();
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(kFinalStreamingBatches, RuntimeCounter(1));
+    lockedStats->addRuntimeStat(
+        kFinalStreamingInputRows,
+        RuntimeCounter(static_cast<int64_t>(representedRows)));
+  }
+  if (deviceMemoryDiagnosticsEnabled() &&
+      (finalStreamingBatchCount_ == 1 ||
+       finalStreamingBatchCount_ % 64 == 0)) {
+    logDeviceMemorySnapshot(fmt::format(
+        "operator=CudfGroupby node={} state=final_streaming.aggregate "
+        "batch={} inputRows={} distinctKeys={} maxDistinctKeys={}",
+        diagnosticNodeId_,
+        finalStreamingBatchCount_,
+        representedRows,
+        distinctKeys,
+        finalStreamingMaxDistinctKeys_));
+  }
+}
+
+void CudfGroupby::addFinalAggregationRun(FinalAggregationRun run) {
+  VELOX_CHECK_NOT_NULL(run.data);
+  VELOX_CHECK_GT(run.representedRows, 0);
+  ++finalInputRunCount_;
+
+  auto level = aggregationRunLevel(run.representedRows);
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(
+        kFinalAggregationInputRuns, RuntimeCounter(1));
+    lockedStats->addRuntimeStat(
+        kFinalAggregationMaxLevel,
+        RuntimeCounter(static_cast<int64_t>(level)));
+  }
+
+  for (;;) {
+    if (finalRunLevels_.size() <= level) {
+      finalRunLevels_.resize(level + 1);
+    }
+    if (!finalRunLevels_[level].has_value()) {
+      finalRunLevels_[level] = std::move(run);
+      return;
+    }
+
+    auto peer = std::move(*finalRunLevels_[level]);
+    finalRunLevels_[level].reset();
+    const auto representedRows =
+        addRepresentedRows(peer.representedRows, run.representedRows);
+    auto outputLevel = aggregationRunLevel(representedRows);
+    // Both inputs occupied the same logarithmic interval, so their combined
+    // weight must advance. Keep this explicit to prevent a malformed weight
+    // from repeatedly colliding at the same level.
+    outputLevel = std::max(outputLevel, level + 1);
+    run = mergeFinalAggregationRuns(
+        std::move(peer), std::move(run), outputLevel, false);
+    level = outputLevel;
+  }
+}
+
+CudfGroupby::FinalAggregationRun CudfGroupby::mergeFinalAggregationRuns(
+    FinalAggregationRun left,
+    FinalAggregationRun right,
+    size_t outputLevel,
+    bool finalizing) {
+  VELOX_CHECK_NOT_NULL(left.data);
+  VELOX_CHECK_NOT_NULL(right.data);
+  VELOX_CHECK(left.data->stream().value() == stateStream_.value());
+  VELOX_CHECK(right.data->stream().value() == stateStream_.value());
+
+  const auto inputRows = static_cast<int64_t>(left.data->size()) +
+      static_cast<int64_t>(right.data->size());
+  const auto inputBytes = left.data->estimateFlatSize() +
+      right.data->estimateFlatSize();
+  VELOX_CHECK_LE(
+      inputBytes,
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+  const auto representedRows =
+      addRepresentedRows(left.representedRows, right.representedRows);
+
+  std::vector<CudfVectorPtr> inputs;
+  inputs.reserve(2);
+  inputs.push_back(std::move(left.data));
+  inputs.push_back(std::move(right.data));
+  auto concatenated = getConcatenatedTable(
+      std::move(inputs), bufferedResultType_, stateStream_, get_temp_mr());
+  auto output = doGroupByAggregation(
+      concatenated->view(),
       groupingKeyOutputChannels_,
       intermediateAggregators_,
       bufferedResultType_,
-      finalStream,
+      stateStream_,
       get_output_mr());
-  bufferedResult_ = compactedOutput;
+  VELOX_CHECK_NOT_NULL(output);
+
+  ++finalRunMergeCount_;
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(
+        kFinalAggregationRunMerges, RuntimeCounter(1));
+    if (finalizing) {
+      lockedStats->addRuntimeStat(
+          kFinalAggregationFinalizeMerges, RuntimeCounter(1));
+    }
+    lockedStats->addRuntimeStat(
+        kFinalAggregationMergeRows, RuntimeCounter(inputRows));
+    lockedStats->addRuntimeStat(
+        kFinalAggregationMergeBytes,
+        RuntimeCounter(static_cast<int64_t>(inputBytes)));
+    lockedStats->addRuntimeStat(
+        kFinalAggregationMaxLevel,
+        RuntimeCounter(static_cast<int64_t>(outputLevel)));
+  }
+
+  if (deviceMemoryDiagnosticsEnabled() &&
+      (finalizing || finalRunMergeCount_ == 1 ||
+       finalRunMergeCount_ % 64 == 0)) {
+    logDeviceMemorySnapshot(fmt::format(
+        "operator=CudfGroupby node={} state=final_run.merge phase={} "
+        "level={} merge={} inputRows={} inputBytes={} outputRows={} "
+        "outputBytes={} representedRows={}",
+        diagnosticNodeId_,
+        finalizing ? "finalize" : "online",
+        outputLevel,
+        finalRunMergeCount_,
+        inputRows,
+        inputBytes,
+        output->size(),
+        output->estimateFlatSize(),
+        representedRows));
+  }
+
+  return FinalAggregationRun{std::move(output), representedRows};
+}
+
+CudfVectorPtr CudfGroupby::drainFinalAggregationRuns() {
+  size_t retainedRuns = 0;
+  uint64_t retainedRows = 0;
+  uint64_t retainedBytes = 0;
+  for (const auto& level : finalRunLevels_) {
+    if (level.has_value()) {
+      ++retainedRuns;
+      retainedRows += static_cast<uint64_t>(level->data->size());
+      retainedBytes += level->data->estimateFlatSize();
+    }
+  }
+  if (deviceMemoryDiagnosticsEnabled()) {
+    logDeviceMemorySnapshot(fmt::format(
+        "operator=CudfGroupby node={} state=final_runs.drain.begin "
+        "inputRuns={} retainedRuns={} retainedRows={} retainedBytes={} "
+        "onlineMerges={}",
+        diagnosticNodeId_,
+        finalInputRunCount_,
+        retainedRuns,
+        retainedRows,
+        retainedBytes,
+        finalRunMergeCount_));
+  }
+
+  std::optional<FinalAggregationRun> carry;
+  for (auto& level : finalRunLevels_) {
+    if (!level.has_value()) {
+      continue;
+    }
+    auto run = std::move(*level);
+    level.reset();
+    if (!carry.has_value()) {
+      carry = std::move(run);
+      continue;
+    }
+    const auto representedRows =
+        addRepresentedRows(carry->representedRows, run.representedRows);
+    const auto outputLevel = aggregationRunLevel(representedRows);
+    carry = mergeFinalAggregationRuns(
+        std::move(*carry), std::move(run), outputLevel, true);
+  }
+  finalRunLevels_.clear();
+
+  if (!carry.has_value()) {
+    return nullptr;
+  }
+  return std::move(carry->data);
+}
+
+CudfVectorPtr CudfGroupby::finalizeStreamingFinalAggregation() {
+  VELOX_CHECK(finalAggregationMode_ == FinalAggregationMode::kStreaming);
+  VELOX_CHECK_NOT_NULL(finalStreamingGroupby_);
+
+  const auto distinctKeys = finalStreamingGroupby_->distinct_keys();
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfGroupby node={} state=final_streaming.finalize.begin "
+      "batches={} distinctKeys={} maxDistinctKeys={}",
+      diagnosticNodeId_,
+      finalStreamingBatchCount_,
+      distinctKeys,
+      finalStreamingMaxDistinctKeys_));
+
+  auto [groupKeys, flatResults] =
+      finalStreamingGroupby_->finalize(stateStream_, get_output_mr());
+  VELOX_CHECK_NOT_NULL(groupKeys);
+  VELOX_CHECK_EQ(groupKeys->num_rows(), distinctKeys);
+
+  // streaming_groupby returns one aggregation_result per flattened request.
+  // Restore the regular request layout expected by each GroupbyAggregator so
+  // its existing output conversion (including casts and compound results) is
+  // reused unchanged.
+  std::vector<cudf::groupby::aggregation_result> regularResults;
+  regularResults.reserve(finalStreamingRequestAggregationCounts_.size());
+  size_t flatResultIndex = 0;
+  for (const auto aggregationCount :
+       finalStreamingRequestAggregationCounts_) {
+    auto& regularResult = regularResults.emplace_back();
+    regularResult.results.reserve(aggregationCount);
+    for (size_t i = 0; i < aggregationCount; ++i) {
+      VELOX_CHECK_LT(flatResultIndex, flatResults.size());
+      auto& flatResult = flatResults[flatResultIndex++];
+      VELOX_CHECK_EQ(flatResult.results.size(), 1);
+      regularResult.results.push_back(std::move(flatResult.results.front()));
+    }
+  }
+  VELOX_CHECK_EQ(flatResultIndex, flatResults.size());
+
+  auto resultColumns = groupKeys->release();
+  for (auto& aggregator : aggregators_) {
+    resultColumns.push_back(aggregator->makeOutputColumn(
+        regularResults, stateStream_, get_output_mr()));
+  }
+  auto resultTable = std::make_unique<cudf::table>(std::move(resultColumns));
+  const auto outputRows = resultTable->num_rows();
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(
+        kFinalStreamingDistinctKeys,
+        RuntimeCounter(static_cast<int64_t>(distinctKeys)));
+    lockedStats->addRuntimeStat(
+        kFinalStreamingOutputRows, RuntimeCounter(outputRows));
+  }
+
+  // finalize and makeOutputColumn may enqueue work that reads persistent state.
+  // Complete it before destroying that state. Both state and output use the
+  // configured async resources; no pool resource or release threshold is used.
+  stateStream_.synchronize();
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfGroupby node={} state=final_streaming.finalize.end "
+      "batches={} distinctKeys={} outputRows={}",
+      diagnosticNodeId_,
+      finalStreamingBatchCount_,
+      distinctKeys,
+      outputRows));
+  finalStreamingGroupby_.reset();
+
+  if (outputRows == 0) {
+    return nullptr;
+  }
+  return std::make_shared<cudf_velox::CudfVector>(
+      pool(), outputType_, outputRows, std::move(resultTable), stateStream_);
 }
 
 void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
@@ -1226,6 +1630,17 @@ void CudfGroupby::doAddInput(RowVectorPtr input) {
   auto cudfInput = std::dynamic_pointer_cast<cudf_velox::CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput);
   input.reset();
+
+  const auto inputStream = cudfInput->stream();
+  if (inputStream.value() != stateStream_.value()) {
+    cudf::detail::join_streams(
+        std::vector<rmm::cuda_stream_view>{inputStream}, stateStream_);
+    // Rebind before taking a view: rebindStream may rebuild the owned table.
+    // Destruction is then queued after all state-stream work using this input.
+    VELOX_CHECK(
+        cudfInput->rebindStream(stateStream_),
+        "CudfGroupby cannot rebind its input to the state stream");
+  }
 
   if (streamingEnabled_) {
     if (isPartialOutput_) {
@@ -1352,6 +1767,15 @@ RowVectorPtr CudfGroupby::doGetOutput() {
   // At this point isPartialOutput_ is false (handled above) and noMoreInput_
   // is true (guarded by the check above).
   if (streamingEnabled_) {
+    if (!isPartialOutput_ && !isSingleStep_ &&
+        finalAggregationMode_ == FinalAggregationMode::kStreaming) {
+      finished_ = true;
+      return finalizeStreamingFinalAggregation();
+    }
+    if (!isPartialOutput_ && !isSingleStep_) {
+      VELOX_CHECK_NULL(bufferedResult_);
+      bufferedResult_ = drainFinalAggregationRuns();
+    }
     finished_ = true;
     if (!bufferedResult_) {
       return nullptr;
@@ -1425,6 +1849,24 @@ void CudfGroupby::doNoMoreInput() {
   if (isPartialOutput_ && inputs_.empty()) {
     finished_ = true;
   }
+}
+
+void CudfGroupby::doClose() {
+  // close() may run while a failed task unwinds. First attempt to drain all
+  // kernels that can still reference persistent streaming state, while
+  // preserving the original task failure if the CUDA context is poisoned.
+  try {
+    stateStream_.synchronize();
+  } catch (const std::exception& error) {
+    LOG(WARNING) << "CudfGroupby state stream cleanup failed: "
+                 << error.what();
+  }
+  finalStreamingGroupby_.reset();
+  finalStreamingRequestAggregationCounts_.clear();
+  finalRunLevels_.clear();
+  bufferedResult_.reset();
+  inputs_.clear();
+  Operator::close();
 }
 
 bool CudfGroupby::isFinished() {

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -24,6 +24,10 @@
 
 namespace facebook::velox::cudf_velox {
 
+namespace test {
+class CudfGroupbyTestHelper;
+}
+
 struct GroupbyAggregator {
   core::AggregationNode::Step step;
   uint32_t inputIndex;
@@ -131,6 +135,8 @@ class CudfGroupby : public CudfOperatorBase {
 
   CudfVectorPtr releaseAndResetBufferedResult();
 
+  void prepareInputForStateStream(const CudfVectorPtr& input);
+
   void computePartialGroupbyStreaming(CudfVectorPtr tbl);
   void computeFinalGroupbyStreaming(CudfVectorPtr tbl);
   void computeSingleGroupbyStreaming(CudfVectorPtr tbl);
@@ -195,6 +201,8 @@ class CudfGroupby : public CudfOperatorBase {
   std::vector<std::optional<FinalAggregationRun>> finalRunLevels_;
   uint64_t finalInputRunCount_{0};
   uint64_t finalRunMergeCount_{0};
+
+  friend class test::CudfGroupbyTestHelper;
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -20,6 +20,8 @@
 
 #include <cudf/groupby.hpp>
 
+#include <optional>
+
 namespace facebook::velox::cudf_velox {
 
 struct GroupbyAggregator {
@@ -32,6 +34,14 @@ struct GroupbyAggregator {
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests,
       rmm::cuda_stream_view stream) = 0;
+
+  // Releases columns materialized solely to back views in the most recently
+  // built request. This is normally handled when the next request replaces
+  // the state, but an unsupported streaming probe must release it before
+  // switching to levelled aggregation.
+  virtual size_t releaseRequestState() {
+    return 0;
+  }
 
   virtual std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
@@ -97,7 +107,20 @@ class CudfGroupby : public CudfOperatorBase {
 
   void doNoMoreInput() override;
 
+  void doClose() override;
+
  private:
+  enum class FinalAggregationMode {
+    kUndecided,
+    kStreaming,
+    kLevelled,
+  };
+
+  struct FinalAggregationRun {
+    CudfVectorPtr data;
+    uint64_t representedRows;
+  };
+
   CudfVectorPtr doGroupByAggregation(
       cudf::table_view tableView,
       std::vector<column_index_t> const& groupByKeys,
@@ -112,6 +135,15 @@ class CudfGroupby : public CudfOperatorBase {
   void computeFinalGroupbyStreaming(CudfVectorPtr tbl);
   void computeSingleGroupbyStreaming(CudfVectorPtr tbl);
 
+  void addFinalAggregationRun(FinalAggregationRun run);
+  FinalAggregationRun mergeFinalAggregationRuns(
+      FinalAggregationRun left,
+      FinalAggregationRun right,
+      size_t outputLevel,
+      bool finalizing);
+  CudfVectorPtr drainFinalAggregationRuns();
+  CudfVectorPtr finalizeStreamingFinalAggregation();
+
   std::vector<column_index_t> groupingKeyInputChannels_;
   std::vector<column_index_t> groupingKeyOutputChannels_;
   std::vector<column_index_t> aggregationInputChannels_;
@@ -119,6 +151,10 @@ class CudfGroupby : public CudfOperatorBase {
 
   std::shared_ptr<const core::AggregationNode> aggregationNode_;
   const core::PlanNodeId diagnosticNodeId_;
+  // Aggregation state outlives an individual addInput() call. Keep all state
+  // production, compaction, and finalization on one stream so dependencies are
+  // not lost when successive exchange pages arrive on different streams.
+  const rmm::cuda_stream_view stateStream_;
   std::vector<std::unique_ptr<GroupbyAggregator>> aggregators_;
   std::vector<std::unique_ptr<GroupbyAggregator>> intermediateAggregators_;
   // Used for kSingle streaming: partial-step aggregators (raw -> intermediate)
@@ -142,6 +178,23 @@ class CudfGroupby : public CudfOperatorBase {
   TypePtr inputType_;
   RowTypePtr bufferedResultType_;
   CudfVectorPtr bufferedResult_;
+
+  // Supported FINAL aggregates use cuDF's persistent hash state directly
+  // across exchange pages. The choice is made from the first page and is never
+  // changed after state has been accumulated. Unsupported aggregate kinds keep
+  // using the all-GPU levelled-run implementation below.
+  FinalAggregationMode finalAggregationMode_{FinalAggregationMode::kUndecided};
+  std::unique_ptr<cudf::groupby::streaming_groupby> finalStreamingGroupby_;
+  std::vector<size_t> finalStreamingRequestAggregationCounts_;
+  cudf::size_type finalStreamingMaxDistinctKeys_{0};
+  uint64_t finalStreamingBatchCount_{0};
+
+  // One independently aggregated FINAL run per binary size level. A new run is
+  // merged only with a peer at the same level, preventing the previous
+  // state-plus-every-batch quadratic re-aggregation pattern.
+  std::vector<std::optional<FinalAggregationRun>> finalRunLevels_;
+  uint64_t finalInputRunCount_{0};
+  uint64_t finalRunMergeCount_{0};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/CudfOrderBy.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
@@ -30,15 +31,118 @@
 #include <malloc.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <filesystem>
+#include <utility>
 
 namespace facebook::velox::cudf_velox {
 namespace {
 
-constexpr uint64_t kSortedRunBytes = 3ULL << 30;
+constexpr uint64_t kSortedRunBytes = 128ULL << 20;
 constexpr uint64_t kMergeChunkBytes = 32ULL << 20;
+constexpr uint64_t kMergePassBytes = 128ULL << 20;
+constexpr uint64_t kSpillRowGroupBytes = 64ULL << 20;
+constexpr uint64_t kOutputChunkBytes = 32ULL << 20;
+constexpr size_t kMergeFanIn = 2;
+constexpr size_t kFinalMergeRuns = 2;
+constexpr cudf::size_type kMaxOutputRows = 262144;
+
 std::atomic<uint64_t> orderBySpillDirectorySequence{0};
+std::atomic<uint64_t> sortedRunBytes{kSortedRunBytes};
+std::atomic<uint64_t> mergeChunkBytes{kMergeChunkBytes};
+std::atomic<uint64_t> outputChunkBytes{kOutputChunkBytes};
+std::atomic<cudf::size_type> maxOutputRows{kMaxOutputRows};
+
+// Read-only diagnostics used to assert the external-sort bounds in GPU tests.
+// They never participate in operator scheduling or correctness.
+std::atomic<uint64_t> observedMaxActiveRuns{0};
+std::atomic<uint64_t> observedSourceChunks{0};
+std::atomic<uint64_t> observedMergeOutputBatches{0};
+std::atomic<uint64_t> observedEmittedChunks{0};
+std::atomic<uint64_t> observedSpillCleanups{0};
+
+bool isSpillSafeType(const TypePtr& type) {
+  if (type == nullptr || type->providesCustomComparison()) {
+    return false;
+  }
+
+  switch (type->kind()) {
+    case TypeKind::BOOLEAN:
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE:
+    case TypeKind::VARCHAR:
+      return true;
+    case TypeKind::INTEGER:
+      // DATE is supported, but interval year-month has not been validated
+      // through the internal Parquet representation.
+      return !type->isIntervalYearMonth();
+    case TypeKind::BIGINT:
+      // Plain BIGINT and short DECIMAL are supported. Interval day-time has
+      // not been validated through the internal Parquet representation.
+      return !type->isIntervalDayTime();
+    case TypeKind::HUGEINT:
+      return type->isDecimal();
+    case TypeKind::TIMESTAMP:
+      switch (CudfConfig::getInstance().timestampUnit) {
+        case cudf::type_id::TIMESTAMP_MILLISECONDS:
+        case cudf::type_id::TIMESTAMP_MICROSECONDS:
+        case cudf::type_id::TIMESTAMP_NANOSECONDS:
+          return true;
+        default:
+          // Parquet changes TIMESTAMP_SECONDS to milliseconds unless the
+          // reader is given an explicit target, making spill data-dependent.
+          return false;
+      }
+    case TypeKind::ARRAY:
+      return type->size() == 1 && isSpillSafeType(type->childAt(0));
+    case TypeKind::ROW:
+      if (type->size() == 0) {
+        return false;
+      }
+      for (uint32_t i = 0; i < type->size(); ++i) {
+        if (!isSpillSafeType(type->childAt(i))) {
+          return false;
+        }
+      }
+      return true;
+    case TypeKind::VARBINARY:
+    case TypeKind::MAP:
+    case TypeKind::UNKNOWN:
+    case TypeKind::FUNCTION:
+    case TypeKind::OPAQUE:
+    case TypeKind::INVALID:
+      return false;
+  }
+  return false;
+}
+
+bool isSupportedSortKeyType(const TypePtr& type) {
+  if (!isSpillSafeType(type) || !type->isOrderable()) {
+    return false;
+  }
+
+  // Nested cuDF sort semantics have not been validated against Velox. Nested
+  // values may still be carried as payload when every leaf is spill-safe.
+  return type->kind() != TypeKind::ARRAY && type->kind() != TypeKind::ROW;
+}
+
+void updateAtomicMax(std::atomic<uint64_t>& target, uint64_t value) {
+  auto current = target.load();
+  while (current < value &&
+         !target.compare_exchange_weak(current, value)) {
+  }
+}
+
+void resetTestingStats() {
+  observedMaxActiveRuns.store(0);
+  observedSourceChunks.store(0);
+  observedMergeOutputBatches.store(0);
+  observedEmittedChunks.store(0);
+  observedSpillCleanups.store(0);
+}
 
 std::unique_ptr<cudf::table> copyTableSlice(
     cudf::table_view input,
@@ -69,6 +173,70 @@ cudf::size_type firstSearchPosition(
 
 } // namespace
 
+bool CudfOrderBy::isSupported(
+    const RowTypePtr& outputType,
+    const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys) {
+  if (outputType == nullptr || sortingKeys.empty() ||
+      !isSpillSafeType(outputType)) {
+    return false;
+  }
+
+  return std::all_of(
+      sortingKeys.begin(), sortingKeys.end(), [](const auto& key) {
+        return key != nullptr && isSupportedSortKeyType(key->type());
+      });
+}
+
+bool CudfOrderBy::isSupported(
+    const std::shared_ptr<const core::OrderByNode>& orderByNode) {
+  return orderByNode != nullptr &&
+      isSupported(orderByNode->outputType(), orderByNode->sortingKeys());
+}
+
+void CudfOrderBy::testingSetMemoryLimits(
+    uint64_t runBytes,
+    uint64_t chunkBytes,
+    uint64_t outputBytes,
+    cudf::size_type outputRows) {
+  VELOX_CHECK_GT(runBytes, 0);
+  VELOX_CHECK_GT(chunkBytes, 0);
+  VELOX_CHECK_GT(outputBytes, 0);
+  VELOX_CHECK_GT(outputRows, 0);
+  sortedRunBytes.store(runBytes);
+  mergeChunkBytes.store(chunkBytes);
+  outputChunkBytes.store(outputBytes);
+  maxOutputRows.store(outputRows);
+  resetTestingStats();
+}
+
+void CudfOrderBy::testingResetMemoryLimits() {
+  sortedRunBytes.store(kSortedRunBytes);
+  mergeChunkBytes.store(kMergeChunkBytes);
+  outputChunkBytes.store(kOutputChunkBytes);
+  maxOutputRows.store(kMaxOutputRows);
+  resetTestingStats();
+}
+
+uint64_t CudfOrderBy::testingMaxActiveRuns() {
+  return observedMaxActiveRuns.load();
+}
+
+uint64_t CudfOrderBy::testingSourceChunks() {
+  return observedSourceChunks.load();
+}
+
+uint64_t CudfOrderBy::testingMergeOutputBatches() {
+  return observedMergeOutputBatches.load();
+}
+
+uint64_t CudfOrderBy::testingEmittedChunks() {
+  return observedEmittedChunks.load();
+}
+
+uint64_t CudfOrderBy::testingSpillCleanups() {
+  return observedSpillCleanups.load();
+}
+
 CudfOrderBy::CudfOrderBy(
     int32_t operatorId,
     exec::DriverCtx* driverCtx,
@@ -83,7 +251,12 @@ CudfOrderBy::CudfOrderBy(
           NvtxMethodFlag::kAll,
           std::nullopt,
           orderByNode),
-      orderByNode_(orderByNode) {
+      orderByNode_(orderByNode),
+      stateStream_(cudfGlobalStreamPool().get_stream()) {
+  VELOX_CHECK(
+      isSupported(orderByNode),
+      "CudfOrderBy received an unsupported external-spill schema or sorting "
+      "key type");
   sortKeys_.reserve(orderByNode->sortingKeys().size());
   columnOrder_.reserve(orderByNode->sortingKeys().size());
   nullOrder_.reserve(orderByNode->sortingKeys().size());
@@ -106,74 +279,108 @@ CudfOrderBy::CudfOrderBy(
 }
 
 void CudfOrderBy::doAddInput(RowVectorPtr input) {
-  // Accumulate inputs
-  if (input->size() > 0) {
+  if (input->size() == 0) {
+    return;
+  }
+
+  try {
     auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
-    VELOX_CHECK_NOT_NULL(cudfInput);
+    VELOX_CHECK_NOT_NULL(cudfInput, "Expected CudfVector input");
+
+    const auto inputStream = cudfInput->stream();
+    if (inputStream.value() != stateStream_.value()) {
+      std::vector<rmm::cuda_stream_view> inputStreams{inputStream};
+      cudf::detail::join_streams(inputStreams, stateStream_);
+    }
+    // A packed-table backing buffer can retain a different deallocation stream
+    // even when the vector's logical stream already equals stateStream_.
+    VELOX_CHECK(
+        cudfInput->rebindStream(stateStream_),
+        "CudfOrderBy cannot rebind its input to the state stream");
+
     bufferedBytes_ += cudfInput->estimateFlatSize();
     inputs_.push_back(std::move(cudfInput));
-    if (bufferedBytes_ >= kSortedRunBytes) {
+    if (bufferedBytes_ >= sortedRunBytes.load()) {
       spillSortedRun();
     }
+  } catch (...) {
+    cleanupSpillStateAfterFailure("addInput");
+    throw;
   }
 }
 
 void CudfOrderBy::doNoMoreInput() {
   Operator::noMoreInput();
 
-  if (spilled_ && !inputs_.empty()) {
-    spillSortedRun();
+  try {
+    if (spilled_ && !inputs_.empty()) {
+      spillSortedRun();
+    }
+    if (spilled_) {
+      prepareSpilledOutput();
+      return;
+    }
+
+    if (inputs_.empty()) {
+      finished_ = true;
+      return;
+    }
+
+    auto input = getConcatenatedTable(
+        std::exchange(inputs_, {}), outputType_, stateStream_, get_output_mr());
+    bufferedBytes_ = 0;
+    VELOX_CHECK_NOT_NULL(input);
+
+    auto sorted = cudf::sort_by_key(
+        input->view(),
+        input->view().select(sortKeys_),
+        columnOrder_,
+        nullOrder_,
+        stateStream_,
+        get_output_mr());
+    setPendingOutput(std::move(sorted));
+  } catch (...) {
+    cleanupSpillStateAfterFailure("noMoreInput");
+    throw;
   }
-  if (spilled_) {
-    initializeSortedRunReaders();
-    return;
-  }
-
-  if (inputs_.empty()) {
-    finished_ = true;
-    return;
-  }
-
-  auto stream = cudfGlobalStreamPool().get_stream();
-  // Using the output memory resource to allow spilling to CPU memory.
-  auto tbl = getConcatenatedTable(
-      std::exchange(inputs_, {}), outputType_, stream, get_output_mr());
-  bufferedBytes_ = 0;
-
-  VELOX_CHECK_NOT_NULL(tbl);
-
-  auto keys = tbl->view().select(sortKeys_);
-  auto values = tbl->view();
-  auto result = cudf::sort_by_key(
-      values, keys, columnOrder_, nullOrder_, stream, get_output_mr());
-  auto const size = result->num_rows();
-  outputTable_ = std::make_shared<CudfVector>(
-      pool(), outputType_, size, std::move(result), stream);
 }
 
 RowVectorPtr CudfOrderBy::doGetOutput() {
   if (finished_ || !noMoreInput_) {
     return nullptr;
   }
-  if (spilled_) {
-    auto stream = cudfGlobalStreamPool().get_stream();
-    auto result = mergeNextSortedBatch(stream, get_output_mr());
-    if (!result || result->num_rows() == 0) {
+
+  try {
+    if (auto output = takePendingOutput()) {
+      return output;
+    }
+
+    if (!spilled_) {
       finished_ = true;
-      cleanupSpillFiles();
       return nullptr;
     }
-    return std::make_shared<CudfVector>(
-        pool(), outputType_, result->num_rows(), std::move(result), stream);
+
+    prepareSpilledOutput();
+    auto merged = mergeNextSortedBatch();
+    if (merged && merged->num_rows() > 0) {
+      setPendingOutput(std::move(merged));
+      return takePendingOutput();
+    }
+
+    finished_ = true;
+    cleanupSpillFiles();
+    return nullptr;
+  } catch (...) {
+    cleanupSpillStateAfterFailure("getOutput");
+    throw;
   }
-  finished_ = true;
-  return std::exchange(outputTable_, nullptr);
 }
 
 void CudfOrderBy::spillSortedRun() {
   if (inputs_.empty()) {
     return;
   }
+
   namespace fs = std::filesystem;
   if (!spilled_) {
     const auto sequence = orderBySpillDirectorySequence.fetch_add(1);
@@ -187,87 +394,172 @@ void CudfOrderBy::spillSortedRun() {
     spilled_ = true;
   }
 
-  auto stream = cudfGlobalStreamPool().get_stream();
-  auto mr = get_output_mr();
-  auto input =
-      getConcatenatedTable(std::exchange(inputs_, {}), outputType_, stream, mr);
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfOrderBy node={} state=sortRun.concatenate.begin "
+      "bufferedBytes={} bufferedInputs={} existingRuns={}",
+      orderByNode_->id(),
+      bufferedBytes_,
+      inputs_.size(),
+      sortedRuns_.size()));
+  auto input = getConcatenatedTable(
+      std::exchange(inputs_, {}), outputType_, stateStream_, get_output_mr());
   bufferedBytes_ = 0;
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfOrderBy node={} state=sortRun.concatenate.end rows={}",
+      orderByNode_->id(),
+      input->num_rows()));
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfOrderBy node={} state=sortRun.sort.begin rows={}",
+      orderByNode_->id(),
+      input->num_rows()));
   auto sorted = cudf::sort_by_key(
       input->view(),
       input->view().select(sortKeys_),
       columnOrder_,
       nullOrder_,
-      stream,
-      mr);
+      stateStream_,
+      get_output_mr());
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfOrderBy node={} state=sortRun.sort.end rows={}",
+      orderByNode_->id(),
+      sorted->num_rows()));
+
   auto path = fmt::format(
       "{}/run-{:06}.parquet", spillDirectory_, spillFileSequence_++);
   auto options = cudf::io::parquet_writer_options::builder(
                      cudf::io::sink_info{path}, sorted->view())
+                     .row_group_size_bytes(kSpillRowGroupBytes)
                      .build();
-  cudf::io::write_parquet(options, stream);
-  sortedRuns_.push_back({std::move(path), nullptr});
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfOrderBy node={} state=sortRun.write.begin rows={} "
+      "existingRuns={} path={}",
+      orderByNode_->id(),
+      sorted->num_rows(),
+      sortedRuns_.size(),
+      path));
+  cudf::io::write_parquet(options, stateStream_);
+
+  SortedRun run;
+  run.path = std::move(path);
+  sortedRuns_.push_back(std::move(run));
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfOrderBy node={} state=sortRun.write.end rows={} runs={} "
+      "path={}",
+      orderByNode_->id(),
+      sorted->num_rows(),
+      sortedRuns_.size(),
+      sortedRuns_.back().path));
   ::malloc_trim(0);
 }
 
-void CudfOrderBy::initializeSortedRunReaders() {
-  if (readersInitialized_) {
-    return;
-  }
-  auto stream = cudfGlobalStreamPool().get_stream();
-  auto mr = get_output_mr();
-  for (auto& run : sortedRuns_) {
-    auto options = cudf::io::parquet_reader_options::builder(
-                       cudf::io::source_info{run.path})
-                       .build();
-    run.reader = std::make_unique<cudf::io::chunked_parquet_reader>(
-        kMergeChunkBytes, 0, options, stream, mr);
-  }
-  readersInitialized_ = true;
+uint64_t CudfOrderBy::measureTableBytes(
+    std::unique_ptr<cudf::table>& table,
+    rmm::cuda_stream_view stream) {
+  VELOX_CHECK_NOT_NULL(table);
+  auto vector = std::make_shared<CudfVector>(
+      pool(), outputType_, table->num_rows(), std::move(table), stream);
+  const auto bytes = vector->estimateFlatSize();
+  table = vector->release();
+  return bytes;
 }
 
-std::unique_ptr<cudf::table> CudfOrderBy::mergeNextSortedBatch(
+bool CudfOrderBy::loadPausedChunk(
+    SortedRun& run,
     rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) {
-  while (!mergeFinished_) {
-    std::vector<std::unique_ptr<cudf::table>> chunks;
-    std::vector<cudf::table_view> mergeViews;
+    MergeStats& stats) {
+  VELOX_CHECK(stream.value() == stateStream_.value());
+  VELOX_CHECK_NOT_NULL(run.reader);
+
+  if (run.chunk && run.chunkOffset < run.chunk->num_rows()) {
+    return true;
+  }
+  run.chunk.reset();
+  run.chunkOffset = 0;
+  run.chunkBytes = 0;
+
+  while (run.reader->has_next()) {
+    auto chunk = run.reader->read_chunk();
+    ++stats.sourceChunks;
+    observedSourceChunks.fetch_add(1);
+    stats.sourceRows += chunk.tbl->num_rows();
+    if (chunk.tbl->num_rows() == 0) {
+      continue;
+    }
+    run.chunk = std::move(chunk.tbl);
+    run.chunkBytes = measureTableBytes(run.chunk, stream);
+    stats.sourceBytes += run.chunkBytes;
+    return true;
+  }
+  return false;
+}
+
+std::unique_ptr<cudf::table> CudfOrderBy::mergeNextPausedBatch(
+    std::vector<SortedRun*>& runs,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    bool& finished,
+    MergeStats& stats) {
+  VELOX_CHECK(stream.value() == stateStream_.value());
+  if (finished) {
+    return nullptr;
+  }
+
+  std::vector<SortedRun*> activeRuns;
+  std::vector<cudf::table_view> remainingViews;
+  activeRuns.reserve(runs.size());
+  remainingViews.reserve(runs.size());
+  uint64_t residentRows{0};
+  uint64_t residentBytes{0};
+  for (auto* run : runs) {
+    VELOX_CHECK_NOT_NULL(run);
+    if (!loadPausedChunk(*run, stream, stats)) {
+      continue;
+    }
+    auto slices = cudf::slice(
+        run->chunk->view(),
+        {run->chunkOffset, run->chunk->num_rows()},
+        stream);
+    VELOX_CHECK_EQ(slices.size(), 1);
+    activeRuns.push_back(run);
+    remainingViews.push_back(slices.front());
+    residentRows += slices.front().num_rows();
+    // Count the complete owning chunk, which safely overestimates a suffix.
+    residentBytes += run->chunkBytes;
+  }
+
+  stats.maxActiveRuns =
+      std::max<uint64_t>(stats.maxActiveRuns, activeRuns.size());
+  stats.maxResidentRows =
+      std::max(stats.maxResidentRows, residentRows);
+  stats.maxResidentBytes =
+      std::max(stats.maxResidentBytes, residentBytes);
+  updateAtomicMax(observedMaxActiveRuns, activeRuns.size());
+  VELOX_CHECK_LE(
+      activeRuns.size(),
+      kMergeFanIn,
+      "CudfOrderBy opened more readers than its fixed merge fan-in");
+
+  if (activeRuns.empty()) {
+    finished = true;
+    return nullptr;
+  }
+
+  std::vector<cudf::table_view> safeViews;
+  std::vector<cudf::size_type> consumed(activeRuns.size(), 0);
+  if (activeRuns.size() == 1) {
+    safeViews.push_back(remainingViews.front());
+    consumed.front() = remainingViews.front().num_rows();
+  } else {
+    // The smallest current tail is a safe global boundary: unread rows in
+    // every sorted run compare after (or equal to) it. Keep each unconsumed
+    // suffix in its owning reader chunk instead of copying a growing carry.
     std::vector<cudf::table_view> boundaryRows;
-    if (mergeCarry_ && mergeCarry_->num_rows() > 0) {
-      mergeViews.push_back(mergeCarry_->view());
+    boundaryRows.reserve(remainingViews.size());
+    for (const auto& view : remainingViews) {
+      auto last = cudf::slice(
+          view, {view.num_rows() - 1, view.num_rows()}, stream);
+      boundaryRows.push_back(last.front());
     }
-    for (auto& run : sortedRuns_) {
-      if (!run.reader || !run.reader->has_next()) {
-        continue;
-      }
-      auto chunk = run.reader->read_chunk();
-      if (chunk.tbl->num_rows() == 0) {
-        continue;
-      }
-      chunks.push_back(std::move(chunk.tbl));
-      mergeViews.push_back(chunks.back()->view());
-      if (run.reader->has_next()) {
-        auto last = cudf::slice(
-            chunks.back()->view(),
-            {chunks.back()->num_rows() - 1, chunks.back()->num_rows()},
-            stream);
-        boundaryRows.push_back(last.front());
-      }
-    }
-    if (mergeViews.empty()) {
-      mergeFinished_ = true;
-      return std::exchange(mergeCarry_, nullptr);
-    }
-
-    std::unique_ptr<cudf::table> merged = mergeViews.size() == 1
-        ? std::make_unique<cudf::table>(mergeViews.front(), stream, mr)
-        : cudf::merge(
-              mergeViews, sortKeys_, columnOrder_, nullOrder_, stream, mr);
-    mergeCarry_.reset();
-    if (boundaryRows.empty()) {
-      mergeFinished_ = true;
-      return merged;
-    }
-
     auto boundaryCandidates = cudf::concatenate(boundaryRows, stream, mr);
     auto sortedBoundaries = cudf::sort_by_key(
         boundaryCandidates->view(),
@@ -277,41 +569,382 @@ std::unique_ptr<cudf::table> CudfOrderBy::mergeNextSortedBatch(
         stream,
         mr);
     auto boundary = cudf::slice(sortedBoundaries->view(), {0, 1}, stream);
-    auto positions = cudf::upper_bound(
-        merged->view().select(sortKeys_),
-        boundary.front().select(sortKeys_),
-        columnOrder_,
-        nullOrder_,
-        stream,
-        mr);
-    const auto safeEnd = firstSearchPosition(positions->view(), stream);
-    mergeCarry_ =
-        copyTableSlice(merged->view(), safeEnd, merged->num_rows(), stream, mr);
-    if (safeEnd > 0) {
-      return copyTableSlice(merged->view(), 0, safeEnd, stream, mr);
+
+    for (size_t index = 0; index < remainingViews.size(); ++index) {
+      auto positions = cudf::upper_bound(
+          remainingViews[index].select(sortKeys_),
+          boundary.front().select(sortKeys_),
+          columnOrder_,
+          nullOrder_,
+          stream,
+          mr);
+      consumed[index] = firstSearchPosition(positions->view(), stream);
+      if (consumed[index] == 0) {
+        continue;
+      }
+      auto safe =
+          cudf::slice(remainingViews[index], {0, consumed[index]}, stream);
+      safeViews.push_back(safe.front());
     }
   }
-  return nullptr;
+
+  VELOX_CHECK(!safeViews.empty(), "Paused OrderBy merge made no progress");
+  auto output = safeViews.size() == 1
+      ? std::make_unique<cudf::table>(safeViews.front(), stream, mr)
+      : cudf::merge(
+            safeViews, sortKeys_, columnOrder_, nullOrder_, stream, mr);
+
+  for (size_t index = 0; index < activeRuns.size(); ++index) {
+    activeRuns[index]->chunkOffset += consumed[index];
+  }
+
+  ++stats.outputBatches;
+  observedMergeOutputBatches.fetch_add(1);
+  stats.outputRows += output->num_rows();
+  const auto batchBytes = measureTableBytes(output, stream);
+  stats.outputBytes += batchBytes;
+  stats.maxOutputBytes = std::max(stats.maxOutputBytes, batchBytes);
+
+  finished = true;
+  for (auto* run : runs) {
+    if ((run->chunk && run->chunkOffset < run->chunk->num_rows()) ||
+        (run->reader && run->reader->has_next())) {
+      finished = false;
+      break;
+    }
+  }
+  return output;
+}
+
+void CudfOrderBy::compactSortedRunsForMerge() {
+  MergeStats compactionStats;
+  while (sortedRuns_.size() > kFinalMergeRuns) {
+    const auto inputRunCount = sortedRuns_.size();
+    std::vector<SortedRun> nextLevel;
+    nextLevel.reserve((sortedRuns_.size() + kMergeFanIn - 1) / kMergeFanIn);
+    std::vector<std::string> obsoletePaths;
+    MergeStats levelStats;
+
+    for (size_t begin = 0; begin < sortedRuns_.size(); begin += kMergeFanIn) {
+      const auto end = std::min(sortedRuns_.size(), begin + kMergeFanIn);
+      if (end - begin == 1) {
+        nextLevel.push_back(std::move(sortedRuns_[begin]));
+        continue;
+      }
+
+      std::vector<SortedRun*> runs;
+      runs.reserve(end - begin);
+      for (size_t index = begin; index < end; ++index) {
+        auto options = cudf::io::parquet_reader_options::builder(
+                           cudf::io::source_info{sortedRuns_[index].path})
+                           .build();
+        auto& run = sortedRuns_[index];
+        run.reader = std::make_unique<cudf::io::chunked_parquet_reader>(
+            mergeChunkBytes.load(),
+            kMergePassBytes,
+            options,
+            stateStream_,
+            get_output_mr());
+        run.chunk.reset();
+        run.chunkOffset = 0;
+        run.chunkBytes = 0;
+        runs.push_back(&run);
+      }
+
+      const auto outputPath = fmt::format(
+          "{}/merge-{:06}.parquet", spillDirectory_, spillFileSequence_++);
+      auto writerOptions =
+          cudf::io::chunked_parquet_writer_options::builder(
+              cudf::io::sink_info{outputPath})
+              .row_group_size_bytes(kSpillRowGroupBytes)
+              .build();
+      cudf::io::chunked_parquet_writer writer(writerOptions, stateStream_);
+      bool groupFinished{false};
+      while (!groupFinished) {
+        auto merged = mergeNextPausedBatch(
+            runs,
+            stateStream_,
+            get_output_mr(),
+            groupFinished,
+            levelStats);
+        if (merged && merged->num_rows() > 0) {
+          writer.write(merged->view());
+        }
+      }
+      writer.close();
+
+      for (size_t index = begin; index < end; ++index) {
+        auto& run = sortedRuns_[index];
+        run.reader.reset();
+        run.chunk.reset();
+        run.chunkOffset = 0;
+        run.chunkBytes = 0;
+        obsoletePaths.push_back(run.path);
+      }
+      SortedRun outputRun;
+      outputRun.path = outputPath;
+      nextLevel.push_back(std::move(outputRun));
+    }
+
+    // Complete I/O and stream-ordered frees before deleting the previous level.
+    stateStream_.synchronize();
+    for (const auto& path : obsoletePaths) {
+      std::error_code error;
+      std::filesystem::remove(path, error);
+      if (error) {
+        LOG(WARNING) << "CudfOrderBy failed to remove compacted run path="
+                     << path << " error=" << error.message();
+      }
+    }
+    sortedRuns_ = std::move(nextLevel);
+
+    compactionStats.sourceChunks += levelStats.sourceChunks;
+    compactionStats.sourceRows += levelStats.sourceRows;
+    compactionStats.sourceBytes += levelStats.sourceBytes;
+    compactionStats.outputBatches += levelStats.outputBatches;
+    compactionStats.outputRows += levelStats.outputRows;
+    compactionStats.outputBytes += levelStats.outputBytes;
+    compactionStats.maxResidentRows = std::max(
+        compactionStats.maxResidentRows, levelStats.maxResidentRows);
+    compactionStats.maxResidentBytes = std::max(
+        compactionStats.maxResidentBytes, levelStats.maxResidentBytes);
+    compactionStats.maxOutputBytes = std::max(
+        compactionStats.maxOutputBytes, levelStats.maxOutputBytes);
+    compactionStats.maxActiveRuns = std::max(
+        compactionStats.maxActiveRuns, levelStats.maxActiveRuns);
+
+    logDeviceMemorySnapshot(fmt::format(
+        "operator=CudfOrderBy node={} state=compaction.level.end "
+        "inputRuns={} outputRuns={} sourceChunks={} outputBatches={} "
+        "maxResidentBytes={} maxOutputBytes={} maxActiveRuns={}",
+        orderByNode_->id(),
+        inputRunCount,
+        sortedRuns_.size(),
+        levelStats.sourceChunks,
+        levelStats.outputBatches,
+        levelStats.maxResidentBytes,
+        levelStats.maxOutputBytes,
+        levelStats.maxActiveRuns));
+  }
+
+  stateStream_.synchronize();
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfOrderBy node={} state=compaction.end runs={} "
+      "sourceChunks={} outputBatches={} maxResidentBytes={} "
+      "maxOutputBytes={} maxActiveRuns={}",
+      orderByNode_->id(),
+      sortedRuns_.size(),
+      compactionStats.sourceChunks,
+      compactionStats.outputBatches,
+      compactionStats.maxResidentBytes,
+      compactionStats.maxOutputBytes,
+      compactionStats.maxActiveRuns));
+}
+
+void CudfOrderBy::initializeSortedRunReaders() {
+  if (readersInitialized_) {
+    return;
+  }
+  VELOX_CHECK_LE(sortedRuns_.size(), kFinalMergeRuns);
+  for (auto& run : sortedRuns_) {
+    auto options = cudf::io::parquet_reader_options::builder(
+                       cudf::io::source_info{run.path})
+                       .build();
+    run.reader = std::make_unique<cudf::io::chunked_parquet_reader>(
+        mergeChunkBytes.load(),
+        kMergePassBytes,
+        options,
+        stateStream_,
+        get_output_mr());
+    run.chunk.reset();
+    run.chunkOffset = 0;
+    run.chunkBytes = 0;
+  }
+  readersInitialized_ = true;
+  logDeviceMemorySnapshot(fmt::format(
+      "operator=CudfOrderBy node={} state=output.merge.begin runs={} "
+      "chunkReadLimit={} passReadLimit={}",
+      orderByNode_->id(),
+      sortedRuns_.size(),
+      mergeChunkBytes.load(),
+      kMergePassBytes));
+}
+
+void CudfOrderBy::prepareSpilledOutput() {
+  if (readersInitialized_) {
+    return;
+  }
+  compactSortedRunsForMerge();
+  initializeSortedRunReaders();
+}
+
+std::unique_ptr<cudf::table> CudfOrderBy::mergeNextSortedBatch() {
+  if (mergeFinished_) {
+    return nullptr;
+  }
+  std::vector<SortedRun*> runs;
+  runs.reserve(sortedRuns_.size());
+  for (auto& run : sortedRuns_) {
+    runs.push_back(&run);
+  }
+  auto result = mergeNextPausedBatch(
+      runs,
+      stateStream_,
+      get_output_mr(),
+      mergeFinished_,
+      outputMergeStats_);
+  if (mergeFinished_) {
+    logDeviceMemorySnapshot(fmt::format(
+        "operator=CudfOrderBy node={} state=output.merge.end runs={} "
+        "sourceChunks={} sourceRows={} sourceBytes={} outputBatches={} "
+        "outputRows={} outputBytes={} maxResidentRows={} "
+        "maxResidentBytes={} maxOutputBytes={} maxActiveRuns={}",
+        orderByNode_->id(),
+        sortedRuns_.size(),
+        outputMergeStats_.sourceChunks,
+        outputMergeStats_.sourceRows,
+        outputMergeStats_.sourceBytes,
+        outputMergeStats_.outputBatches,
+        outputMergeStats_.outputRows,
+        outputMergeStats_.outputBytes,
+        outputMergeStats_.maxResidentRows,
+        outputMergeStats_.maxResidentBytes,
+        outputMergeStats_.maxOutputBytes,
+        outputMergeStats_.maxActiveRuns));
+  }
+  return result;
+}
+
+void CudfOrderBy::setPendingOutput(std::unique_ptr<cudf::table> output) {
+  VELOX_CHECK(!pendingOutput_);
+  if (!output || output->num_rows() == 0) {
+    return;
+  }
+  pendingOutputOffset_ = 0;
+  pendingOutputBytes_ = measureTableBytes(output, stateStream_);
+  pendingOutput_ = std::move(output);
+}
+
+CudfVectorPtr CudfOrderBy::takePendingOutput() {
+  if (!pendingOutput_) {
+    return nullptr;
+  }
+
+  const auto totalRows = pendingOutput_->num_rows();
+  VELOX_CHECK_LT(pendingOutputOffset_, totalRows);
+  const auto remainingRows = totalRows - pendingOutputOffset_;
+  const auto byteLimit = outputChunkBytes.load();
+  cudf::size_type targetRows =
+      std::min(remainingRows, maxOutputRows.load());
+  if (pendingOutputBytes_ > byteLimit) {
+    const auto proportionalRows = static_cast<cudf::size_type>(
+        std::max<uint64_t>(
+            1,
+            static_cast<uint64_t>(totalRows) * byteLimit /
+                pendingOutputBytes_));
+    targetRows = std::min(targetRows, proportionalRows);
+  }
+
+  while (true) {
+    auto chunk = copyTableSlice(
+        pendingOutput_->view(),
+        pendingOutputOffset_,
+        pendingOutputOffset_ + targetRows,
+        stateStream_,
+        get_output_mr());
+    auto output = std::make_shared<CudfVector>(
+        pool(), outputType_, targetRows, std::move(chunk), stateStream_);
+    const auto actualBytes = output->estimateFlatSize();
+    if (actualBytes <= byteLimit || targetRows == 1) {
+      if (actualBytes > byteLimit) {
+        LOG(WARNING) << "CudfOrderBy node=" << orderByNode_->id()
+                     << " emitted one oversized row bytes=" << actualBytes
+                     << " byteLimit=" << byteLimit;
+      }
+      pendingOutputOffset_ += targetRows;
+      observedEmittedChunks.fetch_add(1);
+      if (pendingOutputOffset_ == totalRows) {
+        pendingOutput_.reset();
+        pendingOutputOffset_ = 0;
+        pendingOutputBytes_ = 0;
+      }
+      return output;
+    }
+
+    const auto proportionalRows = static_cast<cudf::size_type>(
+        std::max<uint64_t>(
+            1,
+            static_cast<uint64_t>(targetRows) * byteLimit / actualBytes));
+    targetRows =
+        std::min<cudf::size_type>(targetRows - 1, proportionalRows);
+  }
 }
 
 void CudfOrderBy::cleanupSpillFiles() {
+  // Finish reader/writer work before destroying owners, then wait for their
+  // stream-ordered frees before removing spill files.
+  stateStream_.synchronize();
   sortedRuns_.clear();
-  mergeCarry_.reset();
-  if (spillDirectory_.empty()) {
-    return;
+  pendingOutput_.reset();
+  pendingOutputOffset_ = 0;
+  pendingOutputBytes_ = 0;
+  stateStream_.synchronize();
+
+  if (!spillDirectory_.empty()) {
+    std::error_code error;
+    std::filesystem::remove_all(spillDirectory_, error);
+    if (error) {
+      LOG(WARNING) << "CudfOrderBy failed to remove spill directory path="
+                   << spillDirectory_ << " error=" << error.message();
+    } else {
+      spillDirectory_.clear();
+      observedSpillCleanups.fetch_add(1);
+    }
   }
-  std::error_code error;
-  std::filesystem::remove_all(spillDirectory_, error);
-  spillDirectory_.clear();
   ::malloc_trim(0);
 }
 
-void CudfOrderBy::doClose() {
-  Operator::close();
-  // Release stored inputs
-  // Release cudf memory resources
+void CudfOrderBy::cleanupSpillStateAfterFailure(
+    std::string_view context) noexcept {
+  try {
+    stateStream_.synchronize();
+  } catch (const std::exception& error) {
+    LOG(WARNING) << "CudfOrderBy " << context
+                 << " pre-destruction cleanup failed: " << error.what();
+  }
+
   inputs_.clear();
-  outputTable_.reset();
-  cleanupSpillFiles();
+  sortedRuns_.clear();
+  pendingOutput_.reset();
+  pendingOutputOffset_ = 0;
+  pendingOutputBytes_ = 0;
+
+  try {
+    stateStream_.synchronize();
+  } catch (const std::exception& error) {
+    LOG(WARNING) << "CudfOrderBy " << context
+                 << " post-destruction cleanup failed: " << error.what();
+  }
+
+  if (!spillDirectory_.empty()) {
+    std::error_code error;
+    std::filesystem::remove_all(spillDirectory_, error);
+    if (error) {
+      LOG(WARNING) << "CudfOrderBy " << context
+                   << " failed to remove spill directory path="
+                   << spillDirectory_ << " error=" << error.message();
+    } else {
+      spillDirectory_.clear();
+      observedSpillCleanups.fetch_add(1);
+    }
+  }
 }
+
+void CudfOrderBy::doClose() {
+  // close() also runs during task failure; cleanup preserves the original
+  // exception while draining and destroying all state-stream owners.
+  cleanupSpillStateAfterFailure("close");
+  Operator::close();
+}
+
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -39,17 +39,16 @@
 namespace facebook::velox::cudf_velox {
 namespace {
 
-constexpr uint64_t kSortedRunBytes = 128ULL << 20;
 constexpr uint64_t kMergeChunkBytes = 32ULL << 20;
 constexpr uint64_t kMergePassBytes = 128ULL << 20;
 constexpr uint64_t kSpillRowGroupBytes = 64ULL << 20;
 constexpr uint64_t kOutputChunkBytes = 32ULL << 20;
-constexpr size_t kMergeFanIn = 2;
 constexpr size_t kFinalMergeRuns = 2;
 constexpr cudf::size_type kMaxOutputRows = 262144;
 
 std::atomic<uint64_t> orderBySpillDirectorySequence{0};
-std::atomic<uint64_t> sortedRunBytes{kSortedRunBytes};
+std::atomic<uint64_t> testingSortedRunBytes{0};
+std::atomic<size_t> testingMergeFanIn{0};
 std::atomic<uint64_t> mergeChunkBytes{kMergeChunkBytes};
 std::atomic<uint64_t> outputChunkBytes{kOutputChunkBytes};
 std::atomic<cudf::size_type> maxOutputRows{kMaxOutputRows};
@@ -197,12 +196,15 @@ void CudfOrderBy::testingSetMemoryLimits(
     uint64_t runBytes,
     uint64_t chunkBytes,
     uint64_t outputBytes,
-    cudf::size_type outputRows) {
+    cudf::size_type outputRows,
+    size_t fanIn) {
   VELOX_CHECK_GT(runBytes, 0);
   VELOX_CHECK_GT(chunkBytes, 0);
   VELOX_CHECK_GT(outputBytes, 0);
   VELOX_CHECK_GT(outputRows, 0);
-  sortedRunBytes.store(runBytes);
+  VELOX_CHECK_GE(fanIn, 2);
+  testingSortedRunBytes.store(runBytes);
+  testingMergeFanIn.store(fanIn);
   mergeChunkBytes.store(chunkBytes);
   outputChunkBytes.store(outputBytes);
   maxOutputRows.store(outputRows);
@@ -210,7 +212,8 @@ void CudfOrderBy::testingSetMemoryLimits(
 }
 
 void CudfOrderBy::testingResetMemoryLimits() {
-  sortedRunBytes.store(kSortedRunBytes);
+  testingSortedRunBytes.store(0);
+  testingMergeFanIn.store(0);
   mergeChunkBytes.store(kMergeChunkBytes);
   outputChunkBytes.store(kOutputChunkBytes);
   maxOutputRows.store(kMaxOutputRows);
@@ -252,7 +255,16 @@ CudfOrderBy::CudfOrderBy(
           std::nullopt,
           orderByNode),
       orderByNode_(orderByNode),
-      stateStream_(cudfGlobalStreamPool().get_stream()) {
+      stateStream_(cudfGlobalStreamPool().get_stream()),
+      sortedRunBytes_(
+          testingSortedRunBytes.load() > 0
+              ? testingSortedRunBytes.load()
+              : CudfConfig::getInstance().orderBySortedRunBytes),
+      mergeFanIn_(
+          testingMergeFanIn.load() > 0
+              ? testingMergeFanIn.load()
+              : static_cast<size_t>(
+                    CudfConfig::getInstance().orderByMergeFanIn)) {
   VELOX_CHECK(
       isSupported(orderByNode),
       "CudfOrderBy received an unsupported external-spill schema or sorting "
@@ -300,7 +312,7 @@ void CudfOrderBy::doAddInput(RowVectorPtr input) {
 
     bufferedBytes_ += cudfInput->estimateFlatSize();
     inputs_.push_back(std::move(cudfInput));
-    if (bufferedBytes_ >= sortedRunBytes.load()) {
+    if (bufferedBytes_ >= sortedRunBytes_) {
       spillSortedRun();
     }
   } catch (...) {
@@ -396,11 +408,14 @@ void CudfOrderBy::spillSortedRun() {
 
   logDeviceMemorySnapshot(fmt::format(
       "operator=CudfOrderBy node={} state=sortRun.concatenate.begin "
-      "bufferedBytes={} bufferedInputs={} existingRuns={}",
+      "bufferedBytes={} bufferedInputs={} existingRuns={} "
+      "sortedRunBytes={} mergeFanIn={}",
       orderByNode_->id(),
       bufferedBytes_,
       inputs_.size(),
-      sortedRuns_.size()));
+      sortedRuns_.size(),
+      sortedRunBytes_,
+      mergeFanIn_));
   auto input = getConcatenatedTable(
       std::exchange(inputs_, {}), outputType_, stateStream_, get_output_mr());
   bufferedBytes_ = 0;
@@ -536,8 +551,8 @@ std::unique_ptr<cudf::table> CudfOrderBy::mergeNextPausedBatch(
   updateAtomicMax(observedMaxActiveRuns, activeRuns.size());
   VELOX_CHECK_LE(
       activeRuns.size(),
-      kMergeFanIn,
-      "CudfOrderBy opened more readers than its fixed merge fan-in");
+      mergeFanIn_,
+      "CudfOrderBy opened more readers than its configured merge fan-in");
 
   if (activeRuns.empty()) {
     finished = true;
@@ -621,12 +636,12 @@ void CudfOrderBy::compactSortedRunsForMerge() {
   while (sortedRuns_.size() > kFinalMergeRuns) {
     const auto inputRunCount = sortedRuns_.size();
     std::vector<SortedRun> nextLevel;
-    nextLevel.reserve((sortedRuns_.size() + kMergeFanIn - 1) / kMergeFanIn);
+    nextLevel.reserve((sortedRuns_.size() + mergeFanIn_ - 1) / mergeFanIn_);
     std::vector<std::string> obsoletePaths;
     MergeStats levelStats;
 
-    for (size_t begin = 0; begin < sortedRuns_.size(); begin += kMergeFanIn) {
-      const auto end = std::min(sortedRuns_.size(), begin + kMergeFanIn);
+    for (size_t begin = 0; begin < sortedRuns_.size(); begin += mergeFanIn_) {
+      const auto end = std::min(sortedRuns_.size(), begin + mergeFanIn_);
       if (end - begin == 1) {
         nextLevel.push_back(std::move(sortedRuns_[begin]));
         continue;

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -100,7 +100,8 @@ class CudfOrderBy : public CudfOperatorBase {
       uint64_t sortedRunBytes,
       uint64_t mergeChunkBytes,
       uint64_t outputChunkBytes,
-      cudf::size_type maxOutputRows);
+      cudf::size_type maxOutputRows,
+      size_t mergeFanIn = 2);
   static void testingResetMemoryLimits();
   static uint64_t testingMaxActiveRuns();
   static uint64_t testingSourceChunks();
@@ -139,6 +140,8 @@ class CudfOrderBy : public CudfOperatorBase {
   std::vector<cudf::size_type> sortKeys_;
   std::vector<cudf::order> columnOrder_;
   std::vector<cudf::null_order> nullOrder_;
+  const uint64_t sortedRunBytes_;
+  const size_t mergeFanIn_;
   uint64_t bufferedBytes_{0};
   std::vector<SortedRun> sortedRuns_;
   std::string spillDirectory_;

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -24,16 +24,33 @@
 
 #include <cudf/io/parquet.hpp>
 #include <cudf/types.hpp>
+#include <rmm/cuda_stream_view.hpp>
 
+#include <cstdint>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace facebook::velox::cudf_velox {
+
+namespace test {
+class CudfOrderByTestHelper;
+}
 
 class CudfOrderBy : public CudfOperatorBase {
  public:
   CudfOrderBy(
       int32_t operatorId,
       exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const core::OrderByNode>& orderByNode);
+
+  /// Returns true when all output columns can round-trip through the external
+  /// Parquet runs and every sorting key has supported cuDF ordering semantics.
+  static bool isSupported(
+      const RowTypePtr& outputType,
+      const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys);
+
+  static bool isSupported(
       const std::shared_ptr<const core::OrderByNode>& orderByNode);
 
   bool needsInput() const override {
@@ -55,32 +72,87 @@ class CudfOrderBy : public CudfOperatorBase {
   void doClose() override;
 
  private:
-  void spillSortedRun();
-  void initializeSortedRunReaders();
-  std::unique_ptr<cudf::table> mergeNextSortedBatch(
-      rmm::cuda_stream_view stream,
-      rmm::device_async_resource_ref mr);
-  void cleanupSpillFiles();
+  struct MergeStats {
+    uint64_t sourceChunks{0};
+    uint64_t sourceRows{0};
+    uint64_t sourceBytes{0};
+    uint64_t outputBatches{0};
+    uint64_t outputRows{0};
+    uint64_t outputBytes{0};
+    uint64_t maxResidentRows{0};
+    uint64_t maxResidentBytes{0};
+    uint64_t maxOutputBytes{0};
+    uint64_t maxActiveRuns{0};
+  };
 
-  CudfVectorPtr outputTable_;
+  struct SortedRun {
+    std::string path;
+    std::unique_ptr<cudf::io::chunked_parquet_reader> reader;
+    // A paused reader owns at most one bounded chunk. chunkOffset identifies
+    // the unconsumed suffix without copying it into a growing carry table.
+    std::unique_ptr<cudf::table> chunk;
+    cudf::size_type chunkOffset{0};
+    uint64_t chunkBytes{0};
+  };
+
+  /// Overrides production limits for deterministic spill/merge tests.
+  static void testingSetMemoryLimits(
+      uint64_t sortedRunBytes,
+      uint64_t mergeChunkBytes,
+      uint64_t outputChunkBytes,
+      cudf::size_type maxOutputRows);
+  static void testingResetMemoryLimits();
+  static uint64_t testingMaxActiveRuns();
+  static uint64_t testingSourceChunks();
+  static uint64_t testingMergeOutputBatches();
+  static uint64_t testingEmittedChunks();
+  static uint64_t testingSpillCleanups();
+
+  void spillSortedRun();
+  void compactSortedRunsForMerge();
+  void initializeSortedRunReaders();
+  void prepareSpilledOutput();
+  uint64_t measureTableBytes(
+      std::unique_ptr<cudf::table>& table,
+      rmm::cuda_stream_view stream);
+  bool loadPausedChunk(
+      SortedRun& run,
+      rmm::cuda_stream_view stream,
+      MergeStats& stats);
+  std::unique_ptr<cudf::table> mergeNextPausedBatch(
+      std::vector<SortedRun*>& runs,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr,
+      bool& finished,
+      MergeStats& stats);
+  std::unique_ptr<cudf::table> mergeNextSortedBatch();
+  void setPendingOutput(std::unique_ptr<cudf::table> output);
+  CudfVectorPtr takePendingOutput();
+  void cleanupSpillFiles();
+  void cleanupSpillStateAfterFailure(std::string_view context) noexcept;
+
   std::shared_ptr<const core::OrderByNode> orderByNode_;
+  // Inputs, readers, merge cursors and output slices all outlive one Operator
+  // call. Keep their work and destruction ordered on one persistent stream.
+  const rmm::cuda_stream_view stateStream_;
   std::vector<CudfVectorPtr> inputs_;
   std::vector<cudf::size_type> sortKeys_;
   std::vector<cudf::order> columnOrder_;
   std::vector<cudf::null_order> nullOrder_;
   uint64_t bufferedBytes_{0};
-  struct SortedRun {
-    std::string path;
-    std::unique_ptr<cudf::io::chunked_parquet_reader> reader;
-  };
   std::vector<SortedRun> sortedRuns_;
   std::string spillDirectory_;
   uint64_t spillFileSequence_{0};
-  std::unique_ptr<cudf::table> mergeCarry_;
+  std::unique_ptr<cudf::table> pendingOutput_;
+  cudf::size_type pendingOutputOffset_{0};
+  uint64_t pendingOutputBytes_{0};
+  MergeStats outputMergeStats_;
   bool readersInitialized_{false};
   bool mergeFinished_{false};
   bool spilled_{false};
   bool finished_{false};
+
+  friend class test::CudfOrderByTestHelper;
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -23,6 +23,7 @@
 #include "velox/exec/OperatorUtils.h"
 
 #include <cudf/aggregation.hpp>
+#include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
@@ -257,7 +258,16 @@ CudfWindow::CudfWindow(
           std::nullopt,
           windowNode),
       windowNode_(windowNode),
-      inputType_(windowNode->sources()[0]->outputType()) {
+      inputType_(windowNode->sources()[0]->outputType()),
+      rankLikeStreaming_(
+          windowNode->inputsSorted() &&
+          !windowNode->partitionKeys().empty() &&
+          !windowNode->sortingKeys().empty() &&
+          std::all_of(
+              windowNode->windowFunctions().begin(),
+              windowNode->windowFunctions().end(),
+              isSupportedRankLikeFunction)),
+      stateStream_(cudfGlobalStreamPool().get_stream()) {
   for (const auto& key : windowNode->partitionKeys()) {
     const auto channel = exec::exprToChannel(key.get(), inputType_);
     VELOX_CHECK(
@@ -290,6 +300,34 @@ void CudfWindow::doAddInput(RowVectorPtr input) {
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput, "Expected CudfVector input");
+
+  if (rankLikeStreaming_) {
+    VELOX_CHECK_NULL(
+        pendingOutput_,
+        "CudfWindow received sorted input before prior output was drained");
+    const auto inputStream = cudfInput->stream();
+    if (inputStream.value() != stateStream_.value()) {
+      std::vector<rmm::cuda_stream_view> inputStreams{inputStream};
+      cudf::detail::join_streams(inputStreams, stateStream_);
+    }
+    VELOX_CHECK(
+        cudfInput->rebindStream(stateStream_),
+        "CudfWindow cannot rebind sorted input to its state stream");
+
+    auto inputTable = cudfInput->release();
+    auto output = computeOutputTable(
+        std::move(inputTable), stateStream_, get_output_mr(), true);
+    if (output->num_rows() > 0) {
+      pendingOutput_ = std::make_shared<CudfVector>(
+          pool(),
+          outputType_,
+          output->num_rows(),
+          std::move(output),
+          stateStream_);
+    }
+    return;
+  }
+
   bufferedBytes_ += cudfInput->estimateFlatSize();
   inputs_.push_back(std::move(cudfInput));
 
@@ -319,6 +357,11 @@ void CudfWindow::doAddInput(RowVectorPtr input) {
 
 void CudfWindow::doNoMoreInput() {
   Operator::noMoreInput();
+  if (rankLikeStreaming_) {
+    finished_ = true;
+    return;
+  }
+
   if (spilled_ && !inputs_.empty()) {
     spillSortedRun();
   }
@@ -331,6 +374,10 @@ void CudfWindow::doNoMoreInput() {
 }
 
 RowVectorPtr CudfWindow::doGetOutput() {
+  if (pendingOutput_ != nullptr) {
+    return std::exchange(pendingOutput_, nullptr);
+  }
+
   if (finished_ || !noMoreInput_) {
     return nullptr;
   }
@@ -635,9 +682,256 @@ void CudfWindow::cleanupSpillFiles() {
 }
 
 void CudfWindow::doClose() {
+  if (rankLikeStreaming_) {
+    // close() can run while a task exception is unwinding. A poisoned CUDA
+    // context must not replace that original failure, but owners are always
+    // destroyed between best-effort pre/post drains.
+    try {
+      stateStream_.synchronize();
+    } catch (const std::exception& error) {
+      LOG(WARNING) << "CudfWindow pre-destruction cleanup failed: "
+                   << error.what();
+    }
+    pendingOutput_.reset();
+    previousPartitionKey_.reset();
+    previousOrderKey_.reset();
+    try {
+      // Destruction above enqueues stream-ordered frees for async RMM.
+      stateStream_.synchronize();
+    } catch (const std::exception& error) {
+      LOG(WARNING) << "CudfWindow post-destruction cleanup failed: "
+                   << error.what();
+    }
+  }
   inputs_.clear();
   cleanupSpillFiles();
   Operator::close();
+}
+
+cudf::size_type CudfWindow::continuingPrefixSize(
+    cudf::table_view sortedInput,
+    const std::vector<cudf::size_type>& channels,
+    const std::unique_ptr<cudf::table>& previousKey,
+    const std::vector<cudf::order>& orders,
+    const std::vector<cudf::null_order>& nullOrders,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  if (!previousKey || sortedInput.num_rows() == 0) {
+    return 0;
+  }
+  VELOX_CHECK_EQ(channels.size(), orders.size());
+  VELOX_CHECK_EQ(channels.size(), nullOrders.size());
+  auto positions = cudf::upper_bound(
+      cudf::table_view(selectColumns(sortedInput, channels)),
+      previousKey->view(),
+      orders,
+      nullOrders,
+      stream,
+      mr);
+  return firstSearchPosition(positions->view(), stream);
+}
+
+std::unique_ptr<cudf::column> CudfWindow::fixRankLikeColumn(
+    std::unique_ptr<cudf::column> localResult,
+    std::string_view functionName,
+    cudf::table_view sortedInput,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  if (!hasRankLikeState_ || sortedInput.num_rows() == 0) {
+    return localResult;
+  }
+
+  const std::vector<cudf::order> partitionOrders(
+      partitionKeyChannels_.size(), cudf::order::ASCENDING);
+  const std::vector<cudf::null_order> partitionNullOrders(
+      partitionKeyChannels_.size(), cudf::null_order::BEFORE);
+  const auto samePartitionEnd = continuingPrefixSize(
+      sortedInput,
+      partitionKeyChannels_,
+      previousPartitionKey_,
+      partitionOrders,
+      partitionNullOrders,
+      stream,
+      mr);
+  if (samePartitionEnd == 0) {
+    return localResult;
+  }
+
+  auto addOffset =
+      [&](cudf::column_view values,
+          int64_t offset) -> std::unique_ptr<cudf::column> {
+    switch (values.type().id()) {
+      case cudf::type_id::INT32: {
+        cudf::numeric_scalar<int32_t> scalar(
+            static_cast<int32_t>(offset), true, stream, mr);
+        return cudf::binary_operation(
+            values,
+            scalar,
+            cudf::binary_operator::ADD,
+            values.type(),
+            stream,
+            mr);
+      }
+      case cudf::type_id::INT64: {
+        cudf::numeric_scalar<int64_t> scalar(offset, true, stream, mr);
+        return cudf::binary_operation(
+            values,
+            scalar,
+            cudf::binary_operator::ADD,
+            values.type(),
+            stream,
+            mr);
+      }
+      default:
+        VELOX_FAIL(
+            "Unsupported rank output type {}",
+            static_cast<int>(values.type().id()));
+    }
+  };
+  auto makeConstant =
+      [&](int64_t value,
+          cudf::size_type rows) -> std::unique_ptr<cudf::column> {
+    switch (localResult->type().id()) {
+      case cudf::type_id::INT32: {
+        cudf::numeric_scalar<int32_t> scalar(
+            static_cast<int32_t>(value), true, stream, mr);
+        return cudf::make_column_from_scalar(scalar, rows, stream, mr);
+      }
+      case cudf::type_id::INT64: {
+        cudf::numeric_scalar<int64_t> scalar(value, true, stream, mr);
+        return cudf::make_column_from_scalar(scalar, rows, stream, mr);
+      }
+      default:
+        VELOX_FAIL(
+            "Unsupported rank output type {}",
+            static_cast<int>(localResult->type().id()));
+    }
+  };
+
+  std::vector<std::unique_ptr<cudf::column>> ownedSegments;
+  std::vector<cudf::column_view> segments;
+  auto appendUnchanged = [&](cudf::size_type begin, cudf::size_type end) {
+    if (begin == end) {
+      return;
+    }
+    auto slice = cudf::slice(localResult->view(), {begin, end}, stream);
+    segments.push_back(slice.front());
+  };
+  auto appendOffset =
+      [&](cudf::size_type begin, cudf::size_type end, int64_t offset) {
+    if (begin == end) {
+      return;
+    }
+    auto slice = cudf::slice(localResult->view(), {begin, end}, stream);
+    ownedSegments.push_back(addOffset(slice.front(), offset));
+    segments.push_back(ownedSegments.back()->view());
+  };
+
+  cudf::size_type fixedEnd{0};
+  if (functionName == "rank") {
+    auto continuingPartition =
+        cudf::slice(sortedInput, {0, samePartitionEnd}, stream);
+    const auto sameOrderEnd = continuingPrefixSize(
+        continuingPartition.front(),
+        sortKeyChannels_,
+        previousOrderKey_,
+        sortOrders_,
+        sortNullOrders_,
+        stream,
+        mr);
+    if (sameOrderEnd > 0) {
+      ownedSegments.push_back(makeConstant(previousRank_, sameOrderEnd));
+      segments.push_back(ownedSegments.back()->view());
+    }
+    fixedEnd = sameOrderEnd;
+  }
+  appendOffset(
+      fixedEnd,
+      samePartitionEnd,
+      previousPartitionRows_);
+  appendUnchanged(samePartitionEnd, localResult->size());
+  VELOX_CHECK(!segments.empty());
+  return segments.size() == 1
+      ? std::make_unique<cudf::column>(segments.front(), stream, mr)
+      : cudf::concatenate(segments, stream, mr);
+}
+
+void CudfWindow::updateRankLikeState(
+    cudf::table_view sortedInput,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_GT(sortedInput.num_rows(), 0);
+  const auto numRows = sortedInput.num_rows();
+  const std::vector<cudf::order> partitionOrders(
+      partitionKeyChannels_.size(), cudf::order::ASCENDING);
+  const std::vector<cudf::null_order> partitionNullOrders(
+      partitionKeyChannels_.size(), cudf::null_order::BEFORE);
+  const auto continuedRows = hasRankLikeState_
+      ? continuingPrefixSize(
+            sortedInput,
+            partitionKeyChannels_,
+            previousPartitionKey_,
+            partitionOrders,
+            partitionNullOrders,
+            stream,
+            mr)
+      : 0;
+  const bool continuedWholeBatch = continuedRows == numRows;
+
+  auto partitionColumns =
+      cudf::table_view(selectColumns(sortedInput, partitionKeyChannels_));
+  auto lastPartition =
+      cudf::slice(partitionColumns, {numRows - 1, numRows}, stream);
+  auto partitionPositions = cudf::lower_bound(
+      partitionColumns,
+      lastPartition.front(),
+      partitionOrders,
+      partitionNullOrders,
+      stream,
+      mr);
+  const auto trailingPartitionBegin =
+      firstSearchPosition(partitionPositions->view(), stream);
+
+  auto trailingPartition =
+      cudf::slice(sortedInput, {trailingPartitionBegin, numRows}, stream);
+  auto trailingOrderColumns = cudf::table_view(
+      selectColumns(trailingPartition.front(), sortKeyChannels_));
+  auto lastOrder = cudf::slice(
+      trailingOrderColumns,
+      {trailingOrderColumns.num_rows() - 1, trailingOrderColumns.num_rows()},
+      stream);
+  auto orderPositions = cudf::lower_bound(
+      trailingOrderColumns,
+      lastOrder.front(),
+      sortOrders_,
+      sortNullOrders_,
+      stream,
+      mr);
+  const auto lastPeerBegin =
+      firstSearchPosition(orderPositions->view(), stream);
+  const bool lastPeerContinued =
+      continuedWholeBatch &&
+      continuingPrefixSize(
+          sortedInput,
+          sortKeyChannels_,
+          previousOrderKey_,
+          sortOrders_,
+          sortNullOrders_,
+          stream,
+          mr) == numRows;
+
+  const auto priorRows =
+      continuedWholeBatch ? previousPartitionRows_ : 0;
+  if (!lastPeerContinued) {
+    previousRank_ = priorRows + lastPeerBegin + 1;
+  }
+  previousPartitionRows_ =
+      priorRows + numRows - trailingPartitionBegin;
+  previousPartitionKey_ =
+      std::make_unique<cudf::table>(lastPartition.front(), stream, mr);
+  previousOrderKey_ =
+      std::make_unique<cudf::table>(lastOrder.front(), stream, mr);
+  hasRankLikeState_ = true;
 }
 
 std::unique_ptr<cudf::column> CudfWindow::computeRowNumberColumn(
@@ -960,7 +1254,7 @@ std::unique_ptr<cudf::table> CudfWindow::computeOutputTable(
     std::unique_ptr<cudf::table> input,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr,
-    bool inputAlreadySorted) const {
+    bool inputAlreadySorted) {
   const auto inputSize = inputType_->size();
   const auto numFunctions = windowNode_->windowFunctions().size();
 
@@ -1037,27 +1331,41 @@ std::unique_ptr<cudf::table> CudfWindow::computeOutputTable(
   for (size_t i = 0; i < numFunctions; ++i) {
     const auto& function = windowNode_->windowFunctions()[i];
     const auto& functionName = function.functionCall->name();
+    std::unique_ptr<cudf::column> result;
     if (functionName == "rank") {
-      resultColumns.push_back(computeRankColumn(
-          sortedView, outputType_->childAt(inputSize + i), stream, mr));
+      result = computeRankColumn(
+          sortedView, outputType_->childAt(inputSize + i), stream, mr);
     } else if (functionName == "first" || functionName == "first_value") {
-      resultColumns.push_back(computePartitionFirstColumn(
+      result = computePartitionFirstColumn(
           sortedView,
           function,
           outputType_->childAt(inputSize + i),
           stream,
-          mr));
+          mr);
     } else if (functionName == "sum") {
-      resultColumns.push_back(computeRunningPartitionSumColumn(
+      result = computeRunningPartitionSumColumn(
           sortedView,
           function,
           outputType_->childAt(inputSize + i),
           stream,
-          mr));
+          mr);
     } else {
-      resultColumns.push_back(computeRowNumberColumn(
-          sortedView, outputType_->childAt(inputSize + i), stream, mr));
+      result = computeRowNumberColumn(
+          sortedView, outputType_->childAt(inputSize + i), stream, mr);
     }
+    if (rankLikeStreaming_) {
+      result = fixRankLikeColumn(
+          std::move(result),
+          functionName,
+          sortedView,
+          stream,
+          mr);
+    }
+    resultColumns.push_back(std::move(result));
+  }
+
+  if (rankLikeStreaming_) {
+    updateRankLikeState(sortedView, stream, mr);
   }
 
   if (sortedOrder) {

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -22,8 +22,10 @@
 
 #include <cudf/io/parquet.hpp>
 #include <cudf/types.hpp>
+#include <rmm/cuda_stream_view.hpp>
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace facebook::velox::cudf_velox {
@@ -47,7 +49,7 @@ class CudfWindow : public CudfOperatorBase {
       const std::shared_ptr<const core::WindowNode>& windowNode);
 
   bool needsInput() const override {
-    return !noMoreInput_;
+    return !noMoreInput_ && pendingOutput_ == nullptr;
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -55,7 +57,7 @@ class CudfWindow : public CudfOperatorBase {
   }
 
   bool isFinished() override {
-    return finished_;
+    return finished_ && pendingOutput_ == nullptr;
   }
 
  protected:
@@ -102,7 +104,28 @@ class CudfWindow : public CudfOperatorBase {
       std::unique_ptr<cudf::table> input,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr,
-      bool inputAlreadySorted = false) const;
+      bool inputAlreadySorted = false);
+
+  std::unique_ptr<cudf::column> fixRankLikeColumn(
+      std::unique_ptr<cudf::column> localResult,
+      std::string_view functionName,
+      cudf::table_view sortedInput,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  void updateRankLikeState(
+      cudf::table_view sortedInput,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+
+  cudf::size_type continuingPrefixSize(
+      cudf::table_view sortedInput,
+      const std::vector<cudf::size_type>& channels,
+      const std::unique_ptr<cudf::table>& previousKey,
+      const std::vector<cudf::order>& orders,
+      const std::vector<cudf::null_order>& nullOrders,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
 
   void spillSortedRun();
   void initializeSortedRunReaders();
@@ -125,7 +148,12 @@ class CudfWindow : public CudfOperatorBase {
 
   const std::shared_ptr<const core::WindowNode> windowNode_;
   const RowTypePtr inputType_;
+  // Only partitioned rank-like windows whose child guarantees ordering use
+  // the bounded cross-batch fixer. Other Window shapes retain legacy behavior.
+  const bool rankLikeStreaming_;
+  const rmm::cuda_stream_view stateStream_;
   std::vector<CudfVectorPtr> inputs_;
+  CudfVectorPtr pendingOutput_;
   uint64_t bufferedBytes_{0};
   uint64_t nextDiagnosticBufferedBytes_{512ULL << 20};
   std::vector<SortedRun> sortedRuns_;
@@ -142,6 +170,14 @@ class CudfWindow : public CudfOperatorBase {
   std::vector<cudf::size_type> sortKeyChannels_;
   std::vector<cudf::order> sortOrders_;
   std::vector<cudf::null_order> sortNullOrders_;
+
+  // Minimal running-window state. No rows from the trailing partition are
+  // retained between batches.
+  bool hasRankLikeState_{false};
+  std::unique_ptr<cudf::table> previousPartitionKey_;
+  std::unique_ptr<cudf::table> previousOrderKey_;
+  int64_t previousPartitionRows_{0};
+  int64_t previousRank_{0};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -683,8 +683,14 @@ class OrderByAdapter : public OperatorAdapter {
       const exec::Operator* /*op*/,
       const core::PlanNodePtr& planNode,
       exec::DriverCtx* /*ctx*/) const override {
-    return std::dynamic_pointer_cast<const core::OrderByNode>(planNode) !=
-        nullptr;
+    const auto orderByNode =
+        std::dynamic_pointer_cast<const core::OrderByNode>(planNode);
+    if (!CudfOrderBy::isSupported(orderByNode)) {
+      LOG_FALLBACK(
+          "OrderBy external spill schema or sorting key is not supported");
+      return false;
+    }
+    return true;
   }
 
   bool acceptsGpuInput() const override {
@@ -1345,11 +1351,22 @@ class MergeExchangeAdapter : public OperatorAdapter {
     const bool isUcx = mergeExchangeNode &&
         mergeExchangeNode->transportType() ==
             core::ExchangeNode::TransportType::kUcx;
+    const bool orderBySupported = mergeExchangeNode &&
+        CudfOrderBy::isSupported(
+            mergeExchangeNode->outputType(),
+            mergeExchangeNode->sortingKeys());
     LOG(WARNING) << "CudfMergeExchangeAdapter: canRunOnGPU node="
                  << (mergeExchangeNode ? mergeExchangeNode->id() : "<null>")
                  << " isUcx=" << isUcx
+                 << " orderBySupported=" << orderBySupported
                  << " exchangeEnabled=" << CudfConfig::getInstance().exchange;
-    return CudfConfig::getInstance().exchange && mergeExchangeNode && isUcx;
+    if (!orderBySupported) {
+      LOG_FALLBACK(
+          "MergeExchange OrderBy spill schema or sorting key is not "
+          "supported");
+    }
+    return CudfConfig::getInstance().exchange && mergeExchangeNode && isUcx &&
+        orderBySupported;
   }
 
   bool acceptsGpuInput() const override {

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -43,6 +43,8 @@
 #include "velox/exec/PartitionedOutput.h"
 #include "velox/exec/Values.h"
 
+#include <limits>
+
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
@@ -512,6 +514,23 @@ void CudfConfig::initialize(
   if (config.find(kCudfConcatOptimizationEnabled) != config.end()) {
     concatOptimizationEnabled =
         folly::to<bool>(config[kCudfConcatOptimizationEnabled]);
+  }
+  if (config.find(kCudfGroupbyStreamingMaxDistinctKeys) != config.end()) {
+    const auto value =
+        folly::to<int64_t>(config[kCudfGroupbyStreamingMaxDistinctKeys]);
+    VELOX_USER_CHECK_GE(
+        value,
+        0,
+        "{} must be between 0 and {}",
+        kCudfGroupbyStreamingMaxDistinctKeys,
+        std::numeric_limits<int32_t>::max());
+    VELOX_USER_CHECK_LE(
+        value,
+        std::numeric_limits<int32_t>::max(),
+        "{} must be between 0 and {}",
+        kCudfGroupbyStreamingMaxDistinctKeys,
+        std::numeric_limits<int32_t>::max());
+    groupbyStreamingMaxDistinctKeys = static_cast<int32_t>(value);
   }
   if (config.find(kCudfFunctionNamePrefix) != config.end()) {
     functionNamePrefix = config[kCudfFunctionNamePrefix];

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -532,6 +532,21 @@ void CudfConfig::initialize(
         std::numeric_limits<int32_t>::max());
     groupbyStreamingMaxDistinctKeys = static_cast<int32_t>(value);
   }
+  if (config.find(kCudfOrderBySortedRunBytes) != config.end()) {
+    const auto value =
+        folly::to<int64_t>(config[kCudfOrderBySortedRunBytes]);
+    VELOX_USER_CHECK_GT(
+        value, 0, "{} must be positive", kCudfOrderBySortedRunBytes);
+    orderBySortedRunBytes = static_cast<uint64_t>(value);
+  }
+  if (config.find(kCudfOrderByMergeFanIn) != config.end()) {
+    const auto value = folly::to<int32_t>(config[kCudfOrderByMergeFanIn]);
+    VELOX_USER_CHECK_GE(
+        value, 2, "{} must be between 2 and 64", kCudfOrderByMergeFanIn);
+    VELOX_USER_CHECK_LE(
+        value, 64, "{} must be between 2 and 64", kCudfOrderByMergeFanIn);
+    orderByMergeFanIn = value;
+  }
   if (config.find(kCudfFunctionNamePrefix) != config.end()) {
     functionNamePrefix = config[kCudfFunctionNamePrefix];
   }

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfValues.h"
+#include "velox/experimental/cudf/exec/CudfWindow.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/tests/CudfFunctionBaseTest.h"
 
@@ -23,6 +25,8 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+#include "velox/functions/sparksql/window/WindowFunctionsRegistration.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -34,6 +38,8 @@ class AdapterOperatorTest : public OperatorTestBase {
     OperatorTestBase::SetUp();
     aggregate::prestosql::registerAllAggregateFunctions();
     functions::prestosql::registerAllScalarFunctions();
+    window::prestosql::registerAllWindowFunctions();
+    functions::window::sparksql::registerWindowFunctions("");
     cudf_velox::CudfConfig::getInstance().allowCpuFallback = false;
     cudf_velox::registerCudf();
   }
@@ -84,11 +90,26 @@ TEST_F(AdapterOperatorTest, fullPartitionWindowSumUsesCudfWindow) {
        makeNullableFlatVector<int64_t>({10, 20, 5, 7, std::nullopt, 1})});
   createDuckDbTable({data});
 
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .window({"sum(v) over (partition by k0, k1 rows between "
-                           "unbounded preceding and unbounded following) as s"})
-                  .planNode();
+  auto parsedPlan =
+      PlanBuilder()
+          .values({data})
+          .window({"sum(v) over (partition by k0, k1 rows between "
+                   "unbounded preceding and unbounded following) as s"})
+          .planNode();
+  auto parsedWindow =
+      std::dynamic_pointer_cast<const core::WindowNode>(parsedPlan);
+  ASSERT_NE(parsedWindow, nullptr);
+  auto windowFunctions = parsedWindow->windowFunctions();
+  ASSERT_EQ(windowFunctions.size(), 1);
+  // DuckDB's parser cannot retain ROWS vs RANGE when both frame bounds are
+  // UNBOUNDED. Rebuild the typed node with the frame required by this test.
+  windowFunctions.front().frame.type = core::WindowNode::WindowType::kRows;
+  auto plan = core::WindowNode::Builder(*parsedWindow)
+                  .windowFunctions(std::move(windowFunctions))
+                  .build();
+  ASSERT_EQ(
+      plan->windowFunctions().front().frame.type,
+      core::WindowNode::WindowType::kRows);
 
   auto task = AssertQueryBuilder(duckDbQueryRunner_)
                   .config("cudf.enabled", true)
@@ -98,6 +119,230 @@ TEST_F(AdapterOperatorTest, fullPartitionWindowSumUsesCudfWindow) {
                       "rows between unbounded preceding and unbounded "
                       "following) FROM tmp");
 
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(AdapterOperatorTest, streamingRowNumberCrossesInputBatches) {
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "o", "payload"},
+          {makeNullableFlatVector<int64_t>(
+               {std::nullopt, std::nullopt, 1, 1}),
+           makeNullableFlatVector<int64_t>({std::nullopt, 0, 0, 1}),
+           makeFlatVector<int64_t>({0, 1, 2, 3})}),
+      makeRowVector(
+          {"k", "o", "payload"},
+          {makeNullableFlatVector<int64_t>({1, 1, 2, 2}),
+           makeNullableFlatVector<int64_t>({2, 3, std::nullopt, 0}),
+           makeFlatVector<int64_t>({4, 5, 6, 7})})};
+  createDuckDbTable(data);
+
+  auto plan =
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"row_number() over (partition by k order by o asc nulls first) "
+               "as rn"})
+          .planNode();
+
+  auto task = assertQueryOrdered(
+      plan,
+      "SELECT k, o, payload, row_number() over (partition by k order by o "
+      "asc nulls first) FROM tmp ORDER BY k ASC NULLS FIRST, "
+      "o ASC NULLS FIRST",
+      {0, 1});
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(AdapterOperatorTest, streamingRankFixesContinuedTieAndLaterPeer) {
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "o", "payload"},
+          {makeFlatVector<int64_t>({1, 1, 1, 1}),
+           makeNullableFlatVector<int64_t>(
+               {std::nullopt, std::nullopt, 1, 1}),
+           makeFlatVector<int64_t>({0, 1, 2, 3})}),
+      makeRowVector(
+          {"k", "o", "payload"},
+          {makeFlatVector<int64_t>({1, 1, 1, 2}),
+           makeNullableFlatVector<int64_t>({1, 2, 2, std::nullopt}),
+           makeFlatVector<int64_t>({4, 5, 6, 7})}),
+      makeRowVector(
+          {"k", "o", "payload"},
+          {makeFlatVector<int64_t>({2, 2}),
+           makeNullableFlatVector<int64_t>({std::nullopt, 0}),
+           makeFlatVector<int64_t>({8, 9})})};
+  createDuckDbTable(data);
+
+  auto plan =
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"row_number() over (partition by k order by o asc nulls first) "
+               "as rn",
+               "rank() over (partition by k order by o asc nulls first) "
+               "as rnk"})
+          .planNode();
+
+  auto task = assertQueryOrdered(
+      plan,
+      "SELECT k, o, payload, "
+      "row_number() over (partition by k order by o asc nulls first), "
+      "rank() over (partition by k order by o asc nulls first) "
+      "FROM tmp ORDER BY k ASC NULLS FIRST, o ASC NULLS FIRST",
+      {0, 1});
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(AdapterOperatorTest, streamingRankProducesOutputBeforeNoMoreInput) {
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "o"},
+          {makeFlatVector<int64_t>({1, 1}),
+           makeFlatVector<int64_t>({0, 1})}),
+      makeRowVector(
+          {"k", "o"},
+          {makeFlatVector<int64_t>({1, 1}),
+           makeFlatVector<int64_t>({2, 3})})};
+
+  auto plan =
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"rank() over (partition by k order by o) as rnk"})
+          .planNode();
+  auto windowNode =
+      std::dynamic_pointer_cast<const core::WindowNode>(plan);
+  ASSERT_NE(windowNode, nullptr);
+  auto valuesNode = std::dynamic_pointer_cast<const core::ValuesNode>(
+      windowNode->sources()[0]);
+  ASSERT_NE(valuesNode, nullptr);
+
+  auto task = Task::create(
+      "streaming-rank-produces-output-before-no-more-input",
+      core::PlanFragment{plan},
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
+  auto driver = Driver::testingCreate(std::make_unique<DriverCtx>(
+      task, 0, 0, kUngroupedGroupId, 0));
+  cudf_velox::CudfValues values(0, driver->driverCtx(), valuesNode);
+  cudf_velox::CudfWindow window(1, driver->driverCtx(), windowNode);
+  values.initialize();
+  window.initialize();
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    auto input = values.getOutput();
+    ASSERT_NE(input, nullptr);
+    ASSERT_TRUE(window.needsInput());
+    window.addInput(std::move(input));
+
+    // This is intentionally before noMoreInput(). The legacy implementation
+    // kept needsInput() true and returned nullptr here until all input arrived.
+    EXPECT_FALSE(window.needsInput());
+    EXPECT_FALSE(window.isFinished());
+    {
+      auto output = window.getOutput();
+      ASSERT_NE(output, nullptr);
+      EXPECT_EQ(output->size(), data[i]->size());
+    }
+    EXPECT_TRUE(window.needsInput());
+    EXPECT_FALSE(window.isFinished());
+  }
+
+  EXPECT_EQ(values.getOutput(), nullptr);
+  window.noMoreInput();
+  EXPECT_TRUE(window.isFinished());
+  EXPECT_EQ(window.getOutput(), nullptr);
+  window.close();
+  values.close();
+}
+
+TEST_F(AdapterOperatorTest, streamingRankThreeBatchDescendingNullTie) {
+  std::vector<RowVectorPtr> data{
+      makeRowVector(
+          {"k", "a", "b", "payload"},
+          {makeFlatVector<int64_t>({1, 1}),
+           makeNullableFlatVector<int64_t>({10, 9}),
+           makeNullableFlatVector<int64_t>({5, std::nullopt}),
+           makeFlatVector<int64_t>({0, 1})}),
+      makeRowVector(
+          {"k", "a", "b", "payload"},
+          {makeFlatVector<int64_t>({1}),
+           makeNullableFlatVector<int64_t>({9}),
+           makeNullableFlatVector<int64_t>({std::nullopt}),
+           makeFlatVector<int64_t>({2})}),
+      makeRowVector(
+          {"k", "a", "b", "payload"},
+          {makeFlatVector<int64_t>({1, 1, 1, 1, 1, 1, 1}),
+           makeNullableFlatVector<int64_t>(
+               {9, 9, 9, 9, 8, std::nullopt, std::nullopt}),
+           makeNullableFlatVector<int64_t>(
+               {std::nullopt, 7, 7, 3, std::nullopt, std::nullopt, 4}),
+           makeFlatVector<int64_t>({3, 4, 5, 6, 7, 8, 9})})};
+
+  auto plan =
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"row_number() over (partition by k order by a desc nulls last, "
+               "b desc nulls first) as rn",
+               "rank() over (partition by k order by a desc nulls last, "
+               "b desc nulls first) as rnk"})
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"k", "a", "b", "payload", "rn", "rnk"},
+      {makeFlatVector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),
+       makeNullableFlatVector<int64_t>(
+           {10, 9, 9, 9, 9, 9, 9, 8, std::nullopt, std::nullopt}),
+       makeNullableFlatVector<int64_t>(
+           {5,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            7,
+            7,
+            3,
+            std::nullopt,
+            std::nullopt,
+            4}),
+       makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+       makeFlatVector<int32_t>({1, 2, 2, 2, 5, 5, 7, 8, 9, 10})});
+
+  auto task = AssertQueryBuilder(plan).maxDrivers(1).assertResults(expected);
+  EXPECT_TRUE(wasCudfWindowUsed(task));
+}
+
+TEST_F(AdapterOperatorTest, streamingRankDoesNotRetainGiantPartition) {
+  constexpr int32_t kBatches = 32;
+  constexpr vector_size_t kRowsPerBatch = 2048;
+  std::vector<RowVectorPtr> data;
+  data.reserve(kBatches);
+  for (int32_t batch = 0; batch < kBatches; ++batch) {
+    data.push_back(makeRowVector(
+        {"k", "o"},
+        {makeFlatVector<int64_t>(
+             kRowsPerBatch, [](vector_size_t) { return 7; }),
+         makeFlatVector<int64_t>(
+             kRowsPerBatch, [batch](vector_size_t row) {
+               return static_cast<int64_t>(batch) * kRowsPerBatch + row;
+             })}));
+  }
+  createDuckDbTable(data);
+
+  auto plan =
+      PlanBuilder()
+          .values(data)
+          .streamingWindow(
+              {"rank() over (partition by k order by o) as rnk"})
+          .planNode();
+  auto task = assertQueryOrdered(
+      plan,
+      "SELECT k, o, rank() over (partition by k order by o) "
+      "FROM tmp ORDER BY k, o",
+      {0, 1});
   EXPECT_TRUE(wasCudfWindowUsed(task));
 }
 

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -16,17 +16,46 @@
 
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/AggregationRegistry.h"
+#include "velox/experimental/cudf/exec/CudfGroupby.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/PrestoAggregateFunctions.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/tests/utils/CudfStreamTestUtils.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/exec/Driver.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/type/Timestamp.h"
 
+#include <cudf/contiguous_split.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/resource_ref.hpp>
+
 #include <cmath>
+
+namespace facebook::velox::cudf_velox::test {
+
+class CudfGroupbyTestHelper {
+ public:
+  static rmm::cuda_stream_view stateStream(const CudfGroupby& groupby) {
+    return groupby.stateStream_;
+  }
+
+  static void prepareInputForStateStream(
+      CudfGroupby& groupby,
+      const CudfVectorPtr& input) {
+    groupby.prepareInputForStateStream(input);
+  }
+};
+
+} // namespace facebook::velox::cudf_velox::test
 
 namespace facebook::velox::exec::test {
 
@@ -1020,12 +1049,78 @@ class FinalAggregationStreamingTest : public AggregationTest {
     EXPECT_EQ(finalStats.count("cudfFinalAggregationInputRuns"), 0);
   }
 
-  // All three tests have at most 1,000 input rows. Keep the capacity small so
-  // they exercise persistent streaming state without changing the singleton
-  // for any other test. The member destructor restores the prior value even
-  // when a fatal assertion or exception exits a test early.
+  // These tests have at most 1,000 input rows. Keep the capacity small so they
+  // exercise persistent streaming state without changing the singleton for
+  // any other test. The member destructor restores the prior value even when
+  // a fatal assertion or exception exits a test early.
   ScopedStreamingCapacity streamingCapacity_{4096};
 };
+
+TEST_F(
+    FinalAggregationStreamingTest,
+    finalAggregationRebindsPackedInputWithMatchingLogicalStream) {
+  auto rawInput = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2}),
+       makeFlatVector<int64_t>({10, 20})});
+  auto plan = PlanBuilder()
+                  .values({rawInput})
+                  .partialAggregation({"c0"}, {"count(c1)"})
+                  .finalAggregation()
+                  .planNode();
+  auto finalNode =
+      std::dynamic_pointer_cast<const core::AggregationNode>(plan);
+  ASSERT_NE(finalNode, nullptr);
+
+  auto task = Task::create(
+      "final-aggregation-packed-input-stream",
+      core::PlanFragment{plan},
+      0,
+      core::QueryCtx::create(executor_.get()),
+      Task::ExecutionMode::kParallel);
+  DriverCtx driverCtx(task, 0, 0, 0, 0);
+  cudf_velox::CudfGroupby groupby(1, &driverCtx, finalNode);
+  const auto stateStream =
+      cudf_velox::test::CudfGroupbyTestHelper::stateStream(groupby);
+
+  rmm::cuda_stream allocationStream{rmm::cuda_stream::flags::non_blocking};
+  ASSERT_NE(allocationStream.value(), stateStream.value());
+  const auto inputType = finalNode->sources()[0]->outputType();
+  auto intermediateInput = makeRowVector(
+      inputType->names(),
+      {makeFlatVector<int64_t>({1, 2}),
+       makeFlatVector<int64_t>({3, 4})});
+  auto table = cudf_velox::with_arrow::toCudfTable(
+      intermediateInput,
+      pool(),
+      allocationStream.view(),
+      cudf_velox::get_output_mr());
+
+  cudf_velox::test::RecordingAsyncDeviceResource recordingResource{
+      /*deferDeallocations=*/true};
+  auto packedColumns = cudf::pack(
+      table->view(),
+      allocationStream.view(),
+      rmm::to_device_async_resource_ref_checked(&recordingResource));
+  allocationStream.synchronize();
+  auto packedView = cudf::unpack(packedColumns);
+  auto packedTable = std::make_unique<cudf::packed_table>(
+      cudf::packed_table{packedView, std::move(packedColumns)});
+  auto packedInput = std::make_shared<cudf_velox::CudfVector>(
+      pool(),
+      inputType,
+      packedTable->table.num_rows(),
+      std::move(packedTable),
+      stateStream);
+  recordingResource.reset();
+
+  cudf_velox::test::CudfGroupbyTestHelper::prepareInputForStateStream(
+      groupby, packedInput);
+  packedInput.reset();
+  stateStream.synchronize();
+  EXPECT_GT(recordingResource.deallocationCount(), 0);
+  EXPECT_EQ(recordingResource.lastDeallocationStream(), stateStream.value());
+  recordingResource.releaseDeferred();
+}
 
 TEST_F(FinalAggregationStreamingTest, finalAggregationStreamsOnAddInput) {
   auto vectors = {

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -990,7 +990,44 @@ TEST_F(AggregationTest, partialAggregationMemoryLimit) {
           .customStats.count("flushRowCount"));
 }
 
-TEST_F(AggregationTest, finalAggregationStreamsOnAddInput) {
+class FinalAggregationStreamingTest : public AggregationTest {
+ protected:
+  class ScopedStreamingCapacity {
+   public:
+    explicit ScopedStreamingCapacity(int32_t capacity)
+        : previousCapacity_(
+              cudf_velox::CudfConfig::getInstance()
+                  .groupbyStreamingMaxDistinctKeys) {
+      cudf_velox::CudfConfig::getInstance()
+          .groupbyStreamingMaxDistinctKeys = capacity;
+    }
+
+    ~ScopedStreamingCapacity() {
+      cudf_velox::CudfConfig::getInstance()
+          .groupbyStreamingMaxDistinctKeys = previousCapacity_;
+    }
+
+   private:
+    const int32_t previousCapacity_;
+  };
+
+  template <typename Stats>
+  void assertStreamingFinalStats(const Stats& finalStats) {
+    EXPECT_GT(finalStats.at("cudfFinalStreamingBatches").sum, 1);
+    EXPECT_GT(finalStats.at("cudfFinalStreamingInputRows").sum, 0);
+    EXPECT_GT(finalStats.at("cudfFinalStreamingDistinctKeys").sum, 0);
+    EXPECT_GT(finalStats.at("cudfFinalStreamingOutputRows").sum, 0);
+    EXPECT_EQ(finalStats.count("cudfFinalAggregationInputRuns"), 0);
+  }
+
+  // All three tests have at most 1,000 input rows. Keep the capacity small so
+  // they exercise persistent streaming state without changing the singleton
+  // for any other test. The member destructor restores the prior value even
+  // when a fatal assertion or exception exits a test early.
+  ScopedStreamingCapacity streamingCapacity_{4096};
+};
+
+TEST_F(FinalAggregationStreamingTest, finalAggregationStreamsOnAddInput) {
   auto vectors = {
       makeRowVector({makeFlatVector<int32_t>(
           100, [](auto row) { return row; }, nullEvery(5))}),
@@ -1022,9 +1059,10 @@ TEST_F(AggregationTest, finalAggregationStreamsOnAddInput) {
   const auto planStats = toPlanStats(task->taskStats());
   EXPECT_GT(planStats.at(partialAggId).customStats.at("flushRowCount").sum, 0);
   EXPECT_GT(planStats.at(finalAggId).outputRows, 0);
+  assertStreamingFinalStats(planStats.at(finalAggId).customStats);
 }
 
-TEST_F(AggregationTest, finalAggregationStreamingMixedAggs) {
+TEST_F(FinalAggregationStreamingTest, finalAggregationStreamingMixedAggs) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);
 
@@ -1046,9 +1084,10 @@ TEST_F(AggregationTest, finalAggregationStreamingMixedAggs) {
 
   const auto planStats = toPlanStats(task->taskStats());
   EXPECT_GT(planStats.at(finalAggId).outputRows, 0);
+  assertStreamingFinalStats(planStats.at(finalAggId).customStats);
 }
 
-TEST_F(AggregationTest, finalAggregationStreamingMultiKey) {
+TEST_F(FinalAggregationStreamingTest, finalAggregationStreamingMultiKey) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);
 
@@ -1070,6 +1109,7 @@ TEST_F(AggregationTest, finalAggregationStreamingMultiKey) {
 
   const auto planStats = toPlanStats(task->taskStats());
   EXPECT_GT(planStats.at(finalAggId).outputRows, 0);
+  assertStreamingFinalStats(planStats.at(finalAggId).customStats);
 }
 
 class EmptyInputAggregationTest : public AggregationTest {

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 velox_add_cudf_test(
   NAME velox_cudf_adapter_operator_test
   SOURCES Main.cpp AdapterOperatorTest.cpp
-  LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib
+  LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib velox_window velox_functions_spark_window
 )
 
 velox_add_cudf_test(

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 namespace facebook::velox::cudf_velox::test {
 
 TEST(ConfigTest, CudfConfig) {
@@ -27,7 +29,8 @@ TEST(ConfigTest, CudfConfig) {
       {CudfConfig::kCudfMemoryResource, "arena"},
       {CudfConfig::kCudfMemoryPercent, "25"},
       {CudfConfig::kCudfFunctionNamePrefix, "presto"},
-      {CudfConfig::kCudfAllowCpuFallback, "false"}};
+      {CudfConfig::kCudfAllowCpuFallback, "false"},
+      {CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys, "16777216"}};
 
   CudfConfig config;
   config.initialize(std::move(options));
@@ -37,5 +40,28 @@ TEST(ConfigTest, CudfConfig) {
   ASSERT_EQ(config.memoryPercent, 25);
   ASSERT_EQ(config.functionNamePrefix, "presto");
   ASSERT_EQ(config.allowCpuFallback, false);
+  ASSERT_EQ(config.groupbyStreamingMaxDistinctKeys, 16777216);
 }
+
+TEST(ConfigTest, GroupbyStreamingMaxDistinctKeysRange) {
+  CudfConfig defaultConfig;
+  ASSERT_EQ(defaultConfig.groupbyStreamingMaxDistinctKeys, 0);
+
+  CudfConfig maxConfig;
+  maxConfig.initialize({
+      {CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys,
+       std::to_string(std::numeric_limits<int32_t>::max())}});
+  ASSERT_EQ(
+      maxConfig.groupbyStreamingMaxDistinctKeys,
+      std::numeric_limits<int32_t>::max());
+
+  CudfConfig negativeConfig;
+  EXPECT_ANY_THROW(negativeConfig.initialize(
+      {{CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys, "-1"}}));
+
+  CudfConfig overflowConfig;
+  EXPECT_ANY_THROW(overflowConfig.initialize(
+      {{CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys, "2147483648"}}));
+}
+
 } // namespace facebook::velox::cudf_velox::test

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -30,7 +30,9 @@ TEST(ConfigTest, CudfConfig) {
       {CudfConfig::kCudfMemoryPercent, "25"},
       {CudfConfig::kCudfFunctionNamePrefix, "presto"},
       {CudfConfig::kCudfAllowCpuFallback, "false"},
-      {CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys, "16777216"}};
+      {CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys, "16777216"},
+      {CudfConfig::kCudfOrderBySortedRunBytes, "67108864"},
+      {CudfConfig::kCudfOrderByMergeFanIn, "7"}};
 
   CudfConfig config;
   config.initialize(std::move(options));
@@ -41,6 +43,26 @@ TEST(ConfigTest, CudfConfig) {
   ASSERT_EQ(config.functionNamePrefix, "presto");
   ASSERT_EQ(config.allowCpuFallback, false);
   ASSERT_EQ(config.groupbyStreamingMaxDistinctKeys, 16777216);
+  ASSERT_EQ(config.orderBySortedRunBytes, 67108864);
+  ASSERT_EQ(config.orderByMergeFanIn, 7);
+}
+
+TEST(ConfigTest, OrderByBounds) {
+  CudfConfig defaultConfig;
+  EXPECT_EQ(defaultConfig.orderBySortedRunBytes, 256ULL << 20);
+  EXPECT_EQ(defaultConfig.orderByMergeFanIn, 8);
+
+  CudfConfig zeroRunBytes;
+  EXPECT_ANY_THROW(zeroRunBytes.initialize(
+      {{CudfConfig::kCudfOrderBySortedRunBytes, "0"}}));
+
+  CudfConfig lowFanIn;
+  EXPECT_ANY_THROW(lowFanIn.initialize(
+      {{CudfConfig::kCudfOrderByMergeFanIn, "1"}}));
+
+  CudfConfig highFanIn;
+  EXPECT_ANY_THROW(highFanIn.initialize(
+      {{CudfConfig::kCudfOrderByMergeFanIn, "65"}}));
 }
 
 TEST(ConfigTest, GroupbyStreamingMaxDistinctKeysRange) {

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
+#include "velox/experimental/cudf/tests/utils/CudfStreamTestUtils.h"
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -23,11 +25,8 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/memory_resource>
-#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <array>
@@ -36,6 +35,7 @@
 
 using namespace facebook::velox;
 using namespace facebook::velox::cudf_velox;
+using namespace facebook::velox::cudf_velox::test;
 using namespace facebook::velox::test;
 
 namespace {
@@ -68,70 +68,6 @@ class TestCudaStream {
  private:
   cudaStream_t stream_{nullptr};
 };
-
-struct RecordingAsyncResourceState {
-  cudaStream_t lastDeallocationStream{nullptr};
-  std::size_t deallocationCount{0};
-};
-
-class RecordingAsyncDeviceResource {
- public:
-  void* allocate(
-      cuda::stream_ref stream,
-      std::size_t bytes,
-      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) {
-    return asyncUpstream_.allocate(stream, bytes, alignment);
-  }
-
-  void deallocate(
-      cuda::stream_ref stream,
-      void* ptr,
-      std::size_t bytes,
-      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept {
-    state_->lastDeallocationStream = stream.get();
-    ++state_->deallocationCount;
-    asyncUpstream_.deallocate(stream, ptr, bytes, alignment);
-  }
-
-  void* allocate_sync(
-      std::size_t bytes,
-      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) {
-    return asyncUpstream_.allocate_sync(bytes, alignment);
-  }
-
-  void deallocate_sync(
-      void* ptr,
-      std::size_t bytes,
-      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept {
-    asyncUpstream_.deallocate_sync(ptr, bytes, alignment);
-  }
-
-  void reset() {
-    state_->lastDeallocationStream = nullptr;
-    state_->deallocationCount = 0;
-  }
-
-  std::size_t deallocationCount() const {
-    return state_->deallocationCount;
-  }
-
-  cudaStream_t lastDeallocationStream() const {
-    return state_->lastDeallocationStream;
-  }
-
-  bool operator==(const RecordingAsyncDeviceResource& other) const noexcept {
-    return state_ == other.state_;
-  }
-
- private:
-  std::shared_ptr<RecordingAsyncResourceState> state_{
-      std::make_shared<RecordingAsyncResourceState>()};
-  rmm::mr::cuda_async_memory_resource asyncUpstream_;
-};
-
-void get_property(
-    const RecordingAsyncDeviceResource&,
-    cuda::mr::device_accessible) noexcept {}
 
 std::unique_ptr<cudf::table> makeTable(
     rmm::cuda_stream_view stream,

--- a/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
@@ -21,6 +21,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -240,6 +241,23 @@ class CudfDecimalTest : public exec::test::OperatorTestBase {
     unregisterCudf();
     exec::test::OperatorTestBase::TearDown();
   }
+};
+
+class ScopedGroupbyStreamingCapacity {
+ public:
+  explicit ScopedGroupbyStreamingCapacity(int32_t capacity)
+      : previousCapacity_(
+            CudfConfig::getInstance().groupbyStreamingMaxDistinctKeys) {
+    CudfConfig::getInstance().groupbyStreamingMaxDistinctKeys = capacity;
+  }
+
+  ~ScopedGroupbyStreamingCapacity() {
+    CudfConfig::getInstance().groupbyStreamingMaxDistinctKeys =
+        previousCapacity_;
+  }
+
+ private:
+  const int32_t previousCapacity_;
 };
 
 TEST_F(CudfDecimalTest, decimalAvgDecimalInput) {
@@ -717,6 +735,70 @@ TEST_F(CudfDecimalTest, decimalSumPartialFinalVarbinary) {
 
   facebook::velox::exec::test::AssertQueryBuilder(plan, duckDbQueryRunner_)
       .assertResults("SELECT k, sum(d) AS s FROM tmp GROUP BY k");
+}
+
+TEST_F(
+    CudfDecimalTest,
+    decimalFinalStreamingProbeReleasesMaterializedColumns) {
+  ScopedGroupbyStreamingCapacity streamingCapacity(4096);
+  auto input1 = makeRowVector(
+      {"k", "d"},
+      {
+          makeFlatVector<int32_t>({1, 1, 2}),
+          makeFlatVector<int64_t>({12345, -2500, 10000}, DECIMAL(12, 2)),
+      });
+  auto input2 = makeRowVector(
+      {"k", "d"},
+      {
+          makeFlatVector<int32_t>({2, 2, 3}),
+          makeFlatVector<int64_t>({200, -300, 700}, DECIMAL(12, 2)),
+      });
+  auto input3 = makeRowVector(
+      {"k", "d"},
+      {
+          makeFlatVector<int32_t>({1, 3, 4}),
+          makeFlatVector<int64_t>({100, -250, 900}, DECIMAL(12, 2)),
+      });
+  std::vector<RowVectorPtr> vectors = {input1, input2, input3};
+  auto expected = makeRowVector(
+      {"k", "s", "a"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4}),
+          makeFlatVector<int128_t>(
+              {static_cast<int128_t>(9945),
+               static_cast<int128_t>(9900),
+               static_cast<int128_t>(450),
+               static_cast<int128_t>(900)},
+              DECIMAL(38, 2)),
+          makeFlatVector<int64_t>({3315, 3300, 225, 900}, DECIMAL(12, 2)),
+      });
+
+  core::PlanNodeId partialAggId;
+  core::PlanNodeId finalAggId;
+  auto plan = exec::test::PlanBuilder()
+                  .values(vectors)
+                  .partialAggregation(
+                      {"k"}, {"sum(d) AS s", "avg(d) AS a"})
+                  .capturePlanNodeId(partialAggId)
+                  .finalAggregation()
+                  .capturePlanNodeId(finalAggId)
+                  .planNode();
+  auto task = exec::test::AssertQueryBuilder(plan)
+                  .config(core::QueryConfig::kMaxPartialAggregationMemory, 1)
+                  .assertResults(expected);
+
+  const auto planStats = exec::toPlanStats(task->taskStats());
+  EXPECT_GT(
+      planStats.at(partialAggId)
+          .customStats.at("flushRowCount")
+          .sum,
+      0);
+  const auto& finalStats = planStats.at(finalAggId).customStats;
+  EXPECT_EQ(
+      finalStats.at("cudfFinalStreamingFallbackProbeColumnsReleased").sum,
+      3);
+  EXPECT_GT(finalStats.at("cudfFinalAggregationInputRuns").sum, 1);
+  EXPECT_EQ(finalStats.count("cudfFinalStreamingBatches"), 0);
 }
 
 TEST_F(CudfDecimalTest, decimalPartialSumVarbinaryToVeloxRoundTrip) {

--- a/velox/experimental/cudf/tests/OrderByTest.cpp
+++ b/velox/experimental/cudf/tests/OrderByTest.cpp
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/CudfConversion.h"
+#include "velox/experimental/cudf/exec/CudfOrderBy.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -31,7 +34,50 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::common::testutil;
 
+namespace facebook::velox::cudf_velox::test {
+
+class CudfOrderByTestHelper {
+ public:
+  static void setMemoryLimits(
+      uint64_t sortedRunBytes,
+      uint64_t mergeChunkBytes,
+      uint64_t outputChunkBytes,
+      cudf::size_type maxOutputRows) {
+    CudfOrderBy::testingSetMemoryLimits(
+        sortedRunBytes, mergeChunkBytes, outputChunkBytes, maxOutputRows);
+  }
+
+  static void resetMemoryLimits() {
+    CudfOrderBy::testingResetMemoryLimits();
+  }
+
+  static uint64_t maxActiveRuns() {
+    return CudfOrderBy::testingMaxActiveRuns();
+  }
+
+  static uint64_t sourceChunks() {
+    return CudfOrderBy::testingSourceChunks();
+  }
+
+  static uint64_t mergeOutputBatches() {
+    return CudfOrderBy::testingMergeOutputBatches();
+  }
+
+  static uint64_t emittedChunks() {
+    return CudfOrderBy::testingEmittedChunks();
+  }
+
+  static uint64_t spillCleanups() {
+    return CudfOrderBy::testingSpillCleanups();
+  }
+};
+
+} // namespace facebook::velox::cudf_velox::test
+
 namespace {
+
+using OrderByTestHelper =
+    facebook::velox::cudf_velox::test::CudfOrderByTestHelper;
 
 class OrderByTest : public OperatorTestBase {
  protected:
@@ -40,6 +86,7 @@ class OrderByTest : public OperatorTestBase {
     filesystems::registerLocalFileSystem();
     cudf_velox::registerCudf();
     rng_.seed(123);
+    timestampUnit_ = cudf_velox::CudfConfig::getInstance().timestampUnit;
 
     rowType_ = ROW(
         {{"c0", INTEGER()},
@@ -49,6 +96,8 @@ class OrderByTest : public OperatorTestBase {
   }
 
   void TearDown() override {
+    OrderByTestHelper::resetMemoryLimits();
+    cudf_velox::CudfConfig::getInstance().timestampUnit = timestampUnit_;
     cudf_velox::unregisterCudf();
     OperatorTestBase::TearDown();
   }
@@ -178,7 +227,93 @@ class OrderByTest : public OperatorTestBase {
 
   folly::Random::DefaultGenerator rng_;
   RowTypePtr rowType_;
+  cudf::type_id timestampUnit_;
 };
+
+TEST_F(OrderByTest, externalSpillSchemaEligibility) {
+  const auto timestampOrderBy =
+      std::dynamic_pointer_cast<const core::OrderByNode>(
+          PlanBuilder()
+              .tableScan(ROW({"key", "payload"}, {TIMESTAMP(), INTEGER()}))
+              .orderBy({"key ASC NULLS LAST"}, false)
+              .planNode());
+  ASSERT_NE(timestampOrderBy, nullptr);
+
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  config.timestampUnit = cudf::type_id::TIMESTAMP_SECONDS;
+  EXPECT_FALSE(cudf_velox::CudfOrderBy::isSupported(timestampOrderBy));
+
+  for (const auto unit : {cudf::type_id::TIMESTAMP_MILLISECONDS,
+                          cudf::type_id::TIMESTAMP_MICROSECONDS,
+                          cudf::type_id::TIMESTAMP_NANOSECONDS}) {
+    config.timestampUnit = unit;
+    EXPECT_TRUE(cudf_velox::CudfOrderBy::isSupported(timestampOrderBy));
+  }
+
+  const auto safeNestedPayload =
+      std::dynamic_pointer_cast<const core::OrderByNode>(
+          PlanBuilder()
+              .tableScan(ROW(
+                  {"key", "payload"},
+                  {INTEGER(), ARRAY(ROW({BIGINT(), VARCHAR()}))}))
+              .orderBy({"key ASC NULLS LAST"}, false)
+              .planNode());
+  ASSERT_NE(safeNestedPayload, nullptr);
+  EXPECT_TRUE(cudf_velox::CudfOrderBy::isSupported(safeNestedPayload));
+
+  const auto unsupportedBinaryPayload =
+      std::dynamic_pointer_cast<const core::OrderByNode>(
+          PlanBuilder()
+              .tableScan(
+                  ROW({"key", "payload"}, {INTEGER(), VARBINARY()}))
+              .orderBy({"key ASC NULLS LAST"}, false)
+              .planNode());
+  ASSERT_NE(unsupportedBinaryPayload, nullptr);
+  EXPECT_FALSE(
+      cudf_velox::CudfOrderBy::isSupported(unsupportedBinaryPayload));
+}
+
+TEST_F(OrderByTest, externalSpillConstructorDefense) {
+  const auto timestampOrderBy =
+      std::dynamic_pointer_cast<const core::OrderByNode>(
+          PlanBuilder()
+              .tableScan(ROW({"key", "payload"}, {INTEGER(), TIMESTAMP()}))
+              .orderBy({"key ASC NULLS LAST"}, false)
+              .planNode());
+  ASSERT_NE(timestampOrderBy, nullptr);
+
+  const auto makeFakeTask = [&](const std::string& taskId) {
+    core::PlanFragment fakePlanFragment;
+    fakePlanFragment.planNode = std::make_shared<core::ValuesNode>(
+        core::PlanNodeId{"0"}, std::vector<RowVectorPtr>{});
+    return Task::create(
+        taskId,
+        std::move(fakePlanFragment),
+        0,
+        core::QueryCtx::create(executor_.get()),
+        Task::ExecutionMode::kParallel);
+  };
+
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  config.timestampUnit = cudf::type_id::TIMESTAMP_SECONDS;
+  {
+    auto fakeTask = makeFakeTask("CudfOrderByTest.unsupported");
+    DriverCtx driverCtx(fakeTask, 0, 0, 0, 0);
+    VELOX_ASSERT_THROW(
+        cudf_velox::CudfOrderBy(1, &driverCtx, timestampOrderBy),
+        "unsupported external-spill schema");
+  }
+
+  config.timestampUnit = cudf::type_id::TIMESTAMP_NANOSECONDS;
+  {
+    auto fakeTask = makeFakeTask("CudfOrderByTest.supported");
+    DriverCtx driverCtx(fakeTask, 0, 0, 0, 0);
+    EXPECT_NO_THROW({
+      cudf_velox::CudfOrderBy orderBy(1, &driverCtx, timestampOrderBy);
+      orderBy.close();
+    });
+  }
+}
 
 TEST_F(OrderByTest, selectiveFilter) {
   vector_size_t batchSize = 1000;
@@ -316,6 +451,62 @@ TEST_F(OrderByTest, varfields) {
   createDuckDbTable(vectors);
 
   testSingleKey(vectors, "c2");
+}
+
+TEST_F(OrderByTest, boundedExternalSortManyRuns) {
+  constexpr int32_t kNumRuns = 23;
+  constexpr vector_size_t kRowsPerRun = 97;
+  constexpr cudf::size_type kMaxOutputRows = 17;
+  // One input vector per run plus tiny reader/output chunks deterministically
+  // exercises multiple binary compaction levels and final paused readers.
+  OrderByTestHelper::setMemoryLimits(1, 4096, 4096, kMaxOutputRows);
+
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(kNumRuns);
+  for (int32_t run = 0; run < kNumRuns; ++run) {
+    auto c0 = makeFlatVector<int64_t>(
+        kRowsPerRun,
+        [run](vector_size_t row) { return (row * 7 + run * 3) % 17; },
+        nullEvery(23, run % 23));
+    auto c1 = makeFlatVector<int64_t>(
+        kRowsPerRun,
+        [run](vector_size_t row) { return (row * 5 + run * 11) % 19; },
+        nullEvery(29, (run * 2) % 29));
+    // A unique final key makes the expected global order deterministic even
+    // though SQL does not define insertion order for complete sort-key ties.
+    auto c2 = makeFlatVector<int64_t>(
+        kRowsPerRun,
+        [run](vector_size_t row) { return run * kRowsPerRun + row; });
+    auto payload = makeFlatVector<std::string>(
+        kRowsPerRun, [run](vector_size_t row) {
+          return fmt::format("run={};row={};", run, row) +
+              std::string(512, static_cast<char>('a' + run % 26));
+        });
+    vectors.push_back(makeRowVector({c0, c1, c2, payload}));
+  }
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy(
+                      {"c0 ASC NULLS FIRST",
+                       "c1 DESC NULLS LAST",
+                       "c2 ASC NULLS LAST"},
+                      false)
+                  .planNode();
+  assertQueryOrdered(
+      plan,
+      "SELECT * FROM tmp ORDER BY c0 ASC NULLS FIRST, "
+      "c1 DESC NULLS LAST, c2 ASC NULLS LAST",
+      {0, 1, 2});
+
+  EXPECT_EQ(OrderByTestHelper::maxActiveRuns(), 2);
+  EXPECT_GE(OrderByTestHelper::sourceChunks(), kNumRuns);
+  EXPECT_GT(OrderByTestHelper::mergeOutputBatches(), 0);
+  EXPECT_GE(
+      OrderByTestHelper::emittedChunks(),
+      (kNumRuns * kRowsPerRun + kMaxOutputRows - 1) / kMaxOutputRows);
+  EXPECT_EQ(OrderByTestHelper::spillCleanups(), 1);
 }
 
 /// Verifies output batch rows of OrderBy

--- a/velox/experimental/cudf/tests/utils/CudfStreamTestUtils.h
+++ b/velox/experimental/cudf/tests/utils/CudfStreamTestUtils.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <rmm/mr/cuda_async_memory_resource.hpp>
+
+#include <cuda/memory_resource>
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace facebook::velox::cudf_velox::test {
+
+struct RecordingAsyncResourceState {
+  cudaStream_t lastDeallocationStream{nullptr};
+  std::size_t deallocationCount{0};
+};
+
+class RecordingAsyncDeviceResource {
+  struct PendingDeallocation {
+    void* ptr;
+    std::size_t bytes;
+    std::size_t alignment;
+  };
+
+  struct Storage {
+    explicit Storage(bool defer) : deferDeallocations(defer) {}
+
+    ~Storage() {
+      releaseDeferred();
+    }
+
+    void releaseDeferred() noexcept {
+      if (pendingDeallocations.empty()) {
+        return;
+      }
+      cudaDeviceSynchronize();
+      for (const auto& pending : pendingDeallocations) {
+        asyncUpstream.deallocate(
+            cuda::stream_ref{cudaStreamPerThread},
+            pending.ptr,
+            pending.bytes,
+            pending.alignment);
+      }
+      cudaDeviceSynchronize();
+      pendingDeallocations.clear();
+    }
+
+    RecordingAsyncResourceState state;
+    rmm::mr::cuda_async_memory_resource asyncUpstream;
+    bool deferDeallocations;
+    std::vector<PendingDeallocation> pendingDeallocations;
+  };
+
+ public:
+  explicit RecordingAsyncDeviceResource(bool deferDeallocations = false)
+      : storage_(std::make_shared<Storage>(deferDeallocations)) {}
+
+  void* allocate(
+      cuda::stream_ref stream,
+      std::size_t bytes,
+      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) {
+    return storage_->asyncUpstream.allocate(stream, bytes, alignment);
+  }
+
+  void deallocate(
+      cuda::stream_ref stream,
+      void* ptr,
+      std::size_t bytes,
+      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept {
+    storage_->state.lastDeallocationStream = stream.get();
+    ++storage_->state.deallocationCount;
+    if (storage_->deferDeallocations) {
+      try {
+        storage_->pendingDeallocations.push_back({ptr, bytes, alignment});
+      } catch (...) {
+        cudaDeviceSynchronize();
+        storage_->asyncUpstream.deallocate(stream, ptr, bytes, alignment);
+      }
+      return;
+    }
+    storage_->asyncUpstream.deallocate(stream, ptr, bytes, alignment);
+  }
+
+  void* allocate_sync(
+      std::size_t bytes,
+      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) {
+    return storage_->asyncUpstream.allocate_sync(bytes, alignment);
+  }
+
+  void deallocate_sync(
+      void* ptr,
+      std::size_t bytes,
+      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept {
+    storage_->asyncUpstream.deallocate_sync(ptr, bytes, alignment);
+  }
+
+  void reset() {
+    storage_->state.lastDeallocationStream = nullptr;
+    storage_->state.deallocationCount = 0;
+  }
+
+  std::size_t deallocationCount() const {
+    return storage_->state.deallocationCount;
+  }
+
+  cudaStream_t lastDeallocationStream() const {
+    return storage_->state.lastDeallocationStream;
+  }
+
+  void releaseDeferred() noexcept {
+    storage_->releaseDeferred();
+  }
+
+  bool operator==(const RecordingAsyncDeviceResource& other) const noexcept {
+    return storage_ == other.storage_;
+  }
+
+ private:
+  std::shared_ptr<Storage> storage_;
+};
+
+inline void get_property(
+    const RecordingAsyncDeviceResource&,
+    cuda::mr::device_accessible) noexcept {}
+
+} // namespace facebook::velox::cudf_velox::test


### PR DESCRIPTION
Retargets #52 to `dev` because the original PR was already merged into `2026-q3`, and GitHub does not allow changing the base of a merged PR.

No code changes were made for this retarget. Existing validation is documented in #52. The companion planner retarget is [NVIDIA/spark-gluten#52](https://github.com/NVIDIA/spark-gluten/pull/52), and the output-manager lifecycle prerequisite is #54.

Tests were not rerun for this metadata-only migration.

Generated-by: OpenAI Codex (GPT-5)