### PR TITLE
feat(cudf): Add cuDF right-semi-project joins and bounded UCX hash exchange

### DIFF
--- a/.github/workflows/sync-facebookincubator-main.yml
+++ b/.github/workflows/sync-facebookincubator-main.yml
@@ -18,8 +18,8 @@ on:
   schedule:
     # Run daily at 03:17 UTC (12:17 JST). Avoid the top of the hour,
     # when scheduled workflows are more likely to be delayed.
-    - cron: '17 3 * * *'
-  workflow_dispatch:
+    - cron: 17 3 * * *
+  workflow_dispatch: {}
 
 permissions: {}
 

--- a/.github/workflows/sync-facebookincubator-main.yml
+++ b/.github/workflows/sync-facebookincubator-main.yml
@@ -1,3 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Sync facebookincubator main
 
 on:

--- a/.github/workflows/sync-facebookincubator-main.yml
+++ b/.github/workflows/sync-facebookincubator-main.yml
@@ -1,0 +1,31 @@
+name: Sync facebookincubator main
+
+on:
+  schedule:
+    # Run daily at 03:17 UTC (12:17 JST). Avoid the top of the hour,
+    # when scheduled workflows are more likely to be delayed.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: sync-facebookincubator-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Fast-forward main from upstream
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Sync main from facebookincubator/velox
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/merge-upstream" \
+            -f branch=main

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -93,6 +93,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kMaxPartitionedOutputBufferSize);
     VELOX_REGISTER_QUERY_CONFIG(kMaxOutputBufferSize);
     VELOX_REGISTER_QUERY_CONFIG(kUcxPartitionedOutputBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kUcxPartitionedOutputBatchBytes);
 
     // Output batch.
     VELOX_REGISTER_QUERY_CONFIG(kPreferredOutputBatchBytes);

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -93,6 +93,9 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kMaxPartitionedOutputBufferSize);
     VELOX_REGISTER_QUERY_CONFIG(kMaxOutputBufferSize);
     VELOX_REGISTER_QUERY_CONFIG(kUcxPartitionedOutputBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kUcxHashPartitionInputBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kUcxHashPartitionWindowRows);
+    VELOX_REGISTER_QUERY_CONFIG(kCudfAsyncQueryEndTrimBytes);
     VELOX_REGISTER_QUERY_CONFIG(kUcxPartitionedOutputBatchBytes);
 
     // Output batch.

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -351,6 +351,17 @@ class QueryConfig {
       10'000,
       "Target rows per CudfPartitionedOutput exchange chunk.")
 
+  /// Target bytes to accumulate before flushing CudfPartitionedOutput and the
+  /// maximum approximate payload bytes per destination chunk. Set to 0 to
+  /// disable byte-based accumulation and chunking.
+  VELOX_QUERY_CONFIG(
+      kUcxPartitionedOutputBatchBytes,
+      ucxPartitionedOutputBatchBytes,
+      "cudf.partitioned_output_batch_bytes",
+      uint64_t,
+      0,
+      "Target bytes per CudfPartitionedOutput exchange chunk.")
+
   VELOX_QUERY_CONFIG(
       kMaxPartialAggregationMemory,
       maxPartialAggregationMemoryUsage,

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -351,6 +351,42 @@ class QueryConfig {
       10'000,
       "Target rows per CudfPartitionedOutput exchange chunk.")
 
+  /// Maximum input rows for one libcudf hash_partition call in UCX output.
+  /// Zero keeps the normal single-call path. This is query-scoped so a query
+  /// that needs the libcudf safety bound does not regress every other query.
+  VELOX_QUERY_CONFIG(
+      kUcxHashPartitionInputBatchRows,
+      ucxHashPartitionInputBatchRows,
+      "cudf.hash_partition_input_batch_rows",
+      int64_t,
+      0,
+      "Maximum input rows per UCX hash_partition call; 0 disables slicing.")
+
+  /// Maximum source rows whose safely sliced hash results are recombined at
+  /// once. Zero derives the window from cudf.partitioned_output_batch_rows.
+  VELOX_QUERY_CONFIG(
+      kUcxHashPartitionWindowRows,
+      ucxHashPartitionWindowRows,
+      "cudf.hash_partition_window_rows",
+      int64_t,
+      0,
+      "Maximum source rows per sliced UCX hash recombination window; 0 uses "
+      "the partitioned-output batch row setting.")
+
+  /// Query-boundary cudaMallocAsync trim policy. Values >= 0 trim unused pool
+  /// memory to the requested retained bytes; -1 explicitly disables trim for
+  /// this query; -2 preserves the executor-environment fallback. This allows
+  /// benchmark hot iterations to reuse the pool while retaining deterministic
+  /// release before a following high-peak query.
+  VELOX_QUERY_CONFIG(
+      kCudfAsyncQueryEndTrimBytes,
+      cudfAsyncQueryEndTrimBytes,
+      "cudf.async_query_end_trim_bytes",
+      int64_t,
+      -2,
+      "cudaMallocAsync bytes to retain at query end; -1 disables and -2 uses "
+      "the executor environment fallback.")
+
   /// Target bytes to accumulate before flushing CudfPartitionedOutput and the
   /// maximum approximate payload bytes per destination chunk. Set to 0 to
   /// disable byte-based accumulation and chunking.

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -11,6 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if(VELOX_ENABLE_CUDF)
+  # Task owns output-queue initialization. Without this definition the cuDF
+  # UcxPartitionedOutput operator runs without a registered output queue.
+  set_source_files_properties(
+    Task.cpp TARGET_DIRECTORY velox PROPERTIES COMPILE_DEFINITIONS VELOX_ENABLE_CUDF)
+  set_property(
+    SOURCE Task.cpp
+    TARGET_DIRECTORY velox
+    APPEND
+    PROPERTY INCLUDE_DIRECTORIES
+             "${CMAKE_BINARY_DIR}/_deps/cccl-src/libcudacxx/include"
+             "${CMAKE_BINARY_DIR}/_deps/cccl-src/thrust"
+             "${CMAKE_BINARY_DIR}/_deps/cccl-src/cub"
+             "${CUDAToolkit_INCLUDE_DIRS}")
+endif()
+
 velox_add_library(
   velox_exec
   AddressableNonNullValueList.cpp

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -259,6 +259,18 @@ velox_link_libraries(
   velox_vector
 )
 
+if(VELOX_ENABLE_CUDF)
+  # Task.cpp owns the UCX output-queue lifecycle when cuDF exchange is enabled.
+  # The CMake option does not automatically define a C++ preprocessor macro;
+  # without this definition the guarded initialize/update/remove paths are
+  # silently omitted from production builds.
+  velox_compile_definitions(velox_exec PRIVATE VELOX_ENABLE_CUDF)
+  # Task.cpp includes the cuDF-backed queue manager under the same guard.
+  # Propagate cuDF's CCCL include directories (including <cuda/version>) to
+  # this target without exposing them to velox_exec consumers.
+  velox_link_libraries(velox_exec PRIVATE cudf::cudf)
+endif()
+
 if(VELOX_ENABLE_GEO)
   velox_compile_definitions(velox_exec PRIVATE VELOX_ENABLE_GEO)
   velox_link_libraries(velox_exec velox_common_geospatial_serde)

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -15,16 +15,20 @@ if(VELOX_ENABLE_CUDF)
   # Task owns output-queue initialization. Without this definition the cuDF
   # UcxPartitionedOutput operator runs without a registered output queue.
   set_source_files_properties(
-    Task.cpp TARGET_DIRECTORY velox PROPERTIES COMPILE_DEFINITIONS VELOX_ENABLE_CUDF)
-  set_property(
-    SOURCE Task.cpp
+    Task.cpp
     TARGET_DIRECTORY velox
+    PROPERTIES COMPILE_DEFINITIONS VELOX_ENABLE_CUDF
+  )
+  set_property(
+    SOURCE Task.cpp TARGET_DIRECTORY velox
     APPEND
-    PROPERTY INCLUDE_DIRECTORIES
-             "${CMAKE_BINARY_DIR}/_deps/cccl-src/libcudacxx/include"
-             "${CMAKE_BINARY_DIR}/_deps/cccl-src/thrust"
-             "${CMAKE_BINARY_DIR}/_deps/cccl-src/cub"
-             "${CUDAToolkit_INCLUDE_DIRS}")
+    PROPERTY
+      INCLUDE_DIRECTORIES
+        "${CMAKE_BINARY_DIR}/_deps/cccl-src/libcudacxx/include"
+        "${CMAKE_BINARY_DIR}/_deps/cccl-src/thrust"
+        "${CMAKE_BINARY_DIR}/_deps/cccl-src/cub"
+        "${CUDAToolkit_INCLUDE_DIRS}"
+  )
 endif()
 
 velox_add_library(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -42,11 +42,6 @@
 #include "velox/exec/TableScan.h"
 #include "velox/exec/Task.h"
 
-#ifdef VELOX_ENABLE_CUDF
-#include <velox/experimental/ucx-exchange/UcxOutputQueueManager.h>
-#include "velox/experimental/cudf/CudfConfig.h"
-#endif
-
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
@@ -107,6 +102,24 @@ splitListenerFactories() {
   static folly::Synchronized<std::vector<std::shared_ptr<SplitListenerFactory>>>
       kListenerFactories;
   return kListenerFactories;
+}
+
+folly::Synchronized<std::shared_ptr<PartitionedOutputBufferManager>>&
+partitionedOutputBufferManagerRegistry() {
+  static folly::Synchronized<std::shared_ptr<PartitionedOutputBufferManager>>
+      kManager;
+  return kManager;
+}
+
+std::shared_ptr<PartitionedOutputBufferManager>
+getRegisteredPartitionedOutputBufferManager(
+    const core::PartitionedOutputNode& node,
+    const core::QueryConfig& queryConfig) {
+  auto manager = partitionedOutputBufferManagerRegistry().withRLock(
+      [](const auto& registered) { return registered; });
+  return manager != nullptr && manager->supports(node, queryConfig)
+      ? std::move(manager)
+      : nullptr;
 }
 
 std::string errorMessageImpl(const std::exception_ptr& exception) {
@@ -213,7 +226,6 @@ std::string makeUuid() {
   return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
 }
 
-#ifdef VELOX_ENABLE_CUDF
 bool isUcxExchangePlanNode(
     const core::PlanNode* planNode,
     const core::PlanNodeId& planNodeId) {
@@ -234,7 +246,6 @@ bool isUcxExchangePlanNode(
   }
   return false;
 }
-#endif
 
 // Returns true if an operator is a hash join operator given 'operatorType'.
 bool isHashJoinOperator(const std::string& operatorType) {
@@ -307,6 +318,31 @@ void noMoreSplitsForStore(
 }
 
 } // namespace
+
+bool registerPartitionedOutputBufferManager(
+    const std::shared_ptr<PartitionedOutputBufferManager>& manager) {
+  VELOX_CHECK_NOT_NULL(manager);
+  return partitionedOutputBufferManagerRegistry().withWLock(
+      [&](auto& registered) {
+        if (registered != nullptr) {
+          return false;
+        }
+        registered = manager;
+        return true;
+      });
+}
+
+bool unregisterPartitionedOutputBufferManager(
+    const std::shared_ptr<PartitionedOutputBufferManager>& manager) {
+  return partitionedOutputBufferManagerRegistry().withWLock(
+      [&](auto& registered) {
+        if (registered != manager) {
+          return false;
+        }
+        registered.reset();
+        return true;
+      });
+}
 
 std::string executionModeString(Task::ExecutionMode mode) {
   switch (mode) {
@@ -1304,11 +1340,14 @@ void Task::createAndStartDrivers(uint32_t concurrentSplitGroups) {
 }
 
 void Task::initializePartitionOutput() {
-  VELOX_CHECK(
-      isRunningLocked(),
-      "Task {} has already been terminated before start: {}",
-      taskId_,
-      errorMessageLocked());
+  {
+    std::lock_guard<std::timed_mutex> l(mutex_);
+    VELOX_CHECK(
+        isRunningLocked(),
+        "Task {} has already been terminated before start: {}",
+        taskId_,
+        errorMessageLocked());
+  }
 
   auto bufferManager = bufferManager_.lock();
   VELOX_CHECK_NOT_NULL(
@@ -1317,6 +1356,8 @@ void Task::initializePartitionOutput() {
       "PartitionedOutputBufferManager was already destructed");
   std::shared_ptr<const core::PartitionedOutputNode> partitionedOutputNode{
       nullptr};
+  std::shared_ptr<PartitionedOutputBufferManager>
+      partitionedOutputBufferManager;
   int numOutputDrivers{0};
   {
     std::unique_lock<std::timed_mutex> l(mutex_);
@@ -1337,6 +1378,9 @@ void Task::initializePartitionOutput() {
         if (partitionedOutputNode != nullptr) {
           numDriversInPartitionedOutput_ = factory->numDrivers;
           groupedPartitionedOutput_ = factory->groupedExecution;
+          partitionedOutputBufferManager =
+              getRegisteredPartitionedOutputBufferManager(
+                  *partitionedOutputNode, queryCtx_->queryConfig());
           numOutputDrivers = factory->groupedExecution
               ? factory->numDrivers * planFragment_.numSplitGroups
               : factory->numDrivers;
@@ -1366,18 +1410,36 @@ void Task::initializePartitionOutput() {
         partitionedOutputNode->kind(),
         partitionedOutputNode->numPartitions(),
         numOutputDrivers);
-#ifdef VELOX_ENABLE_CUDF
-    if (velox::cudf_velox::CudfConfig::getInstance().enabled &&
-        velox::cudf_velox::CudfConfig::getInstance().exchange) {
-      auto queueMgr = facebook::velox::ucx_exchange::UcxOutputQueueManager::
-          getInstanceRef();
-      queueMgr->initializeTask(
-          shared_from_this(),
-          partitionedOutputNode->kind(),
-          partitionedOutputNode->numPartitions(),
-          numOutputDrivers);
+    if (partitionedOutputBufferManager != nullptr) {
+      try {
+        partitionedOutputBufferManager->initializeTask(
+            shared_from_this(),
+            partitionedOutputNode->kind(),
+            partitionedOutputNode->numPartitions(),
+            numOutputDrivers);
+      } catch (...) {
+        try {
+          partitionedOutputBufferManager->removeTask(taskId_);
+        } catch (...) {
+          LOG(ERROR) << "Failed to clean up partitioned output after "
+                        "initialization failed for task "
+                     << taskId_;
+        }
+        throw;
+      }
+
+      bool keepManager{false};
+      {
+        std::lock_guard<std::timed_mutex> l(mutex_);
+        if (isRunningLocked()) {
+          partitionedOutputBufferManager_ = partitionedOutputBufferManager;
+          keepManager = true;
+        }
+      }
+      if (!keepManager) {
+        partitionedOutputBufferManager->removeTask(taskId_);
+      }
     }
-#endif
   }
 }
 
@@ -1906,6 +1968,9 @@ void Task::noMoreSplits(const core::PlanNodeId& planNodeId) {
   std::vector<ContinuePromise> splitPromises;
   bool allFinished;
   std::shared_ptr<ExchangeClient> exchangeClient;
+  std::shared_ptr<PartitionedOutputBufferManager>
+      partitionedOutputBufferManager;
+  std::optional<uint32_t> numPartitionedOutputDrivers;
   {
     std::lock_guard<std::timed_mutex> l(mutex_);
 
@@ -1946,11 +2011,20 @@ void Task::noMoreSplits(const core::PlanNodeId& planNodeId) {
       }
     }
 
-    allFinished = checkNoMoreSplitGroupsLocked();
+    allFinished = checkNoMoreSplitGroupsLocked(numPartitionedOutputDrivers);
+
+    if (numPartitionedOutputDrivers.has_value()) {
+      partitionedOutputBufferManager = partitionedOutputBufferManager_;
+    }
 
     if (!isRunningLocked()) {
       exchangeClient = getExchangeClientLocked(planNodeId);
     }
+  }
+
+  if (partitionedOutputBufferManager != nullptr) {
+    partitionedOutputBufferManager->updateNumDrivers(
+        taskId_, numPartitionedOutputDrivers.value());
   }
 
   for (auto& promise : splitPromises) {
@@ -2160,7 +2234,8 @@ void Task::dropInputLocked(
   }
 }
 
-bool Task::checkNoMoreSplitGroupsLocked() {
+bool Task::checkNoMoreSplitGroupsLocked(
+    std::optional<uint32_t>& numPartitionedOutputDrivers) {
   if (isUngroupedExecution()) {
     return false;
   }
@@ -2178,9 +2253,11 @@ bool Task::checkNoMoreSplitGroupsLocked() {
     numTotalDrivers_ = seenSplitGroups_.size() * numDriversPerSplitGroup_ +
         numDriversUngrouped_;
     if (groupedPartitionedOutput_) {
+      const auto numOutputDrivers =
+          numDriversInPartitionedOutput_ * seenSplitGroups_.size();
       auto bufferManager = bufferManager_.lock();
-      bufferManager->updateNumDrivers(
-          taskId(), numDriversInPartitionedOutput_ * seenSplitGroups_.size());
+      bufferManager->updateNumDrivers(taskId(), numOutputDrivers);
+      numPartitionedOutputDrivers = numOutputDrivers;
     }
 
     return checkIfFinishedLocked();
@@ -2386,6 +2463,8 @@ bool Task::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
       bufferManager,
       "Unable to initialize task. "
       "DefaultOutputBufferManager was already destructed");
+  std::shared_ptr<PartitionedOutputBufferManager>
+      partitionedOutputBufferManager;
   {
     std::lock_guard<std::timed_mutex> l(mutex_);
     if (noMoreOutputBuffers_) {
@@ -2395,17 +2474,14 @@ bool Task::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
     if (noMoreBuffers) {
       noMoreOutputBuffers_ = true;
     }
+    partitionedOutputBufferManager = partitionedOutputBufferManager_;
   }
   auto result =
       bufferManager->updateOutputBuffers(taskId_, numBuffers, noMoreBuffers);
-#ifdef VELOX_ENABLE_CUDF
-  if (velox::cudf_velox::CudfConfig::getInstance().enabled &&
-      velox::cudf_velox::CudfConfig::getInstance().exchange) {
-    auto queueMgr =
-        facebook::velox::ucx_exchange::UcxOutputQueueManager::getInstanceRef();
-    queueMgr->updateOutputBuffers(taskId_, numBuffers, noMoreBuffers);
+  if (partitionedOutputBufferManager != nullptr) {
+    partitionedOutputBufferManager->updateOutputBuffers(
+        taskId_, numBuffers, noMoreBuffers);
   }
-#endif
   return result;
 }
 
@@ -2831,11 +2907,9 @@ ContinueFuture Task::terminate(TaskState terminalState) {
 
       // Process remaining remote splits.
       if (getExchangeClientLocked(nodeId) != nullptr) {
-#ifdef VELOX_ENABLE_CUDF
         if (isUcxExchangePlanNode(planFragment_.planNode.get(), nodeId)) {
           continue;
         }
-#endif
         std::vector<exec::Split> splits;
         for (auto& [groupId, store] : state.groupSplitsStores) {
           if (!store) {
@@ -2904,6 +2978,13 @@ ContinueFuture Task::terminate(TaskState terminalState) {
 
 void Task::maybeRemoveFromOutputBufferManager() {
   if (hasPartitionedOutput()) {
+    std::shared_ptr<PartitionedOutputBufferManager>
+        partitionedOutputBufferManager;
+    {
+      std::lock_guard<std::timed_mutex> l(mutex_);
+      partitionedOutputBufferManager =
+          std::move(partitionedOutputBufferManager_);
+    }
     if (auto bufferManager = bufferManager_.lock()) {
       // Capture output buffer stats before deleting the buffer.
       {
@@ -2915,23 +2996,30 @@ void Task::maybeRemoveFromOutputBufferManager() {
       }
       bufferManager->removeTask(taskId_);
     }
-#ifdef VELOX_ENABLE_CUDF
-    if (velox::cudf_velox::CudfConfig::getInstance().enabled &&
-        velox::cudf_velox::CudfConfig::getInstance().exchange) {
-      // Capture output queue stats before deleting the queue.
-      auto queueMgr = facebook::velox::ucx_exchange::UcxOutputQueueManager::
-          getInstanceRef();
-      // Capture output buffer stats before deleting the buffer.
-      {
-        std::lock_guard<std::timed_mutex> l(mutex_);
-        auto optStats = queueMgr->stats(taskId_);
+    if (partitionedOutputBufferManager != nullptr) {
+      try {
+        auto optStats = partitionedOutputBufferManager->stats(taskId_);
         if (optStats.has_value() && optStats.value().totalPagesSent > 0) {
+          std::lock_guard<std::timed_mutex> l(mutex_);
           taskStats_.outputBufferStats = optStats;
         }
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to collect partitioned output stats for task "
+                   << taskId_ << ": " << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Failed to collect partitioned output stats for task "
+                   << taskId_ << ": unknown exception";
       }
-      queueMgr->removeTask(taskId_);
+      try {
+        partitionedOutputBufferManager->removeTask(taskId_);
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to remove partitioned output for task " << taskId_
+                   << ": " << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Failed to remove partitioned output for task " << taskId_
+                   << ": unknown exception";
+      }
     }
-#endif
   }
 }
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -33,6 +33,45 @@
 namespace facebook::velox::exec {
 
 class DefaultOutputBufferManager;
+class Task;
+
+/// Extension point for non-default partitioned-output transports. A Task
+/// selects one registered manager at output initialization and retains it for
+/// the lifetime of that output.
+class PartitionedOutputBufferManager {
+ public:
+  virtual ~PartitionedOutputBufferManager() = default;
+
+  virtual bool supports(
+      const core::PartitionedOutputNode& node,
+      const core::QueryConfig& queryConfig) const = 0;
+
+  virtual void initializeTask(
+      std::shared_ptr<Task> task,
+      core::PartitionedOutputNode::Kind kind,
+      int numPartitions,
+      int numOutputDrivers) = 0;
+
+  virtual void updateOutputBuffers(
+      const std::string& taskId,
+      int numBuffers,
+      bool noMoreBuffers) = 0;
+
+  virtual void updateNumDrivers(
+      const std::string& taskId,
+      uint32_t numOutputDrivers) = 0;
+
+  virtual std::optional<OutputBuffer::Stats> stats(
+      const std::string& taskId) = 0;
+
+  virtual void removeTask(const std::string& taskId) = 0;
+};
+
+bool registerPartitionedOutputBufferManager(
+    const std::shared_ptr<PartitionedOutputBufferManager>& manager);
+
+bool unregisterPartitionedOutputBufferManager(
+    const std::shared_ptr<PartitionedOutputBufferManager>& manager);
 
 class HashJoinBridge;
 class IndexLookupJoinBridge;
@@ -1079,7 +1118,8 @@ class Task : public std::enable_shared_from_this<Task> {
   // kRunning state, but no more split groups are commit and all drivers
   // finished processing and all output has been consumed. In other words,
   // returns true if task should transition to kFinished state.
-  bool checkNoMoreSplitGroupsLocked();
+  bool checkNoMoreSplitGroupsLocked(
+      std::optional<uint32_t>& numPartitionedOutputDrivers);
 
   // Notifies listeners that the task is now complete.
   void onTaskCompletion();
@@ -1401,6 +1441,8 @@ class Task : public std::enable_shared_from_this<Task> {
   // Execution mode. In this case we will need to update the number of output
   // drivers in the end. False otherwise.
   bool groupedPartitionedOutput_{false};
+  std::shared_ptr<PartitionedOutputBufferManager>
+      partitionedOutputBufferManager_;
   // The number of splits groups we run concurrently.
   uint32_t concurrentSplitGroups_{1};
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/Task.h"
+#include <folly/ScopeGuard.h>
 #include "folly/synchronization/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
@@ -565,6 +566,174 @@ class TaskTest : public HiveConnectorTestBase {
     return {task, results};
   }
 };
+
+namespace {
+
+struct TestOutputManagerState {
+  std::atomic_int supportsCalls{0};
+  std::atomic_int initializeCalls{0};
+  std::atomic_int updateBuffersCalls{0};
+  std::atomic_int updateDriversCalls{0};
+  std::atomic_int statsCalls{0};
+  std::atomic_int removeCalls{0};
+  std::atomic_int initialDrivers{0};
+  std::atomic_int lastDrivers{0};
+  std::atomic_int lastBuffers{0};
+  std::atomic_int sequence{0};
+  std::atomic_int statsSequence{0};
+  std::atomic_int removeSequence{0};
+  std::atomic_bool noMoreBuffers{false};
+};
+
+class TestOutputManager final : public PartitionedOutputBufferManager {
+ public:
+  explicit TestOutputManager(std::shared_ptr<TestOutputManagerState> state)
+      : state_(std::move(state)) {}
+
+  bool supports(const core::PartitionedOutputNode&, const core::QueryConfig&)
+      const override {
+    ++state_->supportsCalls;
+    return true;
+  }
+
+  void initializeTask(
+      std::shared_ptr<Task>,
+      core::PartitionedOutputNode::Kind,
+      int,
+      int numOutputDrivers) override {
+    ++state_->initializeCalls;
+    state_->initialDrivers = numOutputDrivers;
+  }
+
+  void updateOutputBuffers(
+      const std::string&,
+      int numBuffers,
+      bool noMoreBuffers) override {
+    ++state_->updateBuffersCalls;
+    state_->lastBuffers = numBuffers;
+    state_->noMoreBuffers = noMoreBuffers;
+  }
+
+  void updateNumDrivers(const std::string&, uint32_t numOutputDrivers)
+      override {
+    ++state_->updateDriversCalls;
+    state_->lastDrivers = numOutputDrivers;
+  }
+
+  std::optional<OutputBuffer::Stats> stats(const std::string&) override {
+    ++state_->statsCalls;
+    state_->statsSequence = ++state_->sequence;
+    return OutputBuffer::Stats(
+        core::PartitionedOutputNode::Kind::kBroadcast,
+        true,
+        true,
+        true,
+        0,
+        0,
+        123,
+        456,
+        7,
+        0,
+        0,
+        {});
+  }
+
+  void removeTask(const std::string&) override {
+    ++state_->removeCalls;
+    state_->removeSequence = ++state_->sequence;
+  }
+
+ private:
+  const std::shared_ptr<TestOutputManagerState> state_;
+};
+
+} // namespace
+
+TEST_F(TaskTest, partitionedOutputManagerLifecycle) {
+  auto state = std::make_shared<TestOutputManagerState>();
+  auto manager = std::make_shared<TestOutputManager>(state);
+  ASSERT_TRUE(registerPartitionedOutputBufferManager(manager));
+  ASSERT_FALSE(registerPartitionedOutputBufferManager(manager));
+  auto unregister = folly::makeGuard(
+      [&]() { unregisterPartitionedOutputBufferManager(manager); });
+
+  auto plan = PlanBuilder()
+                  .tableScan(ROW({"c0"}, {BIGINT()}))
+                  .partitionedOutputBroadcast()
+                  .planFragment();
+  auto task = Task::create(
+      "partitioned-output-manager-lifecycle",
+      std::move(plan),
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel,
+      Consumer{});
+  task->start(2, 1);
+
+  EXPECT_EQ(state->supportsCalls, 1);
+  EXPECT_EQ(state->initializeCalls, 1);
+  EXPECT_EQ(state->initialDrivers, 2);
+  EXPECT_TRUE(task->updateOutputBuffers(3, true));
+  EXPECT_EQ(state->updateBuffersCalls, 1);
+  EXPECT_EQ(state->lastBuffers, 3);
+  EXPECT_TRUE(state->noMoreBuffers);
+
+  task->requestAbort().wait();
+  EXPECT_EQ(state->statsCalls, 1);
+  EXPECT_EQ(state->removeCalls, 1);
+  EXPECT_LT(state->statsSequence, state->removeSequence);
+  const auto stats = task->taskStats().outputBufferStats;
+  ASSERT_TRUE(stats.has_value());
+  EXPECT_EQ(stats->totalBytesSent, 123);
+  EXPECT_EQ(stats->totalRowsSent, 456);
+  EXPECT_EQ(stats->totalPagesSent, 7);
+
+  task->requestAbort().wait();
+  EXPECT_EQ(state->removeCalls, 1);
+  EXPECT_TRUE(unregisterPartitionedOutputBufferManager(manager));
+  unregister.dismiss();
+  EXPECT_FALSE(unregisterPartitionedOutputBufferManager(manager));
+}
+
+TEST_F(TaskTest, groupedPartitionedOutputUpdatesManagerDriverCount) {
+  auto state = std::make_shared<TestOutputManagerState>();
+  auto manager = std::make_shared<TestOutputManager>(state);
+  ASSERT_TRUE(registerPartitionedOutputBufferManager(manager));
+  auto unregister = folly::makeGuard(
+      [&]() { unregisterPartitionedOutputBufferManager(manager); });
+
+  auto data = makeRowVector({makeFlatVector<int64_t>({1})});
+  auto file = TempFilePath::create();
+  writeToFile(file->getPath(), data);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .partitionedOutput({}, 1)
+                  .planFragment();
+  plan.executionStrategy = core::ExecutionStrategy::kGrouped;
+  plan.groupedExecutionLeafNodeIds.emplace(scanNodeId);
+  plan.numSplitGroups = 4;
+  auto task = Task::create(
+      "grouped-partitioned-output-manager",
+      std::move(plan),
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel,
+      Consumer{});
+  task->start(2, 1);
+  EXPECT_EQ(state->initialDrivers, 8);
+
+  task->addSplit(
+      scanNodeId, exec::Split(makeHiveConnectorSplit(file->getPath()), 3));
+  task->noMoreSplitsForGroup(scanNodeId, 3);
+  task->noMoreSplits(scanNodeId);
+
+  EXPECT_GE(state->updateDriversCalls, 1);
+  EXPECT_EQ(state->lastDrivers, 2);
+  task->requestAbort().wait();
+}
 
 TEST_F(TaskTest, toJson) {
   auto plan = PlanBuilder()

--- a/velox/experimental/cudf/CMakeLists.txt
+++ b/velox/experimental/cudf/CMakeLists.txt
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Velox cuDF targets link NVTX directly. Do not rely on cuDF or RMM to expose
+# their directory-scoped imported target to this directory.
+find_package(nvtx3 REQUIRED)
+
 add_subdirectory(connectors)
 add_subdirectory(exec)
 add_subdirectory(expression)

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -45,6 +45,8 @@ struct CudfConfig {
   static constexpr const char* kCudfLogFallback{"cudf.log_fallback"};
   static constexpr const char* kCudfBatchSizeMinThreshold{
       "cudf.batch_size_min_threshold"};
+  static constexpr const char* kCudfBatchSizeMinThresholdBytes{
+      "cudf.batch_size_min_threshold_bytes"};
   static constexpr const char* kCudfBatchSizeMaxThreshold{
       "cudf.batch_size_max_threshold"};
   static constexpr const char* kCudfConcatOptimizationEnabled{
@@ -168,6 +170,11 @@ struct CudfConfig {
   /// Minimum rows to accumulate before GPU-side concatenation in
   /// `CudfBatchConcat` (default 100k).
   int32_t batchSizeMinThreshold{100000};
+
+  /// Target bytes to accumulate before GPU-side concatenation. Zero disables
+  /// the byte threshold. When both row and byte thresholds are configured,
+  /// reaching either one flushes the batch.
+  uint64_t batchSizeMinThresholdBytes{0};
 
   /// Maximum rows allowed in a concatenated batch (user configurable).
   /// When not set, cuDF's own `size_type::max()` is used.

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -45,6 +45,8 @@ struct CudfConfig {
   static constexpr const char* kCudfLogFallback{"cudf.log_fallback"};
   static constexpr const char* kCudfBatchSizeMinThreshold{
       "cudf.batch_size_min_threshold"};
+  static constexpr const char* kCudfExchangeBatchSizeMinThreshold{
+      "cudf.exchange_batch_size_min_threshold"};
   static constexpr const char* kCudfBatchSizeMinThresholdBytes{
       "cudf.batch_size_min_threshold_bytes"};
   static constexpr const char* kCudfBatchSizeMaxThreshold{
@@ -59,6 +61,12 @@ struct CudfConfig {
       "cudf.order_by_merge_fan_in"};
   static constexpr const char* kCudfWindowSortedRunBytes{
       "cudf.window.sorted_run_bytes"};
+  static constexpr const char* kCudfOrderByOutputChunkBytes{
+      "cudf.order_by_output_chunk_bytes"};
+  static constexpr const char* kCudfOrderByMaxOutputRows{
+      "cudf.order_by_max_output_rows"};
+  static constexpr const char* kCudfExchangeConcatOptimizationEnabled{
+      "cudf.exchange_concat_optimization_enabled"};
   static constexpr const char* kCudfTimestampUnit{"cudf.timestamp_unit"};
   // The value could be either spark or presto.
   static constexpr const char* kCudfFunctionEngine{"cudf.function_engine"};
@@ -107,7 +115,7 @@ struct CudfConfig {
   std::string memoryResource{"async"};
 
   /// The initial percent of GPU memory to allocate for pool or arena memory
-  /// resources.
+  /// resources, and the retained-memory release threshold for async.
   int32_t memoryPercent{50};
 
   /// Memory resource for output vectors. When set to a value different from
@@ -142,8 +150,7 @@ struct CudfConfig {
   /// Whether to log a reason for falling back to Velox CPU execution.
   bool logFallback{true};
 
-  /// Whether to insert CudfBatchConcat operators before supported Cudf
-  /// operators.
+  /// Whether to insert CudfBatchConcat before supported Cudf operators.
   /// This can improve performance by reducing the number of cuda kernel
   /// launches on addInput of certain operators by collecting a minimum number
   /// of rows before concatenating and passing on to the next operator.
@@ -167,9 +174,18 @@ struct CudfConfig {
   /// independently sorted run.
   uint64_t windowSortedRunBytes{3ULL << 30};
 
+  /// Maximum bytes and rows returned by one OrderBy output batch.
+  uint64_t orderByOutputChunkBytes{32ULL << 20};
+  int32_t orderByMaxOutputRows{262144};
+
   /// Minimum rows to accumulate before GPU-side concatenation in
   /// `CudfBatchConcat` (default 100k).
   int32_t batchSizeMinThreshold{100000};
+
+  /// Target rows for CudfBatchConcat immediately after a UCX Exchange. Keep
+  /// this below the aggregation target because a fragment can buffer several
+  /// inbound exchanges concurrently while its join builds are still live.
+  int32_t exchangeBatchSizeMinThreshold{32000000};
 
   /// Target bytes to accumulate before GPU-side concatenation. Zero disables
   /// the byte threshold. When both row and byte thresholds are configured,
@@ -202,6 +218,12 @@ struct CudfConfig {
 
   /// VLOG level for ucx-exchange source files.
   int32_t exchangeLogLevel{0};
+
+  /// Whether to insert CudfBatchConcat immediately after ordinary UCX
+  /// Exchange sources. Keep this independent from aggregation-side concat.
+  /// This field is intentionally appended so incremental builds that reuse
+  /// stable UCX objects preserve the offsets of every pre-existing field.
+  bool exchangeConcatOptimizationEnabled{true};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfAggregation.h
+++ b/velox/experimental/cudf/exec/CudfAggregation.h
@@ -119,7 +119,9 @@ bool isCountFunctionName(std::string_view kind);
 bool hasOnlyConstantArguments(const core::CallTypedExpr& call);
 
 // Returns true if the aggregation node contains companion aggregates
-// (e.g. _merge, _partial, _merge_extract suffixes), which disables streaming.
+// (e.g. _merge, _partial, _merge_extract suffixes). Kept for callers that need
+// to inspect the external plan shape; CudfGroupby streaming supports companion
+// aggregates by forcing its internal compaction step to kIntermediate.
 bool hasCompanionAggregates(
     std::vector<core::AggregationNode::Aggregate> const& aggregates);
 

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -266,8 +266,7 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
 }
 
 bool CudfBatchConcat::isFinished() {
-  const bool finished =
-      noMoreInput_ && buffer_.empty() && outputQueue_.empty();
+  const bool finished = noMoreInput_ && buffer_.empty() && outputQueue_.empty();
   if (finished && !summaryLogged_ && logConcatConfig()) {
     summaryLogged_ = true;
     LOG(WARNING) << "CudfBatchConcat summary planNode=" << planNodeId()

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -21,6 +21,7 @@
 #include "velox/experimental/cudf/exec/Utilities.h"
 
 #include <cstdlib>
+#include <limits>
 #include <string_view>
 #include <utility>
 
@@ -59,6 +60,25 @@ RowTypePtr getConcatOutputType(
   return planNode->sources()[0]->outputType();
 }
 
+size_t checkedConcatTargetRows(int32_t targetRows) {
+  VELOX_CHECK_GT(
+      targetRows, 0, "CudfBatchConcat target row count must be positive");
+  return static_cast<size_t>(targetRows);
+}
+
+int32_t queryConcatTargetRows(exec::DriverCtx* driverCtx) {
+  const auto targetRows = concatThreshold(
+      driverCtx,
+      CudfConfig::kCudfBatchSizeMinThreshold,
+      "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_ROWS",
+      CudfConfig::getInstance().batchSizeMinThreshold);
+  VELOX_CHECK_LE(
+      targetRows,
+      static_cast<uint64_t>(std::numeric_limits<int32_t>::max()),
+      "CudfBatchConcat target row count exceeds INT32_MAX");
+  return static_cast<int32_t>(targetRows);
+}
+
 std::string getAggregationStep(
     const std::shared_ptr<const core::PlanNode>& planNode) {
   const auto aggregation =
@@ -78,10 +98,34 @@ CudfBatchConcat::CudfBatchConcat(
     int32_t operatorId,
     exec::DriverCtx* driverCtx,
     std::shared_ptr<const core::PlanNode> planNode)
+    : CudfBatchConcat(
+          operatorId,
+          driverCtx,
+          planNode,
+          getConcatOutputType(planNode)) {}
+
+CudfBatchConcat::CudfBatchConcat(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::PlanNode> planNode,
+    RowTypePtr outputType)
+    : CudfBatchConcat(
+          operatorId,
+          driverCtx,
+          planNode,
+          std::move(outputType),
+          queryConcatTargetRows(driverCtx)) {}
+
+CudfBatchConcat::CudfBatchConcat(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::PlanNode> planNode,
+    RowTypePtr outputType,
+    int32_t targetRows)
     : CudfOperatorBase(
           operatorId,
           driverCtx,
-          getConcatOutputType(planNode),
+          std::move(outputType),
           planNode->id(),
           "CudfBatchConcat",
           nvtx3::rgb{211, 211, 211}, /* LightGrey */
@@ -90,11 +134,7 @@ CudfBatchConcat::CudfBatchConcat(
           planNode),
       driverCtx_(driverCtx),
       aggregationStep_(getAggregationStep(planNode)),
-      targetRows_(concatThreshold(
-          driverCtx,
-          CudfConfig::kCudfBatchSizeMinThreshold,
-          "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_ROWS",
-          CudfConfig::getInstance().batchSizeMinThreshold)),
+      targetRows_(checkedConcatTargetRows(targetRows)),
       targetBytes_(concatThreshold(
           driverCtx,
           CudfConfig::kCudfBatchSizeMinThresholdBytes,
@@ -169,6 +209,18 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
       (currentNumRows_ >= targetRows_ ||
        (targetBytes_ != 0 && currentNumBytes_ >= targetBytes_) ||
        noMoreInput_)) {
+    // Preserve the zero-copy Exchange fast path when a single received batch
+    // already satisfies the target (or is the final tail batch). CudfVector
+    // carries its producing stream, so downstream operators can consume it
+    // directly without rebinding allocation ownership to another stream.
+    if (buffer_.size() == 1) {
+      auto output = std::move(buffer_.front());
+      buffer_.clear();
+      currentNumRows_ = 0;
+      currentNumBytes_ = 0;
+      ++outputBatches_;
+      return output;
+    }
     // Use stream from existing buffer vectors
     const auto outputStream = buffer_[0]->stream();
     auto outputVectors = getConcatenatedCudfVectorsBatched(

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -20,10 +20,35 @@
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
+#include <cstdlib>
+#include <string_view>
 #include <utility>
 
 namespace facebook::velox::cudf_velox {
 namespace {
+
+uint64_t concatThresholdFromEnv(const char* name, uint64_t fallback) {
+  if (const char* value = std::getenv(name)) {
+    try {
+      return std::stoull(value);
+    } catch (...) {
+    }
+  }
+  return fallback;
+}
+
+uint64_t concatThreshold(
+    exec::DriverCtx* driverCtx,
+    const char* configKey,
+    const char* envName,
+    uint64_t fallback) {
+  // Prefer the per-query value.  The process-wide CudfConfig is initialized
+  // before registration, but a long-lived executor can subsequently execute
+  // queries with different batch targets.
+  const auto configured =
+      driverCtx->queryConfig().get<uint64_t>(configKey, fallback);
+  return concatThresholdFromEnv(envName, configured);
+}
 
 RowTypePtr getConcatOutputType(
     const std::shared_ptr<const core::PlanNode>& planNode) {
@@ -32,6 +57,19 @@ RowTypePtr getConcatOutputType(
       1,
       "CudfBatchConcat expects a single-source plan node");
   return planNode->sources()[0]->outputType();
+}
+
+std::string getAggregationStep(
+    const std::shared_ptr<const core::PlanNode>& planNode) {
+  const auto aggregation =
+      std::dynamic_pointer_cast<const core::AggregationNode>(planNode);
+  return aggregation ? fmt::format("{}", aggregation->step()) : "UNKNOWN";
+}
+
+bool logConcatConfig() {
+  const auto* value = std::getenv("GLUTEN_CUDF_BATCH_CONCAT_LOG_CONFIG");
+  return value != nullptr && std::string_view(value) != "0" &&
+      std::string_view(value) != "false";
 }
 
 } // namespace
@@ -51,7 +89,28 @@ CudfBatchConcat::CudfBatchConcat(
           std::nullopt,
           planNode),
       driverCtx_(driverCtx),
-      targetRows_(CudfConfig::getInstance().batchSizeMinThreshold) {}
+      aggregationStep_(getAggregationStep(planNode)),
+      targetRows_(concatThreshold(
+          driverCtx,
+          CudfConfig::kCudfBatchSizeMinThreshold,
+          "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_ROWS",
+          CudfConfig::getInstance().batchSizeMinThreshold)),
+      targetBytes_(concatThreshold(
+          driverCtx,
+          CudfConfig::kCudfBatchSizeMinThresholdBytes,
+          "GLUTEN_CUDF_BATCH_SIZE_MIN_THRESHOLD_BYTES",
+          CudfConfig::getInstance().batchSizeMinThresholdBytes)) {
+  if (logConcatConfig()) {
+    LOG(WARNING) << "CudfBatchConcat configured targetRows=" << targetRows_
+                 << ", targetBytes=" << targetBytes_;
+  }
+}
+
+bool CudfBatchConcat::needsInput() const {
+  return !noMoreInput_ && outputQueue_.empty() &&
+      currentNumRows_ < targetRows_ &&
+      (targetBytes_ == 0 || currentNumBytes_ < targetBytes_);
+}
 
 void CudfBatchConcat::doAddInput(RowVectorPtr input) {
   auto cudfVector = std::dynamic_pointer_cast<CudfVector>(input);
@@ -62,8 +121,38 @@ void CudfBatchConcat::doAddInput(RowVectorPtr input) {
   }
 
   // Push input cudf table to buffer
+  ++inputBatches_;
+  totalInputRows_ += cudfVector->size();
+  totalInputBytes_ += cudfVector->estimateFlatSize();
   currentNumRows_ += cudfVector->size();
+  currentNumBytes_ += cudfVector->estimateFlatSize();
   buffer_.push_back(std::move(cudfVector));
+
+  // Enforce the bound here as well as in needsInput(). Source pipelines may
+  // have already scheduled another input before the driver observes the
+  // updated needsInput() result. Keeping a ready output in outputQueue_ makes
+  // the backpressure explicit and prevents scan batches from accumulating up
+  // to device capacity. Avoid a redundant D2D concatenate for one large input.
+  if (currentNumRows_ >= targetRows_ ||
+      (targetBytes_ != 0 && currentNumBytes_ >= targetBytes_)) {
+    if (buffer_.size() == 1) {
+      outputQueue_.push(std::move(buffer_.front()));
+      buffer_.clear();
+    } else {
+      const auto outputStream = buffer_.front()->stream();
+      auto outputVectors = getConcatenatedCudfVectorsBatched(
+          pool(),
+          std::exchange(buffer_, {}),
+          outputType_,
+          outputStream,
+          get_output_mr());
+      for (auto& output : outputVectors) {
+        outputQueue_.push(std::move(output));
+      }
+    }
+    currentNumRows_ = 0;
+    currentNumBytes_ = 0;
+  }
 }
 
 RowVectorPtr CudfBatchConcat::doGetOutput() {
@@ -71,11 +160,15 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
   if (!outputQueue_.empty()) {
     auto output = std::move(outputQueue_.front());
     outputQueue_.pop();
+    ++outputBatches_;
     return output;
   }
 
   // Merge tables if there are enough rows
-  if (!buffer_.empty() && (currentNumRows_ >= targetRows_ || noMoreInput_)) {
+  if (!buffer_.empty() &&
+      (currentNumRows_ >= targetRows_ ||
+       (targetBytes_ != 0 && currentNumBytes_ >= targetBytes_) ||
+       noMoreInput_)) {
     // Use stream from existing buffer vectors
     const auto outputStream = buffer_[0]->stream();
     auto outputVectors = getConcatenatedCudfVectorsBatched(
@@ -86,6 +179,7 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
         get_output_mr());
 
     currentNumRows_ = 0;
+    currentNumBytes_ = 0;
     VELOX_CHECK_GT(outputVectors.size(), 0);
 
     for (auto it = outputVectors.begin(); it + 1 != outputVectors.end(); ++it) {
@@ -97,8 +191,11 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
     auto& last = outputVectors.back();
     auto rowCount = last->size();
 
-    if (!noMoreInput_ && rowCount < targetRows_) {
+    const auto lastBytes = last->estimateFlatSize();
+    if (!noMoreInput_ && rowCount < targetRows_ &&
+        (targetBytes_ == 0 || lastBytes < targetBytes_)) {
       currentNumRows_ = rowCount;
+      currentNumBytes_ = lastBytes;
       buffer_.push_back(std::move(last));
     } else {
       outputQueue_.push(std::move(last));
@@ -108,6 +205,7 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
     if (!outputQueue_.empty()) {
       auto output = std::move(outputQueue_.front());
       outputQueue_.pop();
+      ++outputBatches_;
       return output;
     }
   }
@@ -116,7 +214,18 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
 }
 
 bool CudfBatchConcat::isFinished() {
-  return noMoreInput_ && buffer_.empty() && outputQueue_.empty();
+  const bool finished =
+      noMoreInput_ && buffer_.empty() && outputQueue_.empty();
+  if (finished && !summaryLogged_ && logConcatConfig()) {
+    summaryLogged_ = true;
+    LOG(WARNING) << "CudfBatchConcat summary planNode=" << planNodeId()
+                 << ", step=" << aggregationStep_
+                 << ", inputBatches=" << inputBatches_
+                 << ", outputBatches=" << outputBatches_
+                 << ", inputRows=" << totalInputRows_
+                 << ", inputBytes=" << totalInputBytes_;
+  }
+  return finished;
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -23,6 +23,7 @@
 #include "velox/exec/Operator.h"
 
 #include <queue>
+#include <string>
 
 namespace facebook::velox::cudf_velox {
 
@@ -33,10 +34,7 @@ class CudfBatchConcat : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::PlanNode> planNode);
 
-  bool needsInput() const override {
-    return !noMoreInput_ && outputQueue_.empty() &&
-        currentNumRows_ < targetRows_;
-  }
+  bool needsInput() const override;
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
     return exec::BlockingReason::kNotBlocked;
@@ -50,10 +48,18 @@ class CudfBatchConcat : public CudfOperatorBase {
 
  private:
   exec::DriverCtx* const driverCtx_;
+  const std::string aggregationStep_;
   std::vector<CudfVectorPtr> buffer_;
   std::queue<CudfVectorPtr> outputQueue_;
+  uint64_t totalInputRows_{0};
+  uint64_t totalInputBytes_{0};
+  uint64_t inputBatches_{0};
+  uint64_t outputBatches_{0};
   size_t currentNumRows_{0};
+  uint64_t currentNumBytes_{0};
   const size_t targetRows_{0};
+  const uint64_t targetBytes_{0};
+  bool summaryLogged_{false};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -34,6 +34,19 @@ class CudfBatchConcat : public CudfOperatorBase {
       exec::DriverCtx* driverCtx,
       std::shared_ptr<const core::PlanNode> planNode);
 
+  CudfBatchConcat(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const core::PlanNode> planNode,
+      RowTypePtr outputType);
+
+  CudfBatchConcat(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const core::PlanNode> planNode,
+      RowTypePtr outputType,
+      int32_t targetRows);
+
   bool needsInput() const override;
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -40,7 +40,9 @@
 #include <cudf/reduction.hpp>
 #include <cudf/unary.hpp>
 
+#include <cstdlib>
 #include <limits>
+#include <mutex>
 
 namespace {
 
@@ -75,6 +77,55 @@ constexpr const char* kFinalStreamingOutputRows =
     "cudfFinalStreamingOutputRows";
 constexpr const char* kFinalStreamingFallbackProbeColumnsReleased =
     "cudfFinalStreamingFallbackProbeColumnsReleased";
+constexpr const char* kIntermediateAggregationInputRuns =
+    "cudfIntermediateAggregationInputRuns";
+constexpr const char* kIntermediateAggregationRunMerges =
+    "cudfIntermediateAggregationRunMerges";
+constexpr const char* kIntermediateAggregationFinalizeMerges =
+    "cudfIntermediateAggregationFinalizeMerges";
+constexpr const char* kIntermediateAggregationMergeRows =
+    "cudfIntermediateAggregationMergeRows";
+constexpr const char* kIntermediateAggregationMergeBytes =
+    "cudfIntermediateAggregationMergeBytes";
+constexpr const char* kIntermediateAggregationMaxLevel =
+    "cudfIntermediateAggregationMaxLevel";
+constexpr const char* kIntermediateAggregationSerializedMerges =
+    "cudfIntermediateAggregationSerializedMerges";
+
+bool serializeLargeIntermediateAggregationMergesEnabled() {
+  static const bool enabled = [] {
+    const auto* value = std::getenv("GLUTEN_CUDF_SERIALIZE_LARGE_FINAL_AGG");
+    if (value == nullptr) {
+      return false;
+    }
+    const std::string_view setting{value};
+    return !setting.empty() && setting != "0" && setting != "false" &&
+        setting != "off" && setting != "no";
+  }();
+  return enabled;
+}
+
+uint64_t largeIntermediateAggregationSerializeBytes() {
+  static const uint64_t threshold = []() -> uint64_t {
+    constexpr uint64_t kDefaultThreshold = 8ULL << 30;
+    const auto* value =
+        std::getenv("GLUTEN_CUDF_LARGE_FINAL_AGG_SERIALIZE_BYTES");
+    if (value == nullptr || *value == '\0') {
+      return kDefaultThreshold;
+    }
+    char* end = nullptr;
+    const auto parsed = std::strtoull(value, &end, 10);
+    return end != value && *end == '\0' && parsed > 0
+        ? static_cast<uint64_t>(parsed)
+        : kDefaultThreshold;
+  }();
+  return threshold;
+}
+
+std::mutex& largeIntermediateAggregationMutex() {
+  static std::mutex mutex;
+  return mutex;
+}
 
 size_t aggregationRunLevel(uint64_t representedRows) {
   VELOX_CHECK_GT(representedRows, 0);
@@ -1167,9 +1218,7 @@ void CudfGroupby::initialize() {
 }
 
 void CudfGroupby::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
-  // For every input, we'll do a groupby and compact results with the existing
-  // intermediate groupby results.
-
+  const auto representedRows = static_cast<uint64_t>(tbl->size());
   auto inputTableStream = tbl->stream();
   // Use getTableView() to avoid expensive materialization for packed_table.
   // tbl stays alive during this function call, keeping the view valid.
@@ -1189,38 +1238,10 @@ void CudfGroupby::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
       inputTableStream,
       get_output_mr());
 
-  // An all-null key batch with ignoreNullKeys enabled has no partial state to
-  // merge. Preserve any state accumulated from earlier batches.
-  if (!groupbyOnInput) {
-    return;
-  }
-
-  // If we already have partial output, concatenate the new results with it.
-  if (bufferedResult_) {
-    auto partialOutputStream = bufferedResult_->stream();
-    std::vector<CudfVectorPtr> tablesToConcat;
-    tablesToConcat.push_back(std::exchange(bufferedResult_, nullptr));
-    tablesToConcat.push_back(std::move(groupbyOnInput));
-    auto concatenatedTable = getConcatenatedTable(
-        std::move(tablesToConcat),
-        bufferedResultType_,
-        partialOutputStream,
-        get_temp_mr());
-
-    // Now we have to groupby again but this time with intermediate aggregators.
-    // Keep concatenatedTable alive while we use its view.
-    auto compactedOutput = doGroupByAggregation(
-        concatenatedTable->view(),
-        groupingKeyOutputChannels_,
-        intermediateAggregators_,
-        bufferedResultType_,
-        partialOutputStream,
-        get_output_mr());
-    bufferedResult_ = compactedOutput;
-  } else {
-    // First time processing, just store the result of the input batch's groupby
-    // This means we're storing the stream from the first batch.
-    bufferedResult_ = groupbyOnInput;
+  if (groupbyOnInput) {
+    addIntermediateAggregationRun(
+        IntermediateAggregationRun{
+            std::move(groupbyOnInput), representedRows});
   }
 }
 
@@ -1645,6 +1666,7 @@ CudfVectorPtr CudfGroupby::finalizeStreamingFinalAggregation() {
 }
 
 void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
+  const auto representedRows = static_cast<uint64_t>(tbl->size());
   auto inputTableStream = tbl->stream();
   auto preparedInput = prepareAggregationInput(
       tbl->getTableView(),
@@ -1662,34 +1684,182 @@ void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
       inputTableStream,
       get_output_mr());
 
-  // An all-null key batch with ignoreNullKeys enabled has no partial state to
-  // merge. Preserve any state accumulated from earlier batches.
-  if (!groupbyOnInput) {
-    return;
+  if (groupbyOnInput) {
+    addIntermediateAggregationRun(
+        IntermediateAggregationRun{
+            std::move(groupbyOnInput), representedRows});
+  }
+}
+
+void CudfGroupby::addIntermediateAggregationRun(
+    IntermediateAggregationRun run) {
+  VELOX_CHECK_NOT_NULL(run.data);
+  VELOX_CHECK_GT(run.representedRows, 0);
+  ++intermediateInputRunCount_;
+
+  auto level = aggregationRunLevel(run.representedRows);
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationInputRuns, RuntimeCounter(1));
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationMaxLevel,
+        RuntimeCounter(static_cast<int64_t>(level)));
   }
 
-  if (bufferedResult_) {
-    auto partialOutputStream = bufferedResult_->stream();
-    std::vector<CudfVectorPtr> tablesToConcat;
-    tablesToConcat.push_back(std::exchange(bufferedResult_, nullptr));
-    tablesToConcat.push_back(std::move(groupbyOnInput));
-    auto concatenatedTable = getConcatenatedTable(
-        std::move(tablesToConcat),
-        bufferedResultType_,
-        partialOutputStream,
-        get_temp_mr());
+  for (;;) {
+    if (intermediateRunLevels_.size() <= level) {
+      intermediateRunLevels_.resize(level + 1);
+    }
+    if (!intermediateRunLevels_[level].has_value()) {
+      intermediateBufferedBytes_ += run.data->estimateFlatSize();
+      intermediateRunLevels_[level] = std::move(run);
+      return;
+    }
 
-    auto compactedOutput = doGroupByAggregation(
-        concatenatedTable->view(),
-        groupingKeyOutputChannels_,
-        intermediateAggregators_,
-        bufferedResultType_,
-        partialOutputStream,
-        get_output_mr());
-    bufferedResult_ = compactedOutput;
-  } else {
-    bufferedResult_ = groupbyOnInput;
+    auto peer = std::move(*intermediateRunLevels_[level]);
+    intermediateRunLevels_[level].reset();
+    const auto peerBytes = peer.data->estimateFlatSize();
+    VELOX_CHECK_GE(intermediateBufferedBytes_, peerBytes);
+    intermediateBufferedBytes_ -= peerBytes;
+
+    const auto representedRows =
+        addRepresentedRows(peer.representedRows, run.representedRows);
+    auto outputLevel = aggregationRunLevel(representedRows);
+    outputLevel = std::max(outputLevel, level + 1);
+    run = mergeIntermediateAggregationRuns(
+        std::move(peer), std::move(run), outputLevel, false);
+    level = outputLevel;
   }
+}
+
+CudfGroupby::IntermediateAggregationRun
+CudfGroupby::mergeIntermediateAggregationRuns(
+    IntermediateAggregationRun left,
+    IntermediateAggregationRun right,
+    size_t outputLevel,
+    bool finalizing) {
+  VELOX_CHECK_NOT_NULL(left.data);
+  VELOX_CHECK_NOT_NULL(right.data);
+  VELOX_CHECK(left.data->stream().value() == stateStream_.value());
+  VELOX_CHECK(right.data->stream().value() == stateStream_.value());
+
+  const auto inputRows = static_cast<int64_t>(left.data->size()) +
+      static_cast<int64_t>(right.data->size());
+  const auto inputBytes =
+      left.data->estimateFlatSize() + right.data->estimateFlatSize();
+  VELOX_CHECK_LE(
+      inputBytes, static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+  const auto representedRows =
+      addRepresentedRows(left.representedRows, right.representedRows);
+  // The pre-rebase MPP path deliberately serialized very large merge kernels
+  // within an executor. Four local aggregation drivers otherwise launch
+  // multi-GiB concatenate and groupby operations concurrently on the same
+  // GPU, increasing both peak memory and Q18 latency. Retain that behavior for
+  // PARTIAL/SINGLE runs while leaving the new FINAL streaming state untouched.
+  const bool serializeLargeMerge =
+      serializeLargeIntermediateAggregationMergesEnabled() &&
+      inputBytes >= largeIntermediateAggregationSerializeBytes();
+  std::unique_lock<std::mutex> largeMergeLock;
+  if (serializeLargeMerge) {
+    largeMergeLock = std::unique_lock<std::mutex>{
+        largeIntermediateAggregationMutex()};
+    stateStream_.synchronize();
+  }
+
+  std::vector<CudfVectorPtr> inputs;
+  inputs.reserve(2);
+  inputs.push_back(std::move(left.data));
+  inputs.push_back(std::move(right.data));
+  auto concatenated = getConcatenatedTable(
+      std::move(inputs), bufferedResultType_, stateStream_, get_temp_mr());
+  auto output = doGroupByAggregation(
+      concatenated->view(),
+      groupingKeyOutputChannels_,
+      intermediateAggregators_,
+      bufferedResultType_,
+      stateStream_,
+      get_output_mr());
+  VELOX_CHECK_NOT_NULL(output);
+  if (serializeLargeMerge) {
+    // Complete the merge and release its temporary concatenation before the
+    // next local driver enters the large-merge section.
+    concatenated.reset();
+    stateStream_.synchronize();
+  }
+
+  ++intermediateRunMergeCount_;
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationRunMerges, RuntimeCounter(1));
+    if (finalizing) {
+      lockedStats->addRuntimeStat(
+          kIntermediateAggregationFinalizeMerges, RuntimeCounter(1));
+    }
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationMergeRows, RuntimeCounter(inputRows));
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationMergeBytes,
+        RuntimeCounter(static_cast<int64_t>(inputBytes)));
+    lockedStats->addRuntimeStat(
+        kIntermediateAggregationMaxLevel,
+        RuntimeCounter(static_cast<int64_t>(outputLevel)));
+    if (serializeLargeMerge) {
+      lockedStats->addRuntimeStat(
+          kIntermediateAggregationSerializedMerges, RuntimeCounter(1));
+    }
+  }
+
+  if (deviceMemoryDiagnosticsEnabled() &&
+      (finalizing || intermediateRunMergeCount_ == 1 ||
+       intermediateRunMergeCount_ % 64 == 0)) {
+    logDeviceMemorySnapshot(
+        fmt::format(
+            "operator=CudfGroupby node={} state=intermediate_run.merge "
+            "phase={} level={} merge={} inputRows={} inputBytes={} "
+            "outputRows={} outputBytes={} representedRows={}",
+            diagnosticNodeId_,
+            finalizing ? "finalize" : "online",
+            outputLevel,
+            intermediateRunMergeCount_,
+            inputRows,
+            inputBytes,
+            output->size(),
+            output->estimateFlatSize(),
+            representedRows));
+  }
+
+  return IntermediateAggregationRun{std::move(output), representedRows};
+}
+
+CudfVectorPtr CudfGroupby::drainIntermediateAggregationRuns() {
+  std::optional<IntermediateAggregationRun> carry;
+  for (auto& level : intermediateRunLevels_) {
+    if (!level.has_value()) {
+      continue;
+    }
+    auto run = std::move(*level);
+    level.reset();
+    if (!carry.has_value()) {
+      carry = std::move(run);
+      continue;
+    }
+    const auto representedRows =
+        addRepresentedRows(carry->representedRows, run.representedRows);
+    carry = mergeIntermediateAggregationRuns(
+        std::move(*carry),
+        std::move(run),
+        aggregationRunLevel(representedRows),
+        true);
+  }
+  intermediateRunLevels_.clear();
+  intermediateBufferedBytes_ = 0;
+
+  if (!carry.has_value()) {
+    return nullptr;
+  }
+  return std::move(carry->data);
 }
 
 void CudfGroupby::prepareInputForStateStream(const CudfVectorPtr& input) {
@@ -1716,7 +1886,7 @@ void CudfGroupby::doAddInput(RowVectorPtr input) {
   VELOX_CHECK_NOT_NULL(cudfInput);
   input.reset();
 
-  if (!isPartialOutput_ && !isSingleStep_) {
+  if (streamingEnabled_) {
     prepareInputForStateStream(cudfInput);
   }
 
@@ -1814,17 +1984,22 @@ CudfVectorPtr CudfGroupby::releaseAndResetBufferedResult() {
 RowVectorPtr CudfGroupby::doGetOutput() {
   // Handle partial streaming groupby.
   if (isPartialOutput_ && streamingEnabled_) {
-    if (bufferedResult_ &&
-        bufferedResult_->estimateFlatSize() >
-            maxPartialAggregationMemoryUsage_) {
+    if (!bufferedResult_ && maxPartialAggregationMemoryUsage_ > 0 &&
+        intermediateBufferedBytes_ >
+            static_cast<uint64_t>(maxPartialAggregationMemoryUsage_)) {
+      bufferedResult_ = drainIntermediateAggregationRuns();
+    }
+    if (bufferedResult_) {
       return releaseAndResetBufferedResult();
     }
-    if (not noMoreInput_) {
+    if (!noMoreInput_) {
       // Don't produce output if the partial output hasn't reached memory limit
       // and there's more batches to come.
       return nullptr;
     }
-    if (!bufferedResult_ && finished_) {
+    bufferedResult_ = drainIntermediateAggregationRuns();
+    if (!bufferedResult_) {
+      finished_ = true;
       return nullptr;
     }
     return releaseAndResetBufferedResult();
@@ -1845,6 +2020,9 @@ RowVectorPtr CudfGroupby::doGetOutput() {
   // At this point isPartialOutput_ is false (handled above) and noMoreInput_
   // is true (guarded by the check above).
   if (streamingEnabled_) {
+    if (isSingleStep_ && !bufferedResult_) {
+      bufferedResult_ = drainIntermediateAggregationRuns();
+    }
     if (!isPartialOutput_ && !isSingleStep_ &&
         finalAggregationMode_ == FinalAggregationMode::kStreaming) {
       finished_ = true;
@@ -1940,6 +2118,8 @@ void CudfGroupby::doClose() {
   }
   finalStreamingGroupby_.reset();
   finalStreamingRequestAggregationCounts_.clear();
+  intermediateRunLevels_.clear();
+  intermediateBufferedBytes_ = 0;
   finalRunLevels_.clear();
   bufferedResult_.reset();
   inputs_.clear();

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -1240,8 +1240,7 @@ void CudfGroupby::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
 
   if (groupbyOnInput) {
     addIntermediateAggregationRun(
-        IntermediateAggregationRun{
-            std::move(groupbyOnInput), representedRows});
+        IntermediateAggregationRun{std::move(groupbyOnInput), representedRows});
   }
 }
 
@@ -1686,8 +1685,7 @@ void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
 
   if (groupbyOnInput) {
     addIntermediateAggregationRun(
-        IntermediateAggregationRun{
-            std::move(groupbyOnInput), representedRows});
+        IntermediateAggregationRun{std::move(groupbyOnInput), representedRows});
   }
 }
 
@@ -1762,8 +1760,8 @@ CudfGroupby::mergeIntermediateAggregationRuns(
       inputBytes >= largeIntermediateAggregationSerializeBytes();
   std::unique_lock<std::mutex> largeMergeLock;
   if (serializeLargeMerge) {
-    largeMergeLock = std::unique_lock<std::mutex>{
-        largeIntermediateAggregationMutex()};
+    largeMergeLock =
+        std::unique_lock<std::mutex>{largeIntermediateAggregationMutex()};
     stateStream_.synchronize();
   }
 

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -1093,13 +1093,23 @@ void CudfGroupby::initialize() {
       aggregationNode_->step(),
       outputType_,
       aggregationInput.constants);
-  // The old blanket companion-aggregate guard forced every input batch into
-  // inputs_ until noMoreInput(). Large MPP final aggregates consequently
-  // retained several GiB of materialized exchange pages per
-  // executor. Companion suffixes describe the external Spark plan step; for
-  // streaming compaction we explicitly force the internal intermediate step
-  // below, so these aggregates can be compacted incrementally as well.
-  streamingEnabled_ = true;
+  // Companion names encode their effective aggregation step. Streaming is
+  // safe when that step agrees with the plan node: each input batch can then
+  // be compacted using the intermediate aggregators and finalized normally.
+  // Mixed companion plans intentionally keep the legacy path because forcing
+  // e.g. count_partial in a single-step node through an intermediate merge
+  // would count partial rows instead of merging their states. Empty grouping
+  // keys also keep the legacy path because cuDF's groupby primitive requires
+  // a key column; global aggregation is handled correctly by the old path.
+  streamingEnabled_ = !aggregationNode_->groupingKeys().empty() &&
+      std::all_of(
+          aggregationNode_->aggregates().begin(),
+          aggregationNode_->aggregates().end(),
+          [&](const auto& aggregate) {
+            return getCompanionStep(
+                       aggregate.call->name(), aggregationNode_->step()) ==
+                aggregationNode_->step();
+          });
 
   if (deviceMemoryDiagnosticsEnabled()) {
     for (const auto& aggregate : aggregationNode_->aggregates()) {
@@ -1178,6 +1188,12 @@ void CudfGroupby::computePartialGroupbyStreaming(CudfVectorPtr tbl) {
       bufferedResultType_,
       inputTableStream,
       get_output_mr());
+
+  // An all-null key batch with ignoreNullKeys enabled has no partial state to
+  // merge. Preserve any state accumulated from earlier batches.
+  if (!groupbyOnInput) {
+    return;
+  }
 
   // If we already have partial output, concatenate the new results with it.
   if (bufferedResult_) {
@@ -1645,6 +1661,12 @@ void CudfGroupby::computeSingleGroupbyStreaming(CudfVectorPtr tbl) {
       bufferedResultType_,
       inputTableStream,
       get_output_mr());
+
+  // An all-null key batch with ignoreNullKeys enabled has no partial state to
+  // merge. Preserve any state accumulated from earlier batches.
+  if (!groupbyOnInput) {
+    return;
+  }
 
   if (bufferedResult_) {
     auto partialOutputStream = bufferedResult_->stream();

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -125,6 +125,11 @@ class CudfGroupby : public CudfOperatorBase {
     uint64_t representedRows;
   };
 
+  struct IntermediateAggregationRun {
+    CudfVectorPtr data;
+    uint64_t representedRows;
+  };
+
   CudfVectorPtr doGroupByAggregation(
       cudf::table_view tableView,
       std::vector<column_index_t> const& groupByKeys,
@@ -140,6 +145,14 @@ class CudfGroupby : public CudfOperatorBase {
   void computePartialGroupbyStreaming(CudfVectorPtr tbl);
   void computeFinalGroupbyStreaming(CudfVectorPtr tbl);
   void computeSingleGroupbyStreaming(CudfVectorPtr tbl);
+
+  void addIntermediateAggregationRun(IntermediateAggregationRun run);
+  IntermediateAggregationRun mergeIntermediateAggregationRuns(
+      IntermediateAggregationRun left,
+      IntermediateAggregationRun right,
+      size_t outputLevel,
+      bool finalizing);
+  CudfVectorPtr drainIntermediateAggregationRuns();
 
   void addFinalAggregationRun(FinalAggregationRun run);
   FinalAggregationRun mergeFinalAggregationRuns(
@@ -184,6 +197,17 @@ class CudfGroupby : public CudfOperatorBase {
   TypePtr inputType_;
   RowTypePtr bufferedResultType_;
   CudfVectorPtr bufferedResult_;
+
+  // PARTIAL and SINGLE aggregation produce one compacted state per input
+  // page. Keep those states in logarithmic size levels and merge only peers
+  // of comparable weight. This avoids regrouping the complete accumulated
+  // state for every page while retaining the configured partial-memory flush
+  // boundary.
+  std::vector<std::optional<IntermediateAggregationRun>>
+      intermediateRunLevels_;
+  uint64_t intermediateBufferedBytes_{0};
+  uint64_t intermediateInputRunCount_{0};
+  uint64_t intermediateRunMergeCount_{0};
 
   // Supported FINAL aggregates use cuDF's persistent hash state directly
   // across exchange pages. The choice is made from the first page and is never

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -203,8 +203,7 @@ class CudfGroupby : public CudfOperatorBase {
   // of comparable weight. This avoids regrouping the complete accumulated
   // state for every page while retaining the configured partial-memory flush
   // boundary.
-  std::vector<std::optional<IntermediateAggregationRun>>
-      intermediateRunLevels_;
+  std::vector<std::optional<IntermediateAggregationRun>> intermediateRunLevels_;
   uint64_t intermediateBufferedBytes_{0};
   uint64_t intermediateInputRunCount_{0};
   uint64_t intermediateRunMergeCount_{0};

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -23,6 +23,7 @@
 #include "velox/experimental/cudf/expression/AstExpression.h"
 #include "velox/experimental/cudf/expression/AstExpressionUtils.h"
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
+#include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h"
 
 #include "velox/common/testutil/TestValue.h"
 #include "velox/core/PlanNode.h"
@@ -296,7 +297,8 @@ void CudfHashJoinBuild::doNoMoreInput() {
   bool buildHashJoin =
       (joinNode_->isInnerJoin() || joinNode_->isLeftJoin() ||
        joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
-       joinNode_->isLeftSemiProjectJoin());
+       joinNode_->isLeftSemiProjectJoin() ||
+       joinNode_->isRightSemiProjectJoin());
 
   std::vector<std::shared_ptr<cudf::hash_join>> hashObjects;
   for (auto i = 0; i < tbls.size(); i++) {
@@ -431,9 +433,10 @@ CudfHashJoinProbe::CudfHashJoinProbe(
       rightColumnOutputIndices_.push_back(i);
       continue;
     }
-    // For LEFT SEMI PROJECT, the last column is the boolean "match" column
-    // which is not in probe or build types - skip it here, handled separately
-    if (isLeftSemiProjectJoin(joinNode_->joinType()) &&
+    // For SEMI PROJECT, the last column is the boolean "match" column which is
+    // not in probe or build types - skip it here, handled separately.
+    if ((isLeftSemiProjectJoin(joinNode_->joinType()) ||
+         isRightSemiProjectJoin(joinNode_->joinType())) &&
         i == outputType->size() - 1 &&
         outputType->childAt(i)->kind() == TypeKind::BOOLEAN) {
       continue;
@@ -549,6 +552,13 @@ void CudfHashJoinProbe::doAddInput(RowVectorPtr input) {
   }
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput);
+  if (joinNode_->isRightSemiProjectJoin() && input->size() > 0) {
+    probeSideHasRows_ = true;
+    if (joinNode_->isNullAware() && !probeSideHasNullKeys_) {
+      probeSideHasNullKeys_ =
+          cudf::has_nulls(cudfInput->getTableView().select(leftKeyIndices_));
+    }
+  }
   // Count nulls in join key columns
   auto [_, null_count] = cudf::bitmask_and(
       cudfInput->getTableView(), cudfInput->stream(), get_temp_mr());
@@ -573,7 +583,7 @@ void CudfHashJoinProbe::doAddInput(RowVectorPtr input) {
 void CudfHashJoinProbe::doNoMoreInput() {
   Operator::noMoreInput();
   if (!joinNode_->isRightJoin() && !joinNode_->isRightSemiFilterJoin() &&
-      !joinNode_->isFullJoin()) {
+      !joinNode_->isRightSemiProjectJoin() && !joinNode_->isFullJoin()) {
     return;
   }
   std::vector<ContinuePromise> promises;
@@ -593,7 +603,8 @@ void CudfHashJoinProbe::doNoMoreInput() {
     }
   };
 
-  if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
+  if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
+      joinNode_->isRightSemiProjectJoin()) {
     isLastDriver_ = true;
     if (hashObject_.has_value()) {
       auto stream = cudfGlobalStreamPool().get_stream();
@@ -633,6 +644,13 @@ void CudfHashJoinProbe::doNoMoreInput() {
         if (probe == nullptr) {
           continue;
         }
+        if (joinNode_->isRightSemiProjectJoin()) {
+          probeSideHasRows_ = probeSideHasRows_ || probe->probeSideHasRows_;
+          probeSideHasNullKeys_ =
+              probeSideHasNullKeys_ || probe->probeSideHasNullKeys_;
+        }
+        VELOX_CHECK_EQ(
+            probe->rightMatchedFlags_.size(), rightMatchedFlags_.size());
         // Combine flags per partition using cuDF bitwise OR
         // DM: This needs a relook. This is for when build side exceeds cudf
         // size_type limits. In case of multiple right side chunks, I'm not sure
@@ -1944,6 +1962,197 @@ CudfHashJoinProbe::rightSemiFilterJoin(
   return cudfOutputs;
 }
 
+std::vector<CudfHashJoinProbe::JoinOutput>
+CudfHashJoinProbe::rightSemiProjectJoin(
+    cudf::table_view leftTableView,
+    rmm::cuda_stream_view stream) {
+  auto& rightTables = hashObject_.value().first;
+  auto& hbs = hashObject_.value().second;
+  VELOX_CHECK_EQ(rightTables.size(), hbs.size());
+  VELOX_CHECK_EQ(rightTables.size(), rightMatchedFlags_.size());
+
+  // Precompute probe columns once per input batch when the AST filter needs
+  // them. HashJoinNode rejects null-aware RIGHT SEMI PROJECT with a filter.
+  std::vector<ColumnOrView> leftPrecomputed;
+  cudf::table_view extendedLeftView = leftTableView;
+  if (joinNode_->filter() && useAstFilter_ &&
+      !leftPrecomputeInstructions_.empty()) {
+    auto leftColumnViews = tableViewToColumnViews(leftTableView);
+    leftPrecomputed = precomputeSubexpressions(
+        leftColumnViews,
+        leftPrecomputeInstructions_,
+        scalars_,
+        probeType_,
+        stream);
+    extendedLeftView = createExtendedTableView(leftTableView, leftPrecomputed);
+  }
+
+  for (size_t i = 0; i < rightTables.size(); ++i) {
+    auto rightTableView = rightTables[i]->view();
+    auto& hb = hbs[i];
+    VELOX_CHECK_NOT_NULL(hb);
+
+    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
+        leftTableView.select(leftKeyIndices_),
+        std::nullopt,
+        stream,
+        get_temp_mr());
+
+    auto leftIndicesCol = cudf::column_view{
+        cudf::device_span<cudf::size_type const>{*leftJoinIndices}};
+    auto rightIndicesCol = cudf::column_view{
+        cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>>
+        astFilteredRightIndices;
+    std::unique_ptr<cudf::column> evaluatedFilteredRightIndices;
+
+    if (joinNode_->filter()) {
+      if (useAstFilter_) {
+        auto extendedRightView = !rightPrecomputeInstructions_.empty()
+            ? cachedExtendedRightViews_[i]
+            : rightTableView;
+        auto filteredIndices = cudf::filter_join_indices(
+            extendedLeftView,
+            extendedRightView,
+            leftIndicesCol,
+            rightIndicesCol,
+            tree_.back(),
+            cudf::join_kind::INNER_JOIN,
+            stream,
+            get_temp_mr());
+        astFilteredRightIndices = std::move(filteredIndices.second);
+        rightIndicesCol = cudf::column_view{
+            cudf::device_span<cudf::size_type const>{*astFilteredRightIndices}};
+      } else {
+        // Evaluate non-AST residuals over candidate pairs, then apply the same
+        // mask to the build indices. Null filter results are excluded by
+        // apply_boolean_mask, matching SQL join predicate semantics.
+        auto leftResult = cudf::gather(
+            leftTableView, leftIndicesCol, oobPolicy, stream, get_temp_mr());
+        auto rightResult = cudf::gather(
+            rightTableView, rightIndicesCol, oobPolicy, stream, get_temp_mr());
+        auto joinedCols = leftResult->release();
+        auto rightCols = rightResult->release();
+        joinedCols.insert(
+            joinedCols.end(),
+            std::make_move_iterator(rightCols.begin()),
+            std::make_move_iterator(rightCols.end()));
+        std::vector<cudf::column_view> joinedViews;
+        joinedViews.reserve(joinedCols.size());
+        for (const auto& col : joinedCols) {
+          joinedViews.push_back(col->view());
+        }
+        VELOX_CHECK_NOT_NULL(filterEvaluator_);
+        auto filterColumn =
+            filterEvaluator_->eval(joinedViews, stream, get_temp_mr());
+        auto filteredTable = cudf::apply_boolean_mask(
+            cudf::table_view{{rightIndicesCol}},
+            asView(filterColumn),
+            stream,
+            get_temp_mr());
+        evaluatedFilteredRightIndices = std::move(filteredTable->release()[0]);
+        rightIndicesCol = evaluatedFilteredRightIndices->view();
+      }
+    }
+
+    // Mark only the build rows matched by this probe batch. The previous
+    // implementation materialized sequence(buildRows), evaluated contains()
+    // over the complete build side, and OR'ed a complete BOOL8 column for
+    // every probe batch. Large exchange consumers can receive thousands of
+    // batches, turning an otherwise incremental semi join into
+    // O(buildRows * probeBatches) work. Each driver owns its flag column, and
+    // setting TRUE is monotonic and idempotent even when a residual produces
+    // duplicate build indices.
+    connector::hive::iceberg::scatterDeletesToMask(
+        rightMatchedFlags_[i]->mutable_view(),
+        cudf::device_span<cudf::size_type const>{
+            rightIndicesCol.data<cudf::size_type>(),
+            static_cast<std::size_t>(rightIndicesCol.size())},
+        stream,
+        get_temp_mr());
+    // rightIndicesCol can reference a batch-local device buffer. Complete the
+    // scatter before its owner is destroyed and before this driver accepts the
+    // next probe batch.
+    stream.synchronize();
+  }
+
+  // RIGHT SEMI PROJECT is build preserving. Probe batches only update state;
+  // output is emitted once every driver has completed probing.
+  return {};
+}
+
+RowVectorPtr CudfHashJoinProbe::rightSemiProjectOutput(
+    rmm::cuda_stream_view stream) {
+  auto& rightTables = hashObject_.value().first;
+  VELOX_CHECK_EQ(rightTables.size(), rightMatchedFlags_.size());
+
+  while (nextBuildOutputIndex_ < rightTables.size()) {
+    const auto i = nextBuildOutputIndex_++;
+    auto rightTableView = rightTables[i]->view();
+    const auto numRows = rightTableView.num_rows();
+    if (numRows == 0) {
+      continue;
+    }
+
+    std::vector<std::unique_ptr<cudf::column>> outputCols(outputType_->size());
+    auto rightInput = rightTableView.select(rightColumnIndicesToGather_);
+    for (size_t j = 0; j < rightColumnIndicesToGather_.size(); ++j) {
+      outputCols[rightColumnOutputIndices_[j]] = std::make_unique<cudf::column>(
+          rightInput.column(j), stream, get_output_mr());
+    }
+
+    std::unique_ptr<cudf::column> matchColumn;
+    if (joinNode_->isNullAware() && probeSideHasRows_) {
+      auto noMatch = cudf::unary_operation(
+          rightMatchedFlags_[i]->view(),
+          cudf::unary_operator::NOT,
+          stream,
+          get_temp_mr());
+      std::unique_ptr<cudf::column> nullMask;
+      if (probeSideHasNullKeys_) {
+        // Any unmatched build row is indeterminate if the probe side contains
+        // a null key. Rows with a true equality match remain true.
+        nullMask = std::move(noMatch);
+      } else {
+        // With a non-empty, non-null probe side, only build rows with a null
+        // key are indeterminate.
+        auto buildKeyNullMask = createProbeKeyNullMask(
+            rightTableView.select(rightKeyIndices_), stream, get_temp_mr());
+        nullMask = cudf::binary_operation(
+            noMatch->view(),
+            buildKeyNullMask->view(),
+            cudf::binary_operator::BITWISE_AND,
+            cudf::data_type{cudf::type_id::BOOL8},
+            stream,
+            get_temp_mr());
+      }
+      matchColumn = applyNullMask(
+          rightMatchedFlags_[i]->view(),
+          nullMask->view(),
+          stream,
+          get_output_mr());
+    } else {
+      // Regular EXISTS semantics, and null-aware IN with an empty probe side,
+      // both use the non-nullable accumulated flags directly.
+      matchColumn = std::make_unique<cudf::column>(
+          rightMatchedFlags_[i]->view(), stream, get_output_mr());
+    }
+    outputCols.back() = std::move(matchColumn);
+
+    stream.synchronize();
+    finished_ = nextBuildOutputIndex_ == rightTables.size();
+    return std::make_shared<CudfVector>(
+        pool(),
+        outputType_,
+        static_cast<vector_size_t>(numRows),
+        std::make_unique<cudf::table>(std::move(outputCols)),
+        stream);
+  }
+
+  finished_ = true;
+  return nullptr;
+}
+
 std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::antiJoin(
     cudf::table_view leftTableViewParam,
     rmm::cuda_stream_view stream) {
@@ -2042,6 +2251,10 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
     return nullptr;
   }
   if (!input_) {
+    if (joinNode_->isRightSemiProjectJoin() && noMoreInput_ && !finished_ &&
+        isLastDriver_) {
+      return rightSemiProjectOutput(cudfGlobalStreamPool().get_stream());
+    }
     // If no more input, emit unmatched-right rows if needed.
     if ((joinNode_->isRightJoin() || joinNode_->isFullJoin()) && noMoreInput_ &&
         !finished_ && isLastDriver_) {
@@ -2171,6 +2384,9 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
     case core::JoinType::kRightSemiFilter:
       cudfOutputs = rightSemiFilterJoin(leftTableView, stream);
       break;
+    case core::JoinType::kRightSemiProject:
+      cudfOutputs = rightSemiProjectJoin(leftTableView, stream);
+      break;
     case core::JoinType::kAnti:
       cudfOutputs = antiJoin(leftTableView, stream);
       break;
@@ -2182,7 +2398,8 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
   }
 
   // Record probe stream for cross-driver synchronization in noMoreInput().
-  if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
+  if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
+      joinNode_->isRightSemiProjectJoin()) {
     lastProbeStream_ = stream;
   }
 
@@ -2192,8 +2409,13 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
   // the refcount while cudfInput still holds a reference.
   cudfInput.reset();
   input_.reset();
-  finished_ =
-      noMoreInput_ && !joinNode_->isRightJoin() && !joinNode_->isFullJoin();
+  finished_ = noMoreInput_ && !joinNode_->isRightJoin() &&
+      !joinNode_->isFullJoin() && !joinNode_->isRightSemiProjectJoin();
+
+  if (joinNode_->isRightSemiProjectJoin()) {
+    VELOX_CHECK(cudfOutputs.empty());
+    return nullptr;
+  }
 
   vector_size_t zeroColumnOutputRows = 0;
   std::vector<std::unique_ptr<cudf::table>> cudfOutputTables;
@@ -2223,7 +2445,7 @@ bool CudfHashJoinProbe::skipProbeOnEmptyBuild() const {
 
 exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
   if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin() ||
-       joinNode_->isFullJoin()) &&
+       joinNode_->isRightSemiProjectJoin() || joinNode_->isFullJoin()) &&
       hashObject_.has_value()) {
     if (!future_.valid()) {
       return exec::BlockingReason::kNotBlocked;
@@ -2255,7 +2477,8 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
   buildReadyEvent_ = cudfJoinBridge->getBuildReadyEvent();
 
   // Lazy initialize matched flags only when build side is done
-  if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
+  if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
+      joinNode_->isRightSemiProjectJoin()) {
     auto& rightTablesInit = hashObject_.value().first;
     rightMatchedFlags_.clear();
     rightMatchedFlags_.reserve(rightTablesInit.size());
@@ -2333,7 +2556,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
     }
   }
   if ((joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin() ||
-       joinNode_->isFullJoin()) &&
+       joinNode_->isRightSemiProjectJoin() || joinNode_->isFullJoin()) &&
       future_.valid()) {
     *future = std::move(future_);
     return exec::BlockingReason::kWaitForJoinProbe;
@@ -2342,7 +2565,12 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
 }
 
 bool CudfHashJoinProbe::isFinished() {
-  auto const isFinished = finished_ || (noMoreInput_ && input_ == nullptr);
+  // RIGHT SEMI PROJECT can emit one build table per getOutput() call. Keep the
+  // last driver alive until all build tables are emitted; peer drivers have no
+  // output after the end-of-probe barrier and can finish normally.
+  const auto hasNoMoreWork = noMoreInput_ && input_ == nullptr &&
+      !(joinNode_->isRightSemiProjectJoin() && isLastDriver_ && !finished_);
+  const auto isFinished = finished_ || hasNoMoreWork;
 
   // Release hashObject_ if finished
   if (isFinished) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
@@ -23,7 +24,6 @@
 #include "velox/experimental/cudf/expression/AstExpression.h"
 #include "velox/experimental/cudf/expression/AstExpressionUtils.h"
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
-#include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h"
 
 #include "velox/common/testutil/TestValue.h"
 #include "velox/core/PlanNode.h"

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -152,10 +152,9 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   /// Supported types:
   /// - Inner, Left, Right, Full joins
   /// - Left/Right Semi Filter joins
-  /// - Left Semi Project join (excluding null-aware join with filter)
+  /// - Left/Right Semi Project joins (null-aware right semi project with a
+  ///   filter is rejected by HashJoinNode validation)
   /// - Anti join (non-null-aware, or null-aware without filter)
-  /// Note: Right Semi Project, and null-aware left semi-project join with
-  /// filter not yet supported.
   static bool isSupportedJoinType(core::JoinType joinType) {
     return joinType == core::JoinType::kInner ||
         joinType == core::JoinType::kLeft ||
@@ -164,6 +163,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
         joinType == core::JoinType::kLeftSemiProject ||
         joinType == core::JoinType::kRight ||
         joinType == core::JoinType::kRightSemiFilter ||
+        joinType == core::JoinType::kRightSemiProject ||
         joinType == core::JoinType::kFull;
   }
 
@@ -226,6 +226,12 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   /// nullability.
   bool buildSideHasNullKeys_{false};
 
+  /// Whether this probe driver has seen any non-empty probe input and whether
+  /// any such input has a null join key. These are reduced across drivers at
+  /// the end-of-probe barrier for null-aware RIGHT SEMI PROJECT joins.
+  bool probeSideHasRows_{false};
+  bool probeSideHasNullKeys_{false};
+
   // Copied from HashProbe.h
   // Indicates whether to skip probe input data processing or not. It only
   // applies for a specific set of join types (see skipProbeOnEmptyBuild()), and
@@ -245,8 +251,8 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   // Streaming right join state
   // Per-build-table flags indicating whether a build row has had at least one
   // left match.
-  /** @brief Flags tracking which build rows have been matched (for right joins)
-   */
+  /** @brief Flags tracking which build rows have been matched for right/full
+   * and right-semi-project joins. */
   std::vector<std::unique_ptr<cudf::column>> rightMatchedFlags_;
 
   /// Cached precomputed columns for right (build) tables
@@ -254,17 +260,24 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   /// Cached extended views for right tables (original + precomputed columns)
   std::vector<cudf::table_view> cachedExtendedRightViews_;
 
-  // For Right joins, only one driver collects the unmatched rows mask and
-  // emits. This value is set true only for that driver. See noMoreInput
+  // For right/full and right-semi-project joins, only one driver combines the
+  // build-row match masks and emits build-side output. This value is set true
+  // only for that driver. See noMoreInput().
   bool isLastDriver_{false};
 
+  /// Next build table to emit for RIGHT SEMI PROJECT. Build tables are emitted
+  /// one at a time so the multi-table path does not concatenate past the cuDF
+  /// size_type limit.
+  size_t nextBuildOutputIndex_{0};
+
   /// CUDA stream used during the last getOutput() probe operation. Set only
-  /// for right/full joins, and only for drivers that process at least one probe
-  /// batch. Used in noMoreInput() to synchronize GPU streams across drivers
-  /// before combining rightMatchedFlags_. Drivers with no probe input are safe
-  /// to skip: the driver loop guarantees all addInput batches are consumed by
-  /// getOutput() before noMoreInput() fires, and unset flags remain in their
-  /// host-synchronized all-false init state with no pending GPU work.
+  /// for right/full/right-semi-project joins, and only for drivers that process
+  /// at least one probe batch. Used in noMoreInput() to synchronize GPU streams
+  /// across drivers before combining rightMatchedFlags_. Drivers with no probe
+  /// input are safe to skip: the driver loop guarantees all addInput batches
+  /// are consumed by getOutput() before noMoreInput() fires, and unset flags
+  /// remain in their host-synchronized all-false init state with no pending GPU
+  /// work.
   std::optional<rmm::cuda_stream_view> lastProbeStream_;
 
   static constexpr auto oobPolicy = cudf::out_of_bounds_policy::NULLIFY;
@@ -341,6 +354,17 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   std::vector<JoinOutput> rightSemiFilterJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
+  /**
+   * @brief Accumulates per-build-row matches for a right semi project join.
+   * This produces no rows while probing; the build rows and match column are
+   * emitted after all probe drivers reach the end-of-input barrier.
+   */
+  std::vector<JoinOutput> rightSemiProjectJoin(
+      cudf::table_view leftTableView,
+      rmm::cuda_stream_view stream);
+
+  /// Emits the next build-side batch for RIGHT SEMI PROJECT.
+  RowVectorPtr rightSemiProjectOutput(rmm::cuda_stream_view stream);
   /**
    * @brief Performs anti join between probe table and all build tables.
    * @param leftTableView Probe-side table view to join

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -70,7 +70,11 @@ CudfLocalPartition::CudfLocalPartition(
           planNode),
       queues_{
           ctx->task->getLocalExchangeQueues(ctx->splitGroupId, planNode->id())},
-      numPartitions_{queues_.size()} {
+      numPartitions_{queues_.size()},
+      hashSeed_{
+          planNode->id().find("_keyed_final_local_hash") != std::string::npos
+              ? cudf::DEFAULT_HASH_SEED ^ 0x9e3779b9U
+              : cudf::DEFAULT_HASH_SEED} {
   // Following is IMO a hacky way to get the partition key indices. It is to
   // workaround the fact that the partition spec constructs the hash function
   // directly and has no public methods to get the partition key indices.
@@ -119,6 +123,12 @@ CudfLocalPartition::CudfLocalPartition(
       }
     }
     partitionFunctionType_ = PartitionFunctionType::kHash;
+    if (hashSeed_ != cudf::DEFAULT_HASH_SEED) {
+      LOG(WARNING) << "CudfLocalPartition: decorrelated keyed-FINAL hash "
+                   << "planNode=" << planNode->id()
+                   << " partitions=" << numPartitions_
+                   << " seed=" << hashSeed_;
+    }
   } else if (
       dynamic_cast<const exec::RoundRobinPartitionFunctionSpec*>(
           &planNode->partitionFunctionSpec()) &&
@@ -210,7 +220,7 @@ void CudfLocalPartition::doAddInput(RowVectorPtr input) {
             partitionKeyIndices,
             numPartitions_,
             cudf::hash_id::HASH_MURMUR3,
-            cudf::DEFAULT_HASH_SEED,
+            hashSeed_,
             stream,
             get_temp_mr());
       } else if (

--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -126,8 +126,7 @@ CudfLocalPartition::CudfLocalPartition(
     if (hashSeed_ != cudf::DEFAULT_HASH_SEED) {
       LOG(WARNING) << "CudfLocalPartition: decorrelated keyed-FINAL hash "
                    << "planNode=" << planNode->id()
-                   << " partitions=" << numPartitions_
-                   << " seed=" << hashSeed_;
+                   << " partitions=" << numPartitions_ << " seed=" << hashSeed_;
     }
   } else if (
       dynamic_cast<const exec::RoundRobinPartitionFunctionSpec*>(

--- a/velox/experimental/cudf/exec/CudfLocalPartition.h
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.h
@@ -74,6 +74,11 @@ class CudfLocalPartition : public CudfOperatorBase {
   PartitionFunctionType partitionFunctionType_;
   size_t counter_{0};
 
+  // A local keyed-FINAL repartition must not reuse the remote exchange seed.
+  // If local partition count divides remote partition count (Q17: 4 vs 32),
+  // identical hashing sends the peer's entire remote bucket to one local lane.
+  uint32_t hashSeed_;
+
   std::vector<exec::BlockingReason> blockingReasons_;
   std::vector<ContinueFuture> futures_;
 

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -42,16 +42,14 @@ namespace {
 constexpr uint64_t kMergeChunkBytes = 32ULL << 20;
 constexpr uint64_t kMergePassBytes = 128ULL << 20;
 constexpr uint64_t kSpillRowGroupBytes = 64ULL << 20;
-constexpr uint64_t kOutputChunkBytes = 32ULL << 20;
 constexpr size_t kFinalMergeRuns = 2;
-constexpr cudf::size_type kMaxOutputRows = 262144;
 
 std::atomic<uint64_t> orderBySpillDirectorySequence{0};
 std::atomic<uint64_t> testingSortedRunBytes{0};
 std::atomic<size_t> testingMergeFanIn{0};
 std::atomic<uint64_t> mergeChunkBytes{kMergeChunkBytes};
-std::atomic<uint64_t> outputChunkBytes{kOutputChunkBytes};
-std::atomic<cudf::size_type> maxOutputRows{kMaxOutputRows};
+std::atomic<uint64_t> testingOutputChunkBytes{0};
+std::atomic<cudf::size_type> testingMaxOutputRows{0};
 
 // Read-only diagnostics used to assert the external-sort bounds in GPU tests.
 // They never participate in operator scheduling or correctness.
@@ -208,8 +206,8 @@ void CudfOrderBy::testingSetMemoryLimits(
   testingSortedRunBytes.store(runBytes);
   testingMergeFanIn.store(fanIn);
   mergeChunkBytes.store(chunkBytes);
-  outputChunkBytes.store(outputBytes);
-  maxOutputRows.store(outputRows);
+  testingOutputChunkBytes.store(outputBytes);
+  testingMaxOutputRows.store(outputRows);
   resetTestingStats();
 }
 
@@ -217,8 +215,8 @@ void CudfOrderBy::testingResetMemoryLimits() {
   testingSortedRunBytes.store(0);
   testingMergeFanIn.store(0);
   mergeChunkBytes.store(kMergeChunkBytes);
-  outputChunkBytes.store(kOutputChunkBytes);
-  maxOutputRows.store(kMaxOutputRows);
+  testingOutputChunkBytes.store(0);
+  testingMaxOutputRows.store(0);
   resetTestingStats();
 }
 
@@ -266,7 +264,16 @@ CudfOrderBy::CudfOrderBy(
           testingMergeFanIn.load() > 0
               ? testingMergeFanIn.load()
               : static_cast<size_t>(
-                    CudfConfig::getInstance().orderByMergeFanIn)) {
+                    CudfConfig::getInstance().orderByMergeFanIn)),
+      outputChunkBytes_(
+          testingOutputChunkBytes.load() > 0
+              ? testingOutputChunkBytes.load()
+              : CudfConfig::getInstance().orderByOutputChunkBytes),
+      maxOutputRows_(
+          testingMaxOutputRows.load() > 0
+              ? testingMaxOutputRows.load()
+              : static_cast<cudf::size_type>(
+                    CudfConfig::getInstance().orderByMaxOutputRows)) {
   VELOX_CHECK(
       isSupported(orderByNode),
       "CudfOrderBy received an unsupported external-spill schema or sorting "
@@ -846,8 +853,9 @@ CudfVectorPtr CudfOrderBy::takePendingOutput() {
   const auto totalRows = pendingOutput_->num_rows();
   VELOX_CHECK_LT(pendingOutputOffset_, totalRows);
   const auto remainingRows = totalRows - pendingOutputOffset_;
-  const auto byteLimit = outputChunkBytes.load();
-  cudf::size_type targetRows = std::min(remainingRows, maxOutputRows.load());
+  const auto byteLimit = outputChunkBytes_;
+  cudf::size_type targetRows =
+      std::min(remainingRows, maxOutputRows_);
   if (pendingOutputBytes_ > byteLimit) {
     const auto proportionalRows =
         static_cast<cudf::size_type>(std::max<uint64_t>(
@@ -855,6 +863,23 @@ CudfVectorPtr CudfOrderBy::takePendingOutput() {
             static_cast<uint64_t>(totalRows) * byteLimit /
                 pendingOutputBytes_));
     targetRows = std::min(targetRows, proportionalRows);
+  }
+
+  // Avoid copying an already materialized in-memory sort result when it fits
+  // the configured output bounds. Spilled/oversized results keep the bounded
+  // slicing path below.
+  if (pendingOutputOffset_ == 0 && targetRows == totalRows &&
+      pendingOutputBytes_ <= byteLimit) {
+    auto output = std::make_shared<CudfVector>(
+        pool(),
+        outputType_,
+        totalRows,
+        std::move(pendingOutput_),
+        stateStream_);
+    pendingOutputOffset_ = 0;
+    pendingOutputBytes_ = 0;
+    observedEmittedChunks.fetch_add(1);
+    return output;
   }
 
   while (true) {

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -107,8 +107,10 @@ bool isSpillSafeType(const TypePtr& type) {
         }
       }
       return true;
-    case TypeKind::VARBINARY:
     case TypeKind::MAP:
+      return type->size() == 2 && isSpillSafeType(type->childAt(0)) &&
+          isSpillSafeType(type->childAt(1));
+    case TypeKind::VARBINARY:
     case TypeKind::UNKNOWN:
     case TypeKind::FUNCTION:
     case TypeKind::OPAQUE:
@@ -125,7 +127,8 @@ bool isSupportedSortKeyType(const TypePtr& type) {
 
   // Nested cuDF sort semantics have not been validated against Velox. Nested
   // values may still be carried as payload when every leaf is spill-safe.
-  return type->kind() != TypeKind::ARRAY && type->kind() != TypeKind::ROW;
+  return type->kind() != TypeKind::ARRAY && type->kind() != TypeKind::MAP &&
+      type->kind() != TypeKind::ROW;
 }
 
 void updateAtomicMax(std::atomic<uint64_t>& target, uint64_t value) {

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -854,8 +854,7 @@ CudfVectorPtr CudfOrderBy::takePendingOutput() {
   VELOX_CHECK_LT(pendingOutputOffset_, totalRows);
   const auto remainingRows = totalRows - pendingOutputOffset_;
   const auto byteLimit = outputChunkBytes_;
-  cudf::size_type targetRows =
-      std::min(remainingRows, maxOutputRows_);
+  cudf::size_type targetRows = std::min(remainingRows, maxOutputRows_);
   if (pendingOutputBytes_ > byteLimit) {
     const auto proportionalRows =
         static_cast<cudf::size_type>(std::max<uint64_t>(

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -143,6 +143,8 @@ class CudfOrderBy : public CudfOperatorBase {
   std::vector<cudf::null_order> nullOrder_;
   const uint64_t sortedRunBytes_;
   const size_t mergeFanIn_;
+  const uint64_t outputChunkBytes_;
+  const cudf::size_type maxOutputRows_;
   uint64_t bufferedBytes_{0};
   std::vector<SortedRun> sortedRuns_;
   std::string spillDirectory_;

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -28,12 +28,14 @@
 #include "velox/type/Type.h"
 
 #include <cudf/aggregation.hpp>
+#include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/groupby.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/join/hash_join.hpp>
 #include <cudf/merge.hpp>
 #include <cudf/reduction.hpp>
 #include <cudf/replace.hpp>
@@ -53,6 +55,7 @@
 #include <malloc.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <filesystem>
 #include <limits>
@@ -92,6 +95,17 @@ cudf::size_type firstSearchPosition(
       stream.value()));
   stream.synchronize();
   return result;
+}
+
+std::vector<cudf::column_view> selectColumns(
+    const cudf::table_view& table,
+    const std::vector<cudf::size_type>& indices) {
+  std::vector<cudf::column_view> columns;
+  columns.reserve(indices.size());
+  for (const auto index : indices) {
+    columns.push_back(table.column(index));
+  }
+  return columns;
 }
 
 // Returns true when the window function's value argument is a cast expression.
@@ -216,6 +230,26 @@ cudf::rank_method toRankMethod(const std::string& name) {
     return cudf::rank_method::DENSE;
   }
   VELOX_FAIL("Unsupported rank window function: {}", name);
+}
+
+bool isStreamingRankFunction(const core::WindowNode::Function& function) {
+  const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
+  const auto baseName =
+      stripFunctionPrefix(function.functionCall->name(), prefix);
+  return (baseName == "row_number" || baseName == "rank") &&
+      function.functionCall->inputs().empty() && !function.ignoreNulls &&
+      function.frame.startType ==
+      core::WindowNode::BoundType::kUnboundedPreceding &&
+      function.frame.endType == core::WindowNode::BoundType::kCurrentRow &&
+      function.frame.startValue == nullptr &&
+      function.frame.endValue == nullptr;
+}
+
+bool isStreamingRankWindow(const core::WindowNode& windowNode) {
+  const auto& functions = windowNode.windowFunctions();
+  return windowNode.inputsSorted() && !windowNode.partitionKeys().empty() &&
+      !windowNode.sortingKeys().empty() && !functions.empty() &&
+      std::all_of(functions.begin(), functions.end(), isStreamingRankFunction);
 }
 
 std::unique_ptr<cudf::column> makeConstantOnesColumn(
@@ -453,7 +487,8 @@ bool CudfWindow::canRunOnGPU(const core::WindowNode& windowNode) {
 bool CudfWindow::canRunOnGPU(
     const core::WindowNode& windowNode,
     std::string* reason) {
-  if (windowNode.sortingKeys().size() > 1) {
+  if (windowNode.sortingKeys().size() > 1 &&
+      !isStreamingRankWindow(windowNode)) {
     if (reason) {
       *reason = "Multi-column ORDER BY requires a cuDF upgrade (follow-on PR)";
     }
@@ -752,6 +787,8 @@ CudfWindow::CudfWindow(
           NvtxMethodFlag::kAddInput | NvtxMethodFlag::kGetOutput),
       windowNode_(windowNode),
       inputRowType_(asRowType(windowNode->inputType())),
+      rankLikeStreaming_(isStreamingRankWindow(*windowNode)),
+      stateStream_(cudfGlobalStreamPool().get_stream()),
       sortedRunBytes_(CudfConfig::getInstance().windowSortedRunBytes) {
   const auto& inputType = windowNode->inputType();
 
@@ -781,6 +818,28 @@ void CudfWindow::doAddInput(RowVectorPtr input) {
 
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput, "CudfWindow expects CudfVector input");
+
+  if (rankLikeStreaming_) {
+    VELOX_CHECK_NULL(
+        pendingOutput_,
+        "CudfWindow received sorted input before prior output was drained");
+    const auto inputStream = cudfInput->stream();
+    if (inputStream.value() != stateStream_.value()) {
+      cudf::detail::join_streams(
+          std::vector<rmm::cuda_stream_view>{inputStream}, stateStream_);
+    }
+    VELOX_CHECK(
+        cudfInput->rebindStream(stateStream_),
+        "CudfWindow cannot rebind sorted input to its state stream");
+
+    stream_ = stateStream_;
+    streamAcquired_ = true;
+    logicalRowCount_ = cudfInput->size();
+    sortedData_ = cudfInput->release();
+    pendingOutput_ = computeOutput();
+    return;
+  }
+
   bufferedBytes_ += cudfInput->estimateFlatSize();
   inputBatches_.push_back(std::move(cudfInput));
 
@@ -997,6 +1056,328 @@ std::unique_ptr<cudf::table> CudfWindow::takeCompletePartitions(
     return nullptr;
   }
   return copyTableSlice(sorted->view(), 0, completeEnd, stream_, mr);
+}
+
+std::unique_ptr<cudf::column> CudfWindow::computeStreamingRowNumberColumn(
+    const cudf::table_view& sortedInput,
+    const TypePtr& expectedType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  const auto valuesColumn = sortedInput.column(sortKeyIndices_[0]);
+  const auto order = sortOrders_[0];
+  const auto nullOrder = nullOrders_[0];
+
+  std::vector<cudf::groupby::scan_request> requests(1);
+  requests[0].values = valuesColumn;
+  requests[0].aggregations.push_back(
+      cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+          cudf::rank_method::FIRST,
+          order,
+          cudf::null_policy::INCLUDE,
+          nullOrder));
+
+  cudf::groupby::groupby grouper(
+      cudf::table_view(selectColumns(sortedInput, partitionKeyIndices_)),
+      cudf::null_policy::INCLUDE,
+      cudf::sorted::YES,
+      std::vector<cudf::order>(
+          partitionKeyIndices_.size(), cudf::order::ASCENDING),
+      std::vector<cudf::null_order>(
+          partitionKeyIndices_.size(), cudf::null_order::BEFORE));
+
+  auto scanResult = grouper.scan(requests, stream, mr);
+  VELOX_CHECK_EQ(scanResult.second.size(), 1);
+  VELOX_CHECK_EQ(scanResult.second[0].results.size(), 1);
+  auto rowNumber = std::move(scanResult.second[0].results[0]);
+
+  const auto expectedCudfType = veloxToCudfDataType(expectedType);
+  if (rowNumber->type() != expectedCudfType) {
+    rowNumber = cudf::cast(rowNumber->view(), expectedCudfType, stream, mr);
+  }
+  return rowNumber;
+}
+
+std::unique_ptr<cudf::column> CudfWindow::computeStreamingRankColumn(
+    const cudf::table_view& sortedInput,
+    const TypePtr& expectedType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  auto rowNumber =
+      computeStreamingRowNumberColumn(sortedInput, expectedType, stream, mr);
+
+  std::vector<cudf::size_type> rankKeyIndices = partitionKeyIndices_;
+  rankKeyIndices.insert(
+      rankKeyIndices.end(), sortKeyIndices_.begin(), sortKeyIndices_.end());
+  auto rankKeyColumns = selectColumns(sortedInput, rankKeyIndices);
+  cudf::groupby::groupby grouper(
+      cudf::table_view(rankKeyColumns), cudf::null_policy::INCLUDE);
+
+  std::vector<cudf::groupby::aggregation_request> requests(1);
+  requests[0].values = rowNumber->view();
+  requests[0].aggregations.push_back(
+      cudf::make_min_aggregation<cudf::groupby_aggregation>());
+
+  auto [groupKeys, results] = grouper.aggregate(requests, stream, mr);
+  VELOX_CHECK_EQ(results.size(), 1);
+  VELOX_CHECK_EQ(results[0].results.size(), 1);
+  auto minRankByPeerGroup = std::move(results[0].results[0]);
+
+  cudf::hash_join lookup(
+      groupKeys->view(),
+      cudf::nullable_join::YES,
+      cudf::null_equality::EQUAL,
+      0.5,
+      stream);
+  auto [leftJoinIndices, rightJoinIndices] = lookup.left_join(
+      cudf::table_view(rankKeyColumns),
+      static_cast<std::size_t>(sortedInput.num_rows()),
+      stream,
+      mr);
+
+  auto leftIndicesCol = cudf::column_view{
+      cudf::device_span<const cudf::size_type>{*leftJoinIndices}};
+  auto rightIndicesCol = cudf::column_view{
+      cudf::device_span<const cudf::size_type>{*rightJoinIndices}};
+  auto gatheredRanks = cudf::gather(
+      cudf::table_view{{minRankByPeerGroup->view()}},
+      rightIndicesCol,
+      cudf::out_of_bounds_policy::NULLIFY,
+      stream,
+      mr);
+  auto gatheredColumns = gatheredRanks->release();
+  VELOX_CHECK_EQ(gatheredColumns.size(), 1);
+
+  auto target = cudf::allocate_like(
+      gatheredColumns[0]->view(),
+      sortedInput.num_rows(),
+      cudf::mask_allocation_policy::RETAIN,
+      stream,
+      mr);
+  auto scattered = cudf::scatter(
+      cudf::table_view{{gatheredColumns[0]->view()}},
+      leftIndicesCol,
+      cudf::table_view{{target->view()}},
+      stream,
+      mr);
+  return std::move(scattered->release()[0]);
+}
+
+cudf::size_type CudfWindow::continuingPrefixSize(
+    const cudf::table_view& sortedInput,
+    const std::vector<cudf::size_type>& indices,
+    const std::unique_ptr<cudf::table>& previousKey,
+    const std::vector<cudf::order>& orders,
+    const std::vector<cudf::null_order>& nullOrders,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  if (!previousKey || sortedInput.num_rows() == 0) {
+    return 0;
+  }
+  VELOX_CHECK_EQ(indices.size(), orders.size());
+  VELOX_CHECK_EQ(indices.size(), nullOrders.size());
+  auto positions = cudf::upper_bound(
+      cudf::table_view(selectColumns(sortedInput, indices)),
+      previousKey->view(),
+      orders,
+      nullOrders,
+      stream,
+      mr);
+  return firstSearchPosition(positions->view(), stream);
+}
+
+std::unique_ptr<cudf::column> CudfWindow::fixRankLikeColumn(
+    std::unique_ptr<cudf::column> localResult,
+    std::string_view functionName,
+    const cudf::table_view& sortedInput,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  if (!hasRankLikeState_ || sortedInput.num_rows() == 0) {
+    return localResult;
+  }
+
+  const std::vector<cudf::order> partitionOrders(
+      partitionKeyIndices_.size(), cudf::order::ASCENDING);
+  const std::vector<cudf::null_order> partitionNullOrders(
+      partitionKeyIndices_.size(), cudf::null_order::BEFORE);
+  const auto samePartitionEnd = continuingPrefixSize(
+      sortedInput,
+      partitionKeyIndices_,
+      previousPartitionKey_,
+      partitionOrders,
+      partitionNullOrders,
+      stream,
+      mr);
+  if (samePartitionEnd == 0) {
+    return localResult;
+  }
+
+  auto addOffset = [&](cudf::column_view values,
+                       int64_t offset) -> std::unique_ptr<cudf::column> {
+    switch (values.type().id()) {
+      case cudf::type_id::INT32: {
+        cudf::numeric_scalar<int32_t> scalar(
+            static_cast<int32_t>(offset), true, stream, mr);
+        return cudf::binary_operation(
+            values,
+            scalar,
+            cudf::binary_operator::ADD,
+            values.type(),
+            stream,
+            mr);
+      }
+      case cudf::type_id::INT64: {
+        cudf::numeric_scalar<int64_t> scalar(offset, true, stream, mr);
+        return cudf::binary_operation(
+            values,
+            scalar,
+            cudf::binary_operator::ADD,
+            values.type(),
+            stream,
+            mr);
+      }
+      default:
+        VELOX_FAIL(
+            "Unsupported rank output type {}",
+            static_cast<int>(values.type().id()));
+    }
+  };
+  auto makeConstant =
+      [&](int64_t value,
+          cudf::size_type rows) -> std::unique_ptr<cudf::column> {
+    switch (localResult->type().id()) {
+      case cudf::type_id::INT32: {
+        cudf::numeric_scalar<int32_t> scalar(
+            static_cast<int32_t>(value), true, stream, mr);
+        return cudf::make_column_from_scalar(scalar, rows, stream, mr);
+      }
+      case cudf::type_id::INT64: {
+        cudf::numeric_scalar<int64_t> scalar(value, true, stream, mr);
+        return cudf::make_column_from_scalar(scalar, rows, stream, mr);
+      }
+      default:
+        VELOX_FAIL(
+            "Unsupported rank output type {}",
+            static_cast<int>(localResult->type().id()));
+    }
+  };
+
+  std::vector<std::unique_ptr<cudf::column>> ownedSegments;
+  std::vector<cudf::column_view> segments;
+  auto appendUnchanged = [&](cudf::size_type begin, cudf::size_type end) {
+    if (begin == end) {
+      return;
+    }
+    auto slice = cudf::slice(localResult->view(), {begin, end}, stream);
+    segments.push_back(slice.front());
+  };
+  auto appendOffset =
+      [&](cudf::size_type begin, cudf::size_type end, int64_t offset) {
+        if (begin == end) {
+          return;
+        }
+        auto slice = cudf::slice(localResult->view(), {begin, end}, stream);
+        ownedSegments.push_back(addOffset(slice.front(), offset));
+        segments.push_back(ownedSegments.back()->view());
+      };
+
+  cudf::size_type fixedEnd{0};
+  if (functionName == "rank") {
+    auto continuingPartition =
+        cudf::slice(sortedInput, {0, samePartitionEnd}, stream);
+    const auto sameOrderEnd = continuingPrefixSize(
+        continuingPartition.front(),
+        sortKeyIndices_,
+        previousOrderKey_,
+        sortOrders_,
+        nullOrders_,
+        stream,
+        mr);
+    if (sameOrderEnd > 0) {
+      ownedSegments.push_back(makeConstant(previousRank_, sameOrderEnd));
+      segments.push_back(ownedSegments.back()->view());
+    }
+    fixedEnd = sameOrderEnd;
+  }
+  appendOffset(fixedEnd, samePartitionEnd, previousPartitionRows_);
+  appendUnchanged(samePartitionEnd, localResult->size());
+  VELOX_CHECK(!segments.empty());
+  return segments.size() == 1
+      ? std::make_unique<cudf::column>(segments.front(), stream, mr)
+      : cudf::concatenate(segments, stream, mr);
+}
+
+void CudfWindow::updateRankLikeState(
+    const cudf::table_view& sortedInput,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_GT(sortedInput.num_rows(), 0);
+  const auto numRows = sortedInput.num_rows();
+  const std::vector<cudf::order> partitionOrders(
+      partitionKeyIndices_.size(), cudf::order::ASCENDING);
+  const std::vector<cudf::null_order> partitionNullOrders(
+      partitionKeyIndices_.size(), cudf::null_order::BEFORE);
+  const auto continuedRows = hasRankLikeState_ ? continuingPrefixSize(
+                                                     sortedInput,
+                                                     partitionKeyIndices_,
+                                                     previousPartitionKey_,
+                                                     partitionOrders,
+                                                     partitionNullOrders,
+                                                     stream,
+                                                     mr)
+                                               : 0;
+  const bool continuedWholeBatch = continuedRows == numRows;
+
+  auto partitionColumns =
+      cudf::table_view(selectColumns(sortedInput, partitionKeyIndices_));
+  auto lastPartition =
+      cudf::slice(partitionColumns, {numRows - 1, numRows}, stream);
+  auto partitionPositions = cudf::lower_bound(
+      partitionColumns,
+      lastPartition.front(),
+      partitionOrders,
+      partitionNullOrders,
+      stream,
+      mr);
+  const auto trailingPartitionBegin =
+      firstSearchPosition(partitionPositions->view(), stream);
+
+  auto trailingPartition =
+      cudf::slice(sortedInput, {trailingPartitionBegin, numRows}, stream);
+  auto trailingOrderColumns = cudf::table_view(
+      selectColumns(trailingPartition.front(), sortKeyIndices_));
+  auto lastOrder = cudf::slice(
+      trailingOrderColumns,
+      {trailingOrderColumns.num_rows() - 1, trailingOrderColumns.num_rows()},
+      stream);
+  auto orderPositions = cudf::lower_bound(
+      trailingOrderColumns,
+      lastOrder.front(),
+      sortOrders_,
+      nullOrders_,
+      stream,
+      mr);
+  const auto lastPeerBegin =
+      firstSearchPosition(orderPositions->view(), stream);
+  const bool lastPeerContinued = continuedWholeBatch &&
+      continuingPrefixSize(
+          sortedInput,
+          sortKeyIndices_,
+          previousOrderKey_,
+          sortOrders_,
+          nullOrders_,
+          stream,
+          mr) == numRows;
+
+  const auto priorRows = continuedWholeBatch ? previousPartitionRows_ : 0;
+  if (!lastPeerContinued) {
+    previousRank_ = priorRows + lastPeerBegin + 1;
+  }
+  previousPartitionRows_ = priorRows + numRows - trailingPartitionBegin;
+  previousPartitionKey_ =
+      std::make_unique<cudf::table>(lastPartition.front(), stream, mr);
+  previousOrderKey_ =
+      std::make_unique<cudf::table>(lastOrder.front(), stream, mr);
+  hasRankLikeState_ = true;
 }
 
 void CudfWindow::computeRankColumnsBatch(
@@ -1219,6 +1600,11 @@ std::unique_ptr<cudf::column> CudfWindow::computeAggregateColumn(
 void CudfWindow::doNoMoreInput() {
   Operator::noMoreInput();
 
+  if (rankLikeStreaming_) {
+    finished_ = true;
+    return;
+  }
+
   if (spilled_) {
     if (!inputBatches_.empty()) {
       spillSortedRun();
@@ -1290,7 +1676,7 @@ void CudfWindow::doNoMoreInput() {
 }
 
 bool CudfWindow::isFinished() {
-  return finished_;
+  return finished_ && pendingOutput_ == nullptr;
 }
 
 RowVectorPtr CudfWindow::computeOutput() {
@@ -1303,7 +1689,7 @@ RowVectorPtr CudfWindow::computeOutput() {
   auto partKeys = sortedView.select(partitionKeyIndices_);
 
   std::unique_ptr<cudf::groupby::groupby> rankGrouper;
-  if (!partitionKeyIndices_.empty()) {
+  if (!rankLikeStreaming_ && !partitionKeyIndices_.empty()) {
     bool needsRankGrouper = false;
     const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
     for (const auto& func : windowNode_->windowFunctions()) {
@@ -1343,7 +1729,23 @@ RowVectorPtr CudfWindow::computeOutput() {
 
     if (baseName == "row_number" || baseName == "rank" ||
         baseName == "dense_rank") {
-      pendingRanks.emplace_back(funcIndex, baseName);
+      if (rankLikeStreaming_) {
+        auto localResult = baseName == "rank"
+            ? computeStreamingRankColumn(
+                  sortedView,
+                  outputType_->childAt(inputRowType_->size() + funcIndex),
+                  stream_,
+                  mr)
+            : computeStreamingRowNumberColumn(
+                  sortedView,
+                  outputType_->childAt(inputRowType_->size() + funcIndex),
+                  stream_,
+                  mr);
+        windowResultCols[funcIndex] = fixRankLikeColumn(
+            std::move(localResult), baseName, sortedView, stream_, mr);
+      } else {
+        pendingRanks.emplace_back(funcIndex, baseName);
+      }
     } else if (baseName == "lag" || baseName == "lead") {
       auto inputColIdx = resolveInputChannel(func, inputRowType_);
       VELOX_CHECK(
@@ -1438,6 +1840,10 @@ RowVectorPtr CudfWindow::computeOutput() {
       windowResultCols,
       stream_,
       mr);
+
+  if (rankLikeStreaming_) {
+    updateRankLikeState(sortedView, stream_, mr);
+  }
 
   if (!rangeRollingBatches.empty()) {
     ColumnOrView orderbyColHolder{cudf::column_view{}};
@@ -1549,6 +1955,10 @@ RowVectorPtr CudfWindow::computeNextSortedOutput() {
 }
 
 RowVectorPtr CudfWindow::doGetOutput() {
+  if (pendingOutput_) {
+    return std::exchange(pendingOutput_, nullptr);
+  }
+
   if (finished_ || !noMoreInput_) {
     return nullptr;
   }
@@ -1603,7 +2013,11 @@ void CudfWindow::doClose() {
     }
   }
   inputBatches_.clear();
+  pendingOutput_.reset();
   sortedData_.reset();
+  previousPartitionKey_.reset();
+  previousOrderKey_.reset();
+  hasRankLikeState_ = false;
   cleanupSpillFiles();
   if (streamAcquired_) {
     try {

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -33,16 +33,19 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace facebook::velox::cudf_velox {
 
 /// GPU-accelerated Window operator using cuDF.
 ///
-/// Incoming GPU batches are stored in addInput(). Small inputs are concatenated
-/// and sorted when noMoreInput() is called. Large, unsorted, partitioned inputs
-/// are written as sorted runs and merged into complete-partition batches before
-/// window evaluation.
+/// Partitioned row_number/rank windows with an inputsSorted contract are
+/// evaluated and emitted one input batch at a time while retaining only the
+/// partition/order boundary state. Other windows store incoming GPU batches in
+/// addInput(). Small inputs are concatenated and sorted when noMoreInput() is
+/// called. Large, unsorted, partitioned inputs are written as sorted runs and
+/// merged into complete-partition batches before window evaluation.
 ///
 /// inputsSorted fast path: when WindowNode::inputsSorted() is true, this
 /// operator skips stable_sorted_order and the full-table gather (see
@@ -54,9 +57,9 @@ namespace facebook::velox::cudf_velox {
 /// sortOrders_/nullOrders_). Rank grouping with partition keys also assumes
 /// that partition-key ordering when constructing the groupby grouper.
 ///
-/// Memory: the sorted path peaks at roughly concat output plus gather copy plus
-/// window result columns. Batch-wise / streaming evaluation would require a
-/// larger redesign.
+/// Memory: the buffered sorted path peaks at roughly concat output plus gather
+/// copy plus window result columns. The narrow rank-like streaming path is
+/// bounded by one input/output batch and constant-size boundary state.
 ///
 /// Rank-like functions (row_number, rank, dense_rank) use
 /// cudf::groupby::scan with cudf::make_rank_aggregation.
@@ -83,7 +86,7 @@ class CudfWindow : public CudfOperatorBase {
       size_t numArgs);
 
   bool needsInput() const override {
-    return !noMoreInput_;
+    return !noMoreInput_ && pendingOutput_ == nullptr;
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -116,6 +119,39 @@ class CudfWindow : public CudfOperatorBase {
   RowVectorPtr computeNextSortedOutput();
   RowVectorPtr computeOutput();
   void cleanupSpillFiles() noexcept;
+
+  std::unique_ptr<cudf::column> computeStreamingRowNumberColumn(
+      const cudf::table_view& sortedInput,
+      const TypePtr& expectedType,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  std::unique_ptr<cudf::column> computeStreamingRankColumn(
+      const cudf::table_view& sortedInput,
+      const TypePtr& expectedType,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  std::unique_ptr<cudf::column> fixRankLikeColumn(
+      std::unique_ptr<cudf::column> localResult,
+      std::string_view functionName,
+      const cudf::table_view& sortedInput,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  void updateRankLikeState(
+      const cudf::table_view& sortedInput,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+
+  cudf::size_type continuingPrefixSize(
+      const cudf::table_view& sortedInput,
+      const std::vector<cudf::size_type>& indices,
+      const std::unique_ptr<cudf::table>& previousKey,
+      const std::vector<cudf::order>& orders,
+      const std::vector<cudf::null_order>& nullOrders,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
 
   // Compute row_number/rank/dense_rank via cudf::groupby::scan or cudf::scan.
   void computeRankColumnsBatch(
@@ -168,6 +204,8 @@ class CudfWindow : public CudfOperatorBase {
 
   std::shared_ptr<const core::WindowNode> windowNode_;
   const RowTypePtr inputRowType_;
+  const bool rankLikeStreaming_;
+  const rmm::cuda_stream_view stateStream_;
 
   std::vector<cudf::size_type> partitionKeyIndices_;
   std::vector<cudf::size_type> sortKeyIndices_;
@@ -175,6 +213,7 @@ class CudfWindow : public CudfOperatorBase {
   std::vector<cudf::null_order> nullOrders_;
 
   std::vector<CudfVectorPtr> inputBatches_;
+  RowVectorPtr pendingOutput_;
   const uint64_t sortedRunBytes_;
   uint64_t bufferedBytes_{0};
   std::vector<SortedRun> sortedRuns_;
@@ -191,6 +230,12 @@ class CudfWindow : public CudfOperatorBase {
   cudf::size_type logicalRowCount_{0};
   rmm::cuda_stream_view stream_{};
   bool streamAcquired_{false};
+
+  bool hasRankLikeState_{false};
+  std::unique_ptr<cudf::table> previousPartitionKey_;
+  std::unique_ptr<cudf::table> previousOrderKey_;
+  int64_t previousPartitionRows_{0};
+  int64_t previousRank_{0};
 
   bool finished_ = false;
 };

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -39,13 +39,16 @@
 #include <unistd.h>
 
 #include <algorithm>
-#include <cerrno>
 #include <cctype>
+#include <cerrno>
 #include <cstdlib>
+#include <limits>
 #include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace facebook::velox::cudf_velox {
@@ -53,11 +56,60 @@ namespace facebook::velox::cudf_velox {
 namespace {
 std::mutex asyncMemoryPoolsMutex;
 std::vector<cudaMemPool_t> asyncMemoryPools;
+// registerCudf creates the main resource before its optional output resource.
+// Remember which device has seen that first resource so an async output-only
+// pool is never mistaken for the primary cuDF allocation pool.
+std::unordered_set<int> primaryMemoryResourceDevices;
+std::unordered_map<int, cudaMemPool_t> primaryAsyncMemoryPools;
+
+std::mutex deviceMemoryAdmissionMutex;
+std::unordered_map<int, std::size_t> deviceMemoryAdmissionBytes;
+
+struct MemoryResourceRegistration {
+  int device{-1};
+  bool primary{false};
+};
+
+MemoryResourceRegistration beginMemoryResourceRegistration() {
+  MemoryResourceRegistration registration;
+  if (cudaGetDevice(&registration.device) != cudaSuccess) {
+    return registration;
+  }
+  std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+  registration.primary =
+      primaryMemoryResourceDevices.insert(registration.device).second;
+  return registration;
+}
+
+void registerAsyncMemoryPool(
+    const MemoryResourceRegistration& registration,
+    cudaMemPool_t pool) {
+  std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+  asyncMemoryPools.push_back(pool);
+  if (registration.primary && registration.device >= 0) {
+    primaryAsyncMemoryPools[registration.device] = pool;
+  }
+}
+
+void releaseDeviceMemoryAdmission(int device, std::size_t bytes) noexcept {
+  std::lock_guard<std::mutex> lock(deviceMemoryAdmissionMutex);
+  const auto it = deviceMemoryAdmissionBytes.find(device);
+  if (it == deviceMemoryAdmissionBytes.end() || it->second < bytes) {
+    LOG(ERROR) << "Invalid device-memory admission release device=" << device
+               << " bytes=" << bytes;
+    return;
+  }
+  it->second -= bytes;
+  if (it->second == 0) {
+    deviceMemoryAdmissionBytes.erase(it);
+  }
+}
 } // namespace
 
 cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
     std::string_view mode,
     int percent) {
+  const auto registration = beginMemoryResourceRegistration();
   if (mode == "cuda") {
     return rmm::mr::cuda_memory_resource{};
   } else if (mode == "pool") {
@@ -74,10 +126,7 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
     // slack while preserving a large cache for steady-state operators.
     auto resource = rmm::mr::cuda_async_memory_resource(
         std::nullopt, rmm::percent_of_free_device_memory(percent));
-    {
-      std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
-      asyncMemoryPools.push_back(resource.pool_handle());
-    }
+    registerAsyncMemoryPool(registration, resource.pool_handle());
     return resource;
   } else if (mode == "arena") {
     return rmm::mr::arena_memory_resource(
@@ -113,8 +162,7 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
 }
 
 bool trimAsyncMemoryPoolsAtQueryEnd() {
-  const auto* value =
-      std::getenv("GLUTEN_CUDF_ASYNC_QUERY_END_TRIM_BYTES");
+  const auto* value = std::getenv("GLUTEN_CUDF_ASYNC_QUERY_END_TRIM_BYTES");
   if (value == nullptr || value[0] == '\0') {
     return false;
   }
@@ -131,7 +179,6 @@ bool trimAsyncMemoryPoolsAtQueryEnd() {
 }
 
 bool trimAsyncMemoryPoolsAtQueryEnd(std::size_t bytesToKeep) {
-
   std::vector<cudaMemPool_t> pools;
   {
     std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
@@ -164,9 +211,8 @@ bool trimAsyncMemoryPoolsAtQueryEnd(std::size_t bytesToKeep) {
   std::size_t freeAfter = 0;
   cudaMemGetInfo(&freeAfter, &totalBytes);
   LOG(INFO) << "CUDF_ASYNC_QUERY_END_TRIM pools=" << pools.size()
-            << " bytesToKeep=" << bytesToKeep
-            << " freeBefore=" << freeBefore << " freeAfter=" << freeAfter
-            << " released="
+            << " bytesToKeep=" << bytesToKeep << " freeBefore=" << freeBefore
+            << " freeAfter=" << freeAfter << " released="
             << (freeAfter >= freeBefore ? freeAfter - freeBefore : 0);
   return true;
 }
@@ -174,6 +220,138 @@ bool trimAsyncMemoryPoolsAtQueryEnd(std::size_t bytesToKeep) {
 void clearAsyncMemoryPoolHandles() {
   std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
   asyncMemoryPools.clear();
+  primaryAsyncMemoryPools.clear();
+  primaryMemoryResourceDevices.clear();
+}
+
+std::size_t DeviceAllocationHeadroom::reusablePoolBytes() const noexcept {
+  if (!asyncPoolValid || poolReservedBytes <= poolUsedBytes) {
+    return 0;
+  }
+  return poolReservedBytes - poolUsedBytes;
+}
+
+std::size_t DeviceAllocationHeadroom::allocatableBytes() const noexcept {
+  if (!cudaValid) {
+    return 0;
+  }
+  const auto reusable = reusablePoolBytes();
+  if (freeBytes > std::numeric_limits<std::size_t>::max() - reusable) {
+    return std::numeric_limits<std::size_t>::max();
+  }
+  return freeBytes + reusable;
+}
+
+DeviceAllocationHeadroom captureDeviceAllocationHeadroom() {
+  DeviceAllocationHeadroom headroom;
+  if (cudaGetDevice(&headroom.device) != cudaSuccess) {
+    return headroom;
+  }
+
+  headroom.cudaValid =
+      cudaMemGetInfo(&headroom.freeBytes, &headroom.totalBytes) == cudaSuccess;
+  if (!headroom.cudaValid) {
+    headroom.freeBytes = 0;
+    headroom.totalBytes = 0;
+    return headroom;
+  }
+
+  std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+  const auto poolIt = primaryAsyncMemoryPools.find(headroom.device);
+  if (poolIt == primaryAsyncMemoryPools.end()) {
+    return headroom;
+  }
+
+  std::uint64_t reservedBytes = 0;
+  std::uint64_t usedBytes = 0;
+  const auto reservedStatus = cudaMemPoolGetAttribute(
+      poolIt->second, cudaMemPoolAttrReservedMemCurrent, &reservedBytes);
+  const auto usedStatus = cudaMemPoolGetAttribute(
+      poolIt->second, cudaMemPoolAttrUsedMemCurrent, &usedBytes);
+  if (reservedStatus != cudaSuccess || usedStatus != cudaSuccess) {
+    return headroom;
+  }
+
+  headroom.asyncPoolValid = true;
+  headroom.poolReservedBytes = static_cast<std::size_t>(reservedBytes);
+  headroom.poolUsedBytes = static_cast<std::size_t>(usedBytes);
+  return headroom;
+}
+
+DeviceMemoryAdmissionReservation::DeviceMemoryAdmissionReservation(
+    int device,
+    std::size_t bytes) noexcept
+    : device_{device}, bytes_{bytes}, active_{true} {}
+
+DeviceMemoryAdmissionReservation::~DeviceMemoryAdmissionReservation() {
+  release();
+}
+
+DeviceMemoryAdmissionReservation::DeviceMemoryAdmissionReservation(
+    DeviceMemoryAdmissionReservation&& other) noexcept
+    : device_{other.device_}, bytes_{other.bytes_}, active_{other.active_} {
+  other.device_ = -1;
+  other.bytes_ = 0;
+  other.active_ = false;
+}
+
+DeviceMemoryAdmissionReservation& DeviceMemoryAdmissionReservation::operator=(
+    DeviceMemoryAdmissionReservation&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  release();
+  device_ = other.device_;
+  bytes_ = other.bytes_;
+  active_ = other.active_;
+  other.device_ = -1;
+  other.bytes_ = 0;
+  other.active_ = false;
+  return *this;
+}
+
+void DeviceMemoryAdmissionReservation::release() noexcept {
+  if (!active_) {
+    return;
+  }
+  releaseDeviceMemoryAdmission(device_, bytes_);
+  device_ = -1;
+  bytes_ = 0;
+  active_ = false;
+}
+
+std::optional<DeviceMemoryAdmissionReservation> tryAcquireDeviceMemoryAdmission(
+    int device,
+    std::size_t bytes,
+    std::size_t capacityBytes) {
+  if (device < 0 || bytes > capacityBytes) {
+    return std::nullopt;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(deviceMemoryAdmissionMutex);
+    const auto it = deviceMemoryAdmissionBytes.find(device);
+    const auto reserved =
+        it == deviceMemoryAdmissionBytes.end() ? 0 : it->second;
+    if (reserved > capacityBytes - bytes) {
+      return std::nullopt;
+    }
+    if (it == deviceMemoryAdmissionBytes.end()) {
+      deviceMemoryAdmissionBytes.emplace(device, bytes);
+    } else {
+      it->second += bytes;
+    }
+  }
+  return DeviceMemoryAdmissionReservation{device, bytes};
+}
+
+std::size_t deviceMemoryAdmissionReservedBytes(int device) {
+  if (device < 0) {
+    return 0;
+  }
+  std::lock_guard<std::mutex> lock(deviceMemoryAdmissionMutex);
+  const auto it = deviceMemoryAdmissionBytes.find(device);
+  return it == deviceMemoryAdmissionBytes.end() ? 0 : it->second;
 }
 
 cudf::detail::cuda_stream_pool& cudfGlobalStreamPool() {

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -39,13 +39,21 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cctype>
 #include <cstdlib>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 namespace facebook::velox::cudf_velox {
+
+namespace {
+std::mutex asyncMemoryPoolsMutex;
+std::vector<cudaMemPool_t> asyncMemoryPools;
+} // namespace
 
 cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
     std::string_view mode,
@@ -57,7 +65,20 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
         rmm::mr::cuda_memory_resource{},
         rmm::percent_of_free_device_memory(percent));
   } else if (mode == "async") {
-    return rmm::mr::cuda_async_memory_resource{};
+    // cuda_async_memory_resource otherwise defaults its release threshold to
+    // UINT64_MAX. After a transient large join/partition workspace, the CUDA
+    // pool then retains almost the entire device even when RMM's live bytes
+    // have fallen. UCX receive buffers use a separate cudaMalloc resource and
+    // cannot reuse those cached blocks. Apply memoryPercent as the async
+    // pool's retention threshold so synchronization returns high-watermark
+    // slack while preserving a large cache for steady-state operators.
+    auto resource = rmm::mr::cuda_async_memory_resource(
+        std::nullopt, rmm::percent_of_free_device_memory(percent));
+    {
+      std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+      asyncMemoryPools.push_back(resource.pool_handle());
+    }
+    return resource;
   } else if (mode == "arena") {
     return rmm::mr::arena_memory_resource(
         rmm::mr::cuda_memory_resource{},
@@ -89,6 +110,70 @@ cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
       "Unknown memory resource mode: " + std::string(mode) +
       "\nExpecting: cuda, pool, async, arena, managed, prefetch_managed, " +
       "managed_pool, prefetch_managed_pool, managed_async, prefetch_managed_async");
+}
+
+bool trimAsyncMemoryPoolsAtQueryEnd() {
+  const auto* value =
+      std::getenv("GLUTEN_CUDF_ASYNC_QUERY_END_TRIM_BYTES");
+  if (value == nullptr || value[0] == '\0') {
+    return false;
+  }
+
+  char* end = nullptr;
+  errno = 0;
+  const auto parsed = std::strtoull(value, &end, 10);
+  if (errno != 0 || end == value || *end != '\0') {
+    LOG(ERROR) << "Ignoring invalid GLUTEN_CUDF_ASYNC_QUERY_END_TRIM_BYTES='"
+               << value << "'";
+    return false;
+  }
+  return trimAsyncMemoryPoolsAtQueryEnd(static_cast<std::size_t>(parsed));
+}
+
+bool trimAsyncMemoryPoolsAtQueryEnd(std::size_t bytesToKeep) {
+
+  std::vector<cudaMemPool_t> pools;
+  {
+    std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+    pools = asyncMemoryPools;
+  }
+  if (pools.empty()) {
+    return false;
+  }
+
+  std::size_t freeBefore = 0;
+  std::size_t totalBytes = 0;
+  cudaMemGetInfo(&freeBefore, &totalBytes);
+  const auto syncStatus = cudaDeviceSynchronize();
+  if (syncStatus != cudaSuccess) {
+    LOG(ERROR) << "CUDF_ASYNC_QUERY_END_TRIM cudaDeviceSynchronize failed: "
+               << cudaGetErrorString(syncStatus);
+    return false;
+  }
+
+  for (const auto pool : pools) {
+    const auto trimStatus = cudaMemPoolTrimTo(pool, bytesToKeep);
+    if (trimStatus != cudaSuccess) {
+      LOG(ERROR) << "CUDF_ASYNC_QUERY_END_TRIM cudaMemPoolTrimTo failed: "
+                 << cudaGetErrorString(trimStatus)
+                 << " bytesToKeep=" << bytesToKeep;
+      return false;
+    }
+  }
+
+  std::size_t freeAfter = 0;
+  cudaMemGetInfo(&freeAfter, &totalBytes);
+  LOG(INFO) << "CUDF_ASYNC_QUERY_END_TRIM pools=" << pools.size()
+            << " bytesToKeep=" << bytesToKeep
+            << " freeBefore=" << freeBefore << " freeAfter=" << freeAfter
+            << " released="
+            << (freeAfter >= freeBefore ? freeAfter - freeBefore : 0);
+  return true;
+}
+
+void clearAsyncMemoryPoolHandles() {
+  std::lock_guard<std::mutex> lock(asyncMemoryPoolsMutex);
+  asyncMemoryPools.clear();
 }
 
 cudf::detail::cuda_stream_pool& cudfGlobalStreamPool() {

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -60,11 +60,23 @@ rmm::device_async_resource_ref get_output_mr();
  * @brief Creates a memory resource based on the given mode.
  *
  * @param mode rmm::mr::pool_memory_resource mode.
- * @param percent The initial percent of GPU memory to allocate for memory
- * resource.
+ * @param percent The initial percent of GPU memory to allocate for pool or
+ * arena resources, or the retained-memory release threshold for async.
  */
 [[nodiscard]] cuda::mr::any_resource<cuda::mr::device_accessible>
 createMemoryResource(std::string_view mode, int percent);
+
+/// If GLUTEN_CUDF_ASYNC_QUERY_END_TRIM_BYTES is set, synchronizes the device
+/// and releases unused cudaMallocAsync pool memory down to that retained-byte
+/// target. Returns true when a trim was requested and completed successfully.
+[[nodiscard]] bool trimAsyncMemoryPoolsAtQueryEnd();
+
+/// Explicit query-scoped variant. Unlike the no-argument environment
+/// fallback, a zero value is a valid request to release every unused block.
+[[nodiscard]] bool trimAsyncMemoryPoolsAtQueryEnd(std::size_t bytesToKeep);
+
+/// Drops native pool handles after their owning RMM resources are destroyed.
+void clearAsyncMemoryPoolHandles();
 
 /**
  * @brief Returns the global CUDA stream pool used by cudf.

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -46,6 +46,69 @@ struct DeviceMemorySnapshot {
   int64_t rmmTotalAllocations{0};
 };
 
+/// A cheap, always-available view of memory that allocations through the
+/// current device's primary cuDF resource may be able to use. When the primary
+/// resource is not cudaMallocAsync, or its pool attributes cannot be read,
+/// allocatableBytes() conservatively reports cudaMemGetInfo's free bytes only.
+struct DeviceAllocationHeadroom {
+  bool cudaValid{false};
+  bool asyncPoolValid{false};
+  int device{-1};
+  std::size_t freeBytes{0};
+  std::size_t totalBytes{0};
+  std::size_t poolReservedBytes{0};
+  std::size_t poolUsedBytes{0};
+
+  [[nodiscard]] std::size_t reusablePoolBytes() const noexcept;
+  [[nodiscard]] std::size_t allocatableBytes() const noexcept;
+};
+
+/// Process-wide, per-device admission reservation. This does not allocate GPU
+/// memory; it prevents cooperating operators from admitting work against the
+/// same headroom snapshot. The reservation is released on destruction.
+class DeviceMemoryAdmissionReservation {
+ public:
+  DeviceMemoryAdmissionReservation() = default;
+  ~DeviceMemoryAdmissionReservation();
+
+  DeviceMemoryAdmissionReservation(
+      DeviceMemoryAdmissionReservation&& other) noexcept;
+  DeviceMemoryAdmissionReservation& operator=(
+      DeviceMemoryAdmissionReservation&& other) noexcept;
+
+  DeviceMemoryAdmissionReservation(const DeviceMemoryAdmissionReservation&) =
+      delete;
+  DeviceMemoryAdmissionReservation& operator=(
+      const DeviceMemoryAdmissionReservation&) = delete;
+
+  [[nodiscard]] explicit operator bool() const noexcept {
+    return active_;
+  }
+
+  [[nodiscard]] int device() const noexcept {
+    return device_;
+  }
+
+  [[nodiscard]] std::size_t reservedBytes() const noexcept {
+    return bytes_;
+  }
+
+  void release() noexcept;
+
+ private:
+  friend std::optional<DeviceMemoryAdmissionReservation>
+  tryAcquireDeviceMemoryAdmission(
+      int device,
+      std::size_t bytes,
+      std::size_t capacityBytes);
+
+  DeviceMemoryAdmissionReservation(int device, std::size_t bytes) noexcept;
+
+  int device_{-1};
+  std::size_t bytes_{0};
+  bool active_{false};
+};
+
 extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
     output_mr_;
@@ -77,6 +140,25 @@ createMemoryResource(std::string_view mode, int percent);
 
 /// Drops native pool handles after their owning RMM resources are destroyed.
 void clearAsyncMemoryPoolHandles();
+
+/// Captures current-device free memory and, when the primary cuDF resource is
+/// cudaMallocAsync, that pool's currently reusable reserved memory. This API is
+/// independent of diagnostic logging and returns a conservative partial
+/// snapshot when pool attributes are unavailable.
+[[nodiscard]] DeviceAllocationHeadroom captureDeviceAllocationHeadroom();
+
+/// Atomically acquires a cooperative admission reservation for a device when
+/// existing reservations plus 'bytes' do not exceed 'capacityBytes'. Returns
+/// nullopt for invalid devices or insufficient capacity.
+[[nodiscard]] std::optional<DeviceMemoryAdmissionReservation>
+tryAcquireDeviceMemoryAdmission(
+    int device,
+    std::size_t bytes,
+    std::size_t capacityBytes);
+
+/// Returns bytes currently reserved by cooperative admission clients on a
+/// device. This is admission accounting, not live RMM allocation usage.
+[[nodiscard]] std::size_t deviceMemoryAdmissionReservedBytes(int device);
 
 /**
  * @brief Returns the global CUDA stream pool used by cudf.

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -1325,15 +1325,15 @@ class ExchangeAdapter : public OperatorAdapter {
     result.push_back(
         std::make_unique<ucx_exchange::UcxExchange>(
             operatorId, ctx, planNode, client));
-    if (
-        CudfConfig::getInstance().concatOptimizationEnabled &&
+    if (CudfConfig::getInstance().concatOptimizationEnabled &&
         CudfConfig::getInstance().exchangeConcatOptimizationEnabled) {
-      result.push_back(std::make_unique<CudfBatchConcat>(
-          operatorId,
-          ctx,
-          planNode,
-          planNode->outputType(),
-          CudfConfig::getInstance().exchangeBatchSizeMinThreshold));
+      result.push_back(
+          std::make_unique<CudfBatchConcat>(
+              operatorId,
+              ctx,
+              planNode,
+              planNode->outputType(),
+              CudfConfig::getInstance().exchangeBatchSizeMinThreshold));
     }
     return result;
   }

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -1325,6 +1325,16 @@ class ExchangeAdapter : public OperatorAdapter {
     result.push_back(
         std::make_unique<ucx_exchange::UcxExchange>(
             operatorId, ctx, planNode, client));
+    if (
+        CudfConfig::getInstance().concatOptimizationEnabled &&
+        CudfConfig::getInstance().exchangeConcatOptimizationEnabled) {
+      result.push_back(std::make_unique<CudfBatchConcat>(
+          operatorId,
+          ctx,
+          planNode,
+          planNode->outputType(),
+          CudfConfig::getInstance().exchangeBatchSizeMinThreshold));
+    }
     return result;
   }
 

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -621,6 +621,25 @@ void CudfConfig::initialize(
         value, 0, "{} must be positive", kCudfWindowSortedRunBytes);
     windowSortedRunBytes = static_cast<uint64_t>(value);
   }
+  if (config.find(kCudfOrderByOutputChunkBytes) != config.end()) {
+    const auto value =
+        folly::to<int64_t>(config[kCudfOrderByOutputChunkBytes]);
+    VELOX_USER_CHECK_GT(
+        value, 0, "{} must be positive", kCudfOrderByOutputChunkBytes);
+    orderByOutputChunkBytes = static_cast<uint64_t>(value);
+  }
+  if (config.find(kCudfOrderByMaxOutputRows) != config.end()) {
+    const auto value = folly::to<int64_t>(config[kCudfOrderByMaxOutputRows]);
+    VELOX_USER_CHECK_GT(
+        value, 0, "{} must be positive", kCudfOrderByMaxOutputRows);
+    VELOX_USER_CHECK_LE(
+        value,
+        std::numeric_limits<int32_t>::max(),
+        "{} must not exceed {}",
+        kCudfOrderByMaxOutputRows,
+        std::numeric_limits<int32_t>::max());
+    orderByMaxOutputRows = static_cast<int32_t>(value);
+  }
   if (config.find(kCudfExchangeConcatOptimizationEnabled) != config.end()) {
     exchangeConcatOptimizationEnabled =
         folly::to<bool>(config[kCudfExchangeConcatOptimizationEnabled]);

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -503,6 +503,10 @@ void CudfConfig::initialize(
     batchSizeMinThreshold =
         folly::to<int32_t>(config[kCudfBatchSizeMinThreshold]);
   }
+  if (config.find(kCudfBatchSizeMinThresholdBytes) != config.end()) {
+    batchSizeMinThresholdBytes =
+        folly::to<uint64_t>(config[kCudfBatchSizeMinThresholdBytes]);
+  }
   if (config.find(kCudfBatchSizeMaxThreshold) != config.end()) {
     batchSizeMaxThreshold =
         folly::to<int32_t>(config[kCudfBatchSizeMaxThreshold]);

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -33,6 +33,7 @@
 #include "velox/experimental/cudf/expression/JitExpression.h"
 #include "velox/experimental/cudf/expression/PrestoFunctions.h"
 #include "velox/experimental/cudf/expression/SparkFunctions.h"
+#include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
 
 #include "folly/Conv.h"
 #include "velox/core/PlanNode.h"
@@ -41,6 +42,7 @@
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/PartitionedOutput.h"
+#include "velox/exec/Task.h"
 #include "velox/exec/Values.h"
 
 #include <cudf/detail/nvtx/ranges.hpp>
@@ -120,6 +122,59 @@ RowTypePtr gpuInputBoundaryType(
   VELOX_CHECK_GT(
       planNode->sources().size(), 0, "GPU input boundary requires a source");
   return planNode->sources()[0]->outputType();
+}
+
+class UcxPartitionedOutputBufferManager final
+    : public exec::PartitionedOutputBufferManager {
+ public:
+  bool supports(
+      const core::PartitionedOutputNode& node,
+      const core::QueryConfig& queryConfig) const override {
+    const auto& config = CudfConfig::getInstance();
+    const auto cudfEnabled =
+        queryConfig.get<bool>(CudfConfig::kCudfEnabled, config.enabled);
+    return cudfEnabled && config.exchange &&
+        node.transportType() ==
+        core::PartitionedOutputNode::TransportType::kUcx;
+  }
+
+  void initializeTask(
+      std::shared_ptr<exec::Task> task,
+      core::PartitionedOutputNode::Kind kind,
+      int numPartitions,
+      int numOutputDrivers) override {
+    ucx_exchange::UcxOutputQueueManager::getInstanceRef()->initializeTask(
+        std::move(task), kind, numPartitions, numOutputDrivers);
+  }
+
+  void updateOutputBuffers(
+      const std::string& taskId,
+      int numBuffers,
+      bool noMoreBuffers) override {
+    ucx_exchange::UcxOutputQueueManager::getInstanceRef()
+        ->updateOutputBuffersIfExists(taskId, numBuffers, noMoreBuffers);
+  }
+
+  void updateNumDrivers(const std::string& taskId, uint32_t numOutputDrivers)
+      override {
+    ucx_exchange::UcxOutputQueueManager::getInstanceRef()
+        ->updateNumDriversIfExists(taskId, numOutputDrivers);
+  }
+
+  std::optional<exec::OutputBuffer::Stats> stats(
+      const std::string& taskId) override {
+    return ucx_exchange::UcxOutputQueueManager::getInstanceRef()->stats(taskId);
+  }
+
+  void removeTask(const std::string& taskId) override {
+    ucx_exchange::UcxOutputQueueManager::getInstanceRef()->removeTask(taskId);
+  }
+};
+
+std::shared_ptr<exec::PartitionedOutputBufferManager>&
+ucxPartitionedOutputBufferManagerRegistration() {
+  static std::shared_ptr<exec::PartitionedOutputBufferManager> manager;
+  return manager;
 }
 
 } // namespace
@@ -457,10 +512,19 @@ void registerCudf() {
     registerJitEvaluator(CudfConfig::getInstance().jitExpressionPriority);
   }
 
+  auto outputManager = std::make_shared<UcxPartitionedOutputBufferManager>();
+  VELOX_CHECK(exec::registerPartitionedOutputBufferManager(outputManager));
+  ucxPartitionedOutputBufferManagerRegistration() = std::move(outputManager);
+
   isCudfRegistered = true;
 }
 
 void unregisterCudf() {
+  auto& outputManager = ucxPartitionedOutputBufferManagerRegistration();
+  if (outputManager != nullptr) {
+    VELOX_CHECK(exec::unregisterPartitionedOutputBufferManager(outputManager));
+    outputManager.reset();
+  }
   output_mr_.reset();
   mr_.reset();
   output_statistics_mr_.reset();

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -529,6 +529,7 @@ void unregisterCudf() {
   mr_.reset();
   output_statistics_mr_.reset();
   statistics_mr_.reset();
+  clearAsyncMemoryPoolHandles();
   exec::DriverFactory::adapters.erase(
       std::remove_if(
           exec::DriverFactory::adapters.begin(),
@@ -570,6 +571,10 @@ void CudfConfig::initialize(
   if (config.find(kCudfBatchSizeMinThresholdBytes) != config.end()) {
     batchSizeMinThresholdBytes =
         folly::to<uint64_t>(config[kCudfBatchSizeMinThresholdBytes]);
+  }
+  if (config.find(kCudfExchangeBatchSizeMinThreshold) != config.end()) {
+    exchangeBatchSizeMinThreshold =
+        folly::to<int32_t>(config[kCudfExchangeBatchSizeMinThreshold]);
   }
   if (config.find(kCudfBatchSizeMaxThreshold) != config.end()) {
     batchSizeMaxThreshold =
@@ -615,6 +620,10 @@ void CudfConfig::initialize(
     VELOX_USER_CHECK_GT(
         value, 0, "{} must be positive", kCudfWindowSortedRunBytes);
     windowSortedRunBytes = static_cast<uint64_t>(value);
+  }
+  if (config.find(kCudfExchangeConcatOptimizationEnabled) != config.end()) {
+    exchangeConcatOptimizationEnabled =
+        folly::to<bool>(config[kCudfExchangeConcatOptimizationEnabled]);
   }
   if (config.find(kCudfFunctionNamePrefix) != config.end()) {
     functionNamePrefix = config[kCudfFunctionNamePrefix];

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -622,8 +622,7 @@ void CudfConfig::initialize(
     windowSortedRunBytes = static_cast<uint64_t>(value);
   }
   if (config.find(kCudfOrderByOutputChunkBytes) != config.end()) {
-    const auto value =
-        folly::to<int64_t>(config[kCudfOrderByOutputChunkBytes]);
+    const auto value = folly::to<int64_t>(config[kCudfOrderByOutputChunkBytes]);
     VELOX_USER_CHECK_GT(
         value, 0, "{} must be positive", kCudfOrderByOutputChunkBytes);
     orderByOutputChunkBytes = static_cast<uint64_t>(value);

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -252,6 +252,42 @@ TEST_F(AdapterOperatorTest, streamingRankProducesOutputBeforeNoMoreInput) {
   values.close();
 }
 
+TEST_F(AdapterOperatorTest, streamingRankClosesWithPendingOutput) {
+  auto data = makeRowVector(
+      {"k", "o"},
+      {makeFlatVector<int64_t>({1, 1}), makeFlatVector<int64_t>({0, 1})});
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .streamingWindow({"rank() over (partition by k order by o) as rnk"})
+          .planNode();
+  auto windowNode = std::dynamic_pointer_cast<const core::WindowNode>(plan);
+  ASSERT_NE(windowNode, nullptr);
+  auto valuesNode = std::dynamic_pointer_cast<const core::ValuesNode>(
+      windowNode->sources()[0]);
+  ASSERT_NE(valuesNode, nullptr);
+
+  auto task = Task::create(
+      "streaming-rank-closes-with-pending-output",
+      core::PlanFragment{plan},
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
+  auto driver = Driver::testingCreate(
+      std::make_unique<DriverCtx>(task, 0, 0, kUngroupedGroupId, 0));
+  cudf_velox::CudfValues values(0, driver->driverCtx(), valuesNode);
+  cudf_velox::CudfWindow window(1, driver->driverCtx(), windowNode);
+  values.initialize();
+  window.initialize();
+
+  auto input = values.getOutput();
+  ASSERT_NE(input, nullptr);
+  window.addInput(std::move(input));
+  EXPECT_FALSE(window.needsInput());
+  EXPECT_NO_THROW(window.close());
+  values.close();
+}
+
 TEST_F(AdapterOperatorTest, streamingRankThreeBatchDescendingNullTie) {
   std::vector<RowVectorPtr> data{
       makeRowVector(

--- a/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
@@ -63,8 +63,9 @@ using namespace facebook::velox::exec::test;
 
 namespace {
 
-class CudfAggregationSelectionTest : public ::testing::Test,
-                                     public facebook::velox::test::VectorTestBase {
+class CudfAggregationSelectionTest
+    : public ::testing::Test,
+      public facebook::velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});

--- a/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
@@ -64,7 +64,7 @@ using namespace facebook::velox::exec::test;
 namespace {
 
 class CudfAggregationSelectionTest : public ::testing::Test,
-                                     public test::VectorTestBase {
+                                     public facebook::velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -1019,6 +1019,62 @@ TEST_F(AggregationTest, partialAggregationMemoryLimit) {
           .customStats.count("flushRowCount"));
 }
 
+TEST_F(AggregationTest, partialAggregationUsesBalancedRunMerges) {
+  std::vector<RowVectorPtr> vectors;
+  constexpr int32_t kBatches = 8;
+  constexpr int32_t kRowsPerBatch = 100;
+  for (int32_t batch = 0; batch < kBatches; ++batch) {
+    vectors.push_back(makeRowVector(
+        {makeFlatVector<int64_t>(
+             kRowsPerBatch,
+             [batch](vector_size_t row) {
+               return static_cast<int64_t>(batch) * kRowsPerBatch + row;
+             }),
+         makeFlatVector<int64_t>(
+             kRowsPerBatch, [](vector_size_t row) { return row + 1; })}));
+  }
+  createDuckDbTable(vectors);
+
+  core::PlanNodeId partialAggId;
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .maxDrivers(1)
+                  .plan(
+                      PlanBuilder()
+                          .values(vectors)
+                          .partialAggregation({"c0"}, {"sum(c1)"})
+                          .capturePlanNodeId(partialAggId)
+                          .finalAggregation()
+                          .planNode())
+                  .assertResults(
+                      "SELECT c0, sum(c1) FROM tmp GROUP BY c0");
+
+  const auto planStats = toPlanStats(task->taskStats());
+  const auto& stats = planStats.at(partialAggId).customStats;
+  std::string availableStats;
+  for (const auto& [nodeId, nodeStats] : planStats) {
+    for (const auto& [statName, unused] : nodeStats.customStats) {
+      availableStats += nodeId + ":" + statName + ",";
+    }
+  }
+  for (const auto* statName :
+       {"cudfIntermediateAggregationInputRuns",
+        "cudfIntermediateAggregationRunMerges",
+        "cudfIntermediateAggregationMergeRows"}) {
+    ASSERT_EQ(stats.count(statName), 1)
+        << "Missing runtime stat: " << statName
+        << "; available stats: " << availableStats;
+  }
+  EXPECT_EQ(stats.at("cudfIntermediateAggregationInputRuns").sum, kBatches);
+  EXPECT_EQ(
+      stats.at("cudfIntermediateAggregationRunMerges").sum, kBatches - 1);
+  // With disjoint keys, balanced merges process 800 rows at each of the three
+  // levels. Repeatedly merging the complete accumulated state would process
+  // 3,500 rows for the same eight pages.
+  EXPECT_EQ(stats.at("cudfIntermediateAggregationMergeRows").sum, 2400);
+  EXPECT_EQ(
+      stats.count("cudfIntermediateAggregationFinalizeMerges"), 0);
+}
+
 class FinalAggregationStreamingTest : public AggregationTest {
  protected:
   class ScopedStreamingCapacity {

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -1154,6 +1154,84 @@ TEST_F(FinalAggregationStreamingTest, finalAggregationStreamsOnAddInput) {
   assertStreamingFinalStats(planStats.at(finalAggId).customStats);
 }
 
+TEST_F(FinalAggregationStreamingTest, finalAggregationLevelledRuns) {
+  ScopedStreamingCapacity levelledCapacity{0};
+  auto vectors = {
+      makeRowVector({makeFlatVector<int32_t>(
+          100, [](auto row) { return row % 17; })}),
+      makeRowVector({makeFlatVector<int32_t>(
+          110, [](auto row) { return (row + 7) % 17; })}),
+      makeRowVector({makeFlatVector<int32_t>(
+          90, [](auto row) { return (row + 13) % 17; })}),
+  };
+  createDuckDbTable(vectors);
+
+  core::PlanNodeId finalAggId;
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .config(QueryConfig::kMaxPartialAggregationMemory, 1)
+                  .plan(
+                      PlanBuilder()
+                          .values(vectors)
+                          .partialAggregation({"c0"}, {"sum(c0)"})
+                          .finalAggregation()
+                          .capturePlanNodeId(finalAggId)
+                          .planNode())
+                  .assertResults("SELECT c0, sum(c0) FROM tmp GROUP BY c0");
+
+  const auto planStats = toPlanStats(task->taskStats());
+  const auto finalStatsIt = std::find_if(
+      planStats.begin(), planStats.end(), [](const auto& entry) {
+        return entry.second.customStats.contains(
+            "cudfFinalAggregationInputRuns");
+      });
+  ASSERT_NE(finalStatsIt, planStats.end());
+  const auto& finalStats = finalStatsIt->second.customStats;
+  ASSERT_TRUE(finalStats.contains("cudfFinalAggregationRunMerges"));
+  EXPECT_GT(finalStats.at("cudfFinalAggregationInputRuns").sum, 1);
+  EXPECT_GT(finalStats.at("cudfFinalAggregationRunMerges").sum, 0);
+  EXPECT_EQ(finalStats.count("cudfFinalStreamingBatches"), 0);
+}
+
+TEST_F(
+    FinalAggregationStreamingTest,
+    companionFinalAggregationUsesLevelledRuns) {
+  ScopedStreamingCapacity levelledCapacity{0};
+  auto vectors = {
+      makeRowVector(
+          {makeFlatVector<int64_t>(100, [](auto row) { return row % 17; }),
+           makeFlatVector<int64_t>(100, [](auto row) { return row + 1; })}),
+      makeRowVector(
+          {makeFlatVector<int64_t>(110, [](auto row) { return row % 17; }),
+           makeFlatVector<int64_t>(110, [](auto row) { return row + 101; })}),
+      makeRowVector(
+          {makeFlatVector<int64_t>(90, [](auto row) { return row % 17; }),
+           makeFlatVector<int64_t>(90, [](auto row) { return row + 211; })}),
+  };
+  createDuckDbTable(vectors);
+
+  core::PlanNodeId finalAggId;
+  auto task =
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .config(QueryConfig::kMaxPartialAggregationMemory, 1)
+          .plan(
+              PlanBuilder()
+                  .values(vectors)
+                  .partialAggregation({"c0"}, {"sum_partial(c1)"})
+                  .finalAggregation(
+                      {"c0"},
+                      {"sum_merge_extract_BIGINT(a0)"},
+                      {{BIGINT()}})
+                  .capturePlanNodeId(finalAggId)
+                  .planNode())
+          .assertResults("SELECT c0, sum(c1) FROM tmp GROUP BY c0");
+
+  const auto planStats = toPlanStats(task->taskStats());
+  const auto& finalStats = planStats.at(finalAggId).customStats;
+  EXPECT_GT(finalStats.at("cudfFinalAggregationInputRuns").sum, 1);
+  EXPECT_GT(finalStats.at("cudfFinalAggregationRunMerges").sum, 0);
+  EXPECT_EQ(finalStats.count("cudfFinalStreamingBatches"), 0);
+}
+
 TEST_F(FinalAggregationStreamingTest, finalAggregationStreamingMixedAggs) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -1045,8 +1045,7 @@ TEST_F(AggregationTest, partialAggregationUsesBalancedRunMerges) {
                           .capturePlanNodeId(partialAggId)
                           .finalAggregation()
                           .planNode())
-                  .assertResults(
-                      "SELECT c0, sum(c1) FROM tmp GROUP BY c0");
+                  .assertResults("SELECT c0, sum(c1) FROM tmp GROUP BY c0");
 
   const auto planStats = toPlanStats(task->taskStats());
   const auto& stats = planStats.at(partialAggId).customStats;
@@ -1065,14 +1064,12 @@ TEST_F(AggregationTest, partialAggregationUsesBalancedRunMerges) {
         << "; available stats: " << availableStats;
   }
   EXPECT_EQ(stats.at("cudfIntermediateAggregationInputRuns").sum, kBatches);
-  EXPECT_EQ(
-      stats.at("cudfIntermediateAggregationRunMerges").sum, kBatches - 1);
+  EXPECT_EQ(stats.at("cudfIntermediateAggregationRunMerges").sum, kBatches - 1);
   // With disjoint keys, balanced merges process 800 rows at each of the three
   // levels. Repeatedly merging the complete accumulated state would process
   // 3,500 rows for the same eight pages.
   EXPECT_EQ(stats.at("cudfIntermediateAggregationMergeRows").sum, 2400);
-  EXPECT_EQ(
-      stats.count("cudfIntermediateAggregationFinalizeMerges"), 0);
+  EXPECT_EQ(stats.count("cudfIntermediateAggregationFinalizeMerges"), 0);
 }
 
 class FinalAggregationStreamingTest : public AggregationTest {
@@ -1213,8 +1210,8 @@ TEST_F(FinalAggregationStreamingTest, finalAggregationStreamsOnAddInput) {
 TEST_F(FinalAggregationStreamingTest, finalAggregationLevelledRuns) {
   ScopedStreamingCapacity levelledCapacity{0};
   auto vectors = {
-      makeRowVector({makeFlatVector<int32_t>(
-          100, [](auto row) { return row % 17; })}),
+      makeRowVector(
+          {makeFlatVector<int32_t>(100, [](auto row) { return row % 17; })}),
       makeRowVector({makeFlatVector<int32_t>(
           110, [](auto row) { return (row + 7) % 17; })}),
       makeRowVector({makeFlatVector<int32_t>(
@@ -1235,8 +1232,8 @@ TEST_F(FinalAggregationStreamingTest, finalAggregationLevelledRuns) {
                   .assertResults("SELECT c0, sum(c0) FROM tmp GROUP BY c0");
 
   const auto planStats = toPlanStats(task->taskStats());
-  const auto finalStatsIt = std::find_if(
-      planStats.begin(), planStats.end(), [](const auto& entry) {
+  const auto finalStatsIt =
+      std::find_if(planStats.begin(), planStats.end(), [](const auto& entry) {
         return entry.second.customStats.contains(
             "cudfFinalAggregationInputRuns");
       });
@@ -1274,9 +1271,7 @@ TEST_F(
                   .values(vectors)
                   .partialAggregation({"c0"}, {"sum_partial(c1)"})
                   .finalAggregation(
-                      {"c0"},
-                      {"sum_merge_extract_BIGINT(a0)"},
-                      {{BIGINT()}})
+                      {"c0"}, {"sum_merge_extract_BIGINT(a0)"}, {{BIGINT()}})
                   .capturePlanNodeId(finalAggId)
                   .planNode())
           .assertResults("SELECT c0, sum(c1) FROM tmp GROUP BY c0");

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -41,10 +41,14 @@ class CudfBatchConcatTest : public OperatorTestBase {
     OperatorTestBase::TearDown();
   }
 
-  void updateCudfConfig(int32_t min, std::optional<int32_t> max) {
+  void updateCudfConfig(
+      int32_t min,
+      std::optional<int32_t> max,
+      uint64_t minBytes = 0) {
     auto& config = CudfConfig::getInstance();
     config.batchSizeMinThreshold = min;
     config.batchSizeMaxThreshold = max;
+    config.batchSizeMinThresholdBytes = minBytes;
   }
 
   template <typename T>
@@ -64,22 +68,6 @@ class CudfBatchConcatTest : public OperatorTestBase {
     return PlanBuilder(generator).localPartitionRoundRobin(sources).planNode();
   }
 
-  // Returns the per-operator-type stats for CudfBatchConcat within the given
-  // plan node, or nullptr if CudfBatchConcat wasn't inserted for that node.
-  const PlanNodeStats* getConcatStats(
-      const std::shared_ptr<Task>& task,
-      const core::PlanNodeId& aggNodeId) {
-    auto planStats = toPlanStats(task->taskStats());
-    auto nodeIt = planStats.find(aggNodeId);
-    if (nodeIt == planStats.end()) {
-      return nullptr;
-    }
-    auto opIt = nodeIt->second.operatorStats.find("CudfBatchConcat");
-    if (opIt == nodeIt->second.operatorStats.end()) {
-      return nullptr;
-    }
-    return opIt->second.get();
-  }
 };
 
 // Verifies that CudfBatchConcat is inserted before aggregation and reduces
@@ -124,6 +112,46 @@ TEST_F(CudfBatchConcatTest, concatReducesBatchesBeforeAggregation) {
       << "CudfBatchConcat should have received all 6 input batches";
   EXPECT_LT(concatStats.outputVectors, concatStats.inputVectors)
       << "CudfBatchConcat should produce fewer output batches than input";
+}
+
+TEST_F(CudfBatchConcatTest, concatFlushesAtByteThreshold) {
+  // Keep the row threshold out of reach. Six 10-row BIGINT batches are
+  // coalesced based only on their cumulative byte size.
+  updateCudfConfig(
+      /*min=*/std::numeric_limits<int32_t>::max(),
+      /*max=*/std::nullopt,
+      /*minBytes=*/100);
+  CudfConfig::getInstance().concatOptimizationEnabled = true;
+
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < 6; ++i) {
+    vectors.push_back(makeRowVector({makeFlatSequence<int64_t>(i * 10, 10)}));
+  }
+  createDuckDbTable(vectors);
+
+  auto generator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId aggNodeId;
+  auto plan = PlanBuilder(generator)
+                  .addNode([&](auto, auto) {
+                    return createFragmentedSource(vectors, generator);
+                  })
+                  .singleAggregation({}, {"sum(c0)"})
+                  .capturePlanNodeId(aggNodeId)
+                  .planNode();
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .plan(plan)
+                  .maxDrivers(1)
+                  .assertResults("SELECT sum(c0) FROM tmp");
+
+  const auto planStats = toPlanStats(task->taskStats());
+  const auto& nodeStats = planStats.at(aggNodeId);
+  const auto concatIt = nodeStats.operatorStats.find("CudfBatchConcat");
+  ASSERT_NE(concatIt, nodeStats.operatorStats.end());
+  const auto& concatStats = *concatIt->second;
+  EXPECT_EQ(concatStats.inputVectors, 6);
+  EXPECT_GT(concatStats.outputVectors, 1);
+  EXPECT_LT(concatStats.outputVectors, concatStats.inputVectors);
 }
 
 // Verifies that CudfBatchConcat is not inserted when the optimization is

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -67,7 +67,6 @@ class CudfBatchConcatTest : public OperatorTestBase {
     }
     return PlanBuilder(generator).localPartitionRoundRobin(sources).planNode();
   }
-
 };
 
 // Verifies that CudfBatchConcat is inserted before aggregation and reduces

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 
 velox_add_cudf_test(
   NAME velox_cudf_adapter_operator_test
-  SOURCES Main.cpp AdapterOperatorTest.cpp
+  SOURCES Main.cpp AdapterOperatorTest.cpp TaskOutputManagerTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib velox_window velox_functions_spark_window
 )
 

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -23,6 +23,12 @@
 namespace facebook::velox::cudf_velox::test {
 
 TEST(ConfigTest, CudfConfig) {
+  CudfConfig defaults;
+  EXPECT_FALSE(defaults.concatOptimizationEnabled);
+  EXPECT_TRUE(defaults.exchangeConcatOptimizationEnabled);
+  EXPECT_EQ(defaults.batchSizeMinThreshold, 100000);
+  EXPECT_EQ(defaults.exchangeBatchSizeMinThreshold, 32000000);
+
   std::unordered_map<std::string, std::string> options = {
       {CudfConfig::kCudfEnabled, "false"},
       {CudfConfig::kCudfDebugEnabled, "true"},
@@ -32,6 +38,7 @@ TEST(ConfigTest, CudfConfig) {
       {CudfConfig::kCudfAllowCpuFallback, "false"},
       {CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys, "16777216"},
       {CudfConfig::kCudfOrderBySortedRunBytes, "67108864"},
+      {CudfConfig::kCudfExchangeConcatOptimizationEnabled, "false"},
       {CudfConfig::kCudfOrderByMergeFanIn, "7"},
       {CudfConfig::kCudfWindowSortedRunBytes, "134217728"}};
 
@@ -42,6 +49,7 @@ TEST(ConfigTest, CudfConfig) {
   ASSERT_EQ(config.memoryResource, "arena");
   ASSERT_EQ(config.memoryPercent, 25);
   ASSERT_EQ(config.functionNamePrefix, "presto");
+  ASSERT_EQ(config.exchangeConcatOptimizationEnabled, false);
   ASSERT_EQ(config.allowCpuFallback, false);
   ASSERT_EQ(config.groupbyStreamingMaxDistinctKeys, 16777216);
   ASSERT_EQ(config.orderBySortedRunBytes, 67108864);

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -38,6 +38,8 @@ TEST(ConfigTest, CudfConfig) {
       {CudfConfig::kCudfAllowCpuFallback, "false"},
       {CudfConfig::kCudfGroupbyStreamingMaxDistinctKeys, "16777216"},
       {CudfConfig::kCudfOrderBySortedRunBytes, "67108864"},
+      {CudfConfig::kCudfOrderByOutputChunkBytes, "134217728"},
+      {CudfConfig::kCudfOrderByMaxOutputRows, "1048576"},
       {CudfConfig::kCudfExchangeConcatOptimizationEnabled, "false"},
       {CudfConfig::kCudfOrderByMergeFanIn, "7"},
       {CudfConfig::kCudfWindowSortedRunBytes, "134217728"}};
@@ -55,6 +57,8 @@ TEST(ConfigTest, CudfConfig) {
   ASSERT_EQ(config.orderBySortedRunBytes, 67108864);
   ASSERT_EQ(config.orderByMergeFanIn, 7);
   ASSERT_EQ(config.windowSortedRunBytes, 134217728);
+  ASSERT_EQ(config.orderByOutputChunkBytes, 134217728);
+  ASSERT_EQ(config.orderByMaxOutputRows, 1048576);
 }
 
 TEST(ConfigTest, WindowBounds) {
@@ -70,6 +74,8 @@ TEST(ConfigTest, OrderByBounds) {
   CudfConfig defaultConfig;
   EXPECT_EQ(defaultConfig.orderBySortedRunBytes, 256ULL << 20);
   EXPECT_EQ(defaultConfig.orderByMergeFanIn, 8);
+  EXPECT_EQ(defaultConfig.orderByOutputChunkBytes, 32ULL << 20);
+  EXPECT_EQ(defaultConfig.orderByMaxOutputRows, 262144);
 
   CudfConfig zeroRunBytes;
   EXPECT_ANY_THROW(
@@ -82,6 +88,18 @@ TEST(ConfigTest, OrderByBounds) {
   CudfConfig highFanIn;
   EXPECT_ANY_THROW(
       highFanIn.initialize({{CudfConfig::kCudfOrderByMergeFanIn, "65"}}));
+
+  CudfConfig zeroOutputBytes;
+  EXPECT_ANY_THROW(zeroOutputBytes.initialize(
+      {{CudfConfig::kCudfOrderByOutputChunkBytes, "0"}}));
+
+  CudfConfig zeroOutputRows;
+  EXPECT_ANY_THROW(zeroOutputRows.initialize(
+      {{CudfConfig::kCudfOrderByMaxOutputRows, "0"}}));
+
+  CudfConfig overflowOutputRows;
+  EXPECT_ANY_THROW(overflowOutputRows.initialize(
+      {{CudfConfig::kCudfOrderByMaxOutputRows, "2147483648"}}));
 }
 
 TEST(ConfigTest, GroupbyStreamingMaxDistinctKeysRange) {

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -1644,7 +1644,8 @@ TEST_P(MultiThreadedHashJoinTest, antiJoin) {
       .run();
 
   std::vector<std::string> filters({
-      "u1 > t1", "u1 * t1 > 0",
+      "u1 > t1",
+      "u1 * t1 > 0",
       // This filter is true on rows without a match. It should not prevent
       // the row from being returned.
       // Disabling this because coalesce is not supported in cudf.

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -1644,8 +1644,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoin) {
       .run();
 
   std::vector<std::string> filters({
-      "u1 > t1",
-      "u1 * t1 > 0",
+      "u1 > t1", "u1 * t1 > 0",
       // This filter is true on rows without a match. It should not prevent
       // the row from being returned.
       // Disabling this because coalesce is not supported in cudf.
@@ -2775,15 +2774,12 @@ TEST_F(HashJoinTest, nullAwareRightSemiProjectOverScan) {
         {buildScanId, {buildFile->getPath()}},
     };
 
-    // right semi project not supported
-    VELOX_ASSERT_THROW(
-        HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-            .planNode(plan)
-            .inputSplits(splitPaths)
-            .checkSpillStats(false)
-            .referenceQuery("SELECT u0, u0 IN (SELECT t0 FROM t) FROM u")
-            .run(),
-        "Replacement with cuDF operator failed");
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .planNode(plan)
+        .inputSplits(splitPaths)
+        .checkSpillStats(false)
+        .referenceQuery("SELECT u0, u0 IN (SELECT t0 FROM t) FROM u")
+        .run();
   }
 }
 
@@ -2885,6 +2881,156 @@ TEST_F(HashJoinTest, duplicateJoinKeys) {
   }
 }
 
+TEST_P(MultiThreadedHashJoinTest, rightSemiProjectBuildLeft) {
+  auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  const auto oldMaxBatchRows = cudfConfig.batchSizeMaxThreshold;
+  SCOPE_EXIT {
+    cudfConfig.batchSizeMaxThreshold = oldMaxBatchRows;
+  };
+  // Force the build into three independently hashed tables. This exercises
+  // flag indexing and final output across multiple build tables without
+  // requiring a cudf::size_type-sized test input.
+  cudfConfig.batchSizeMaxThreshold = 4;
+
+  auto probeVectors = std::vector<RowVectorPtr>{
+      makeRowVector(
+          {makeFlatVector<int64_t>({1, 2, 3, 4}),
+           makeFlatVector<int64_t>({10, 20, 30, 40})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({3, 4, 5, 6}),
+           makeFlatVector<int64_t>({31, 40, 50, 60})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({7, 8, 9, 10}),
+           makeFlatVector<int64_t>({70, 80, 90, 100})})};
+  auto buildVectors = std::vector<RowVectorPtr>{
+      makeRowVector(
+          {makeFlatVector<int64_t>({1, 2, 3, 4}),
+           makeFlatVector<int64_t>({10, 21, 30, 41})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({3, 4, 5, 6}),
+           makeFlatVector<int64_t>({32, 40, 51, 61})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({7, 8, 11, 12}),
+           makeFlatVector<int64_t>({71, 80, 110, 120})})};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId joinNodeId;
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .project({"c0 AS t0", "c1 AS t1"})
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .project({"c0 AS u0", "c1 AS u1"})
+                          .planNode(),
+                      "t1 <> u1",
+                      {"u0", "u1", "match"},
+                      core::JoinType::kRightSemiProject)
+                  .capturePlanNodeId(joinNodeId)
+                  .planNode();
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT u.c0, u.c1, EXISTS (SELECT * FROM t WHERE t.c0 = u.c0 AND t.c1 <> u.c1) FROM u")
+      .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+        // The last probe driver must emit multiple vectors, proving that this
+        // case exercised more than one independently hashed build chunk. The
+        // exact chunk count is an implementation detail of the batch splitter;
+        // DuckDB comparison above still verifies every output row and flag.
+        const auto planStats = toPlanStats(task->taskStats());
+        EXPECT_GT(planStats.at(joinNodeId).outputVectors, 1);
+      })
+      .run();
+}
+
+TEST_P(MultiThreadedHashJoinTest, rightSemiProjectNullableResidual) {
+  auto probeVectors = std::vector<RowVectorPtr>{makeRowVector(
+      {makeFlatVector<int64_t>({1, 1, 2, 2, 3}),
+       makeNullableFlatVector<int64_t>(
+           {10, std::nullopt, 21, std::nullopt, 30})})};
+  auto buildVectors = std::vector<RowVectorPtr>{makeRowVector(
+      {makeFlatVector<int64_t>({1, 1, 2, 2, 3, 4, 4}),
+       makeNullableFlatVector<int64_t>(
+           {10, std::nullopt, 20, std::nullopt, 30, std::nullopt, 41})})};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .project({"c0 AS t0", "c1 AS t1"})
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .project({"c0 AS u0", "c1 AS u1"})
+                          .planNode(),
+                      "t1 <> u1",
+                      {"u0", "u1", "match"},
+                      core::JoinType::kRightSemiProject)
+                  .planNode();
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          // DuckDB 0.8.1 can return NULL for this correlated EXISTS when the
+          // residual operands are NULL. SQL EXISTS and Velox ExistenceJoin are
+          // non-nullable: UNKNOWN residual rows are non-matches, hence false.
+          "SELECT u.c0, u.c1, COALESCE(EXISTS (SELECT * FROM t WHERE t.c0 = u.c0 AND t.c1 <> u.c1), false) FROM u")
+      .run();
+}
+
+TEST_P(MultiThreadedHashJoinTest, rightSemiProjectEmptyProbe) {
+  auto probeVectors = std::vector<RowVectorPtr>{makeRowVector(
+      {makeFlatVector<int64_t>(std::vector<int64_t>{}),
+       makeFlatVector<int64_t>(std::vector<int64_t>{})})};
+  auto buildVectors = std::vector<RowVectorPtr>{makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, 1, std::nullopt, 2, 2}),
+       makeFlatVector<int64_t>({10, 11, 12, 20, 20})})};
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .project({"c0 AS t0", "c1 AS t1"})
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .project({"c0 AS u0", "c1 AS u1"})
+                          .planNode(),
+                      "",
+                      {"u0", "u1", "match"},
+                      core::JoinType::kRightSemiProject)
+                  .planNode();
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT u.c0, u.c1, EXISTS (SELECT * FROM t WHERE t.c0 = u.c0) FROM u")
+      .run();
+}
+
 TEST_F(HashJoinTest, semiProject) {
   // Some keys have multiple rows: 2, 3, 5.
   auto probeVectors = makeBatches(3, [&](int32_t /*unused*/) {
@@ -2931,16 +3077,13 @@ TEST_F(HashJoinTest, semiProject) {
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
+      .run();
 
   // With extra filter.
   planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -2967,16 +3110,13 @@ TEST_F(HashJoinTest, semiProject) {
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
+      .run();
 
   // Empty build side.
   planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -3006,19 +3146,16 @@ TEST_F(HashJoinTest, semiProject) {
       // build-side rows have been filtered out.
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE u.c0 < 0 AND t.c0 = u.c0) FROM t")
-          // NOTE: there is no spilling in empty build test case as all the
-          // build-side rows have been filtered out.
-          .checkSpillStats(false)
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE u.c0 < 0 AND t.c0 = u.c0) FROM t")
+      // NOTE: there is no spilling in empty build test case as all the
+      // build-side rows have been filtered out.
+      .checkSpillStats(false)
+      .run();
 }
 
 TEST_F(HashJoinTest, semiProjectWithNullKeys) {
@@ -3083,16 +3220,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t")
+      .run();
 
   plan = makePlan(true /*nullAware*/);
 
@@ -3104,15 +3238,12 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
       .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
+      .run();
 
   // Null join keys on build side-only.
   plan = makePlan(false /*nullAware*/, "t0 IS NOT NULL");
@@ -3125,16 +3256,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t WHERE t0 IS NOT NULL")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t WHERE t0 IS NOT NULL")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0) FROM t WHERE t0 IS NOT NULL")
+      .run();
 
   plan = makePlan(true /*nullAware*/, "t0 IS NOT NULL");
 
@@ -3147,16 +3275,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
+      .run();
 
   // Null join keys on probe side-only.
   plan = makePlan(false /*nullAware*/, "", "u0 IS NOT NULL");
@@ -3169,16 +3294,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NOT NULL) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NOT NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NOT NULL) FROM t")
+      .run();
 
   plan = makePlan(true /*nullAware*/, "", "u0 IS NOT NULL");
 
@@ -3191,16 +3313,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .planNode(flipJoinSides(plan))
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .planNode(flipJoinSides(plan))
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
+      .run();
 
   // Empty build side.
   plan = makePlan(false /*nullAware*/, "", "u0 < 0");
@@ -3213,16 +3332,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 < 0) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(flipJoinSides(plan))
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 < 0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(flipJoinSides(plan))
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 < 0) FROM t")
+      .run();
 
   plan = makePlan(true /*nullAware*/, "", "u0 < 0");
 
@@ -3235,16 +3351,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(flipJoinSides(plan))
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(flipJoinSides(plan))
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
+      .run();
 
   // Build side with all rows having null join keys.
   plan = makePlan(false /*nullAware*/, "", "u0 IS NULL");
@@ -3257,16 +3370,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NULL) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(flipJoinSides(plan))
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(flipJoinSides(plan))
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, EXISTS (SELECT * FROM u WHERE u0 = t0 AND u0 IS NULL) FROM t")
+      .run();
 
   plan = makePlan(true /*nullAware*/, "", "u0 IS NULL");
 
@@ -3279,16 +3389,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NULL) FROM t")
       .run();
 
-  // null-aware right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
-          .planNode(flipJoinSides(plan))
-          .injectSpill(false)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NULL) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(flipJoinSides(plan))
+      .injectSpill(false)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NULL) FROM t")
+      .run();
 }
 
 TEST_F(HashJoinTest, semiProjectWithFilter) {
@@ -3936,15 +4043,12 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
       .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .planNode(flipJoinSides(plan))
-          .inputSplits(splitPaths)
-          .checkSpillStats(false)
-          .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .planNode(flipJoinSides(plan))
+      .inputSplits(splitPaths)
+      .checkSpillStats(false)
+      .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
+      .run();
 
   // With extra filter.
   planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -3971,16 +4075,13 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
       .run();
 
-  // right semi project not supported
-  VELOX_ASSERT_THROW(
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-          .planNode(flipJoinSides(plan))
-          .inputSplits(splitPaths)
-          .checkSpillStats(false)
-          .referenceQuery(
-              "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
-          .run(),
-      "Replacement with cuDF operator failed");
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .planNode(flipJoinSides(plan))
+      .inputSplits(splitPaths)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
+      .run();
 }
 
 // Tests for join filters that require precomputation (non-AST operations)

--- a/velox/experimental/cudf/tests/Main.cpp
+++ b/velox/experimental/cudf/tests/Main.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/memory/Memory.h"
 #include "velox/common/process/ThreadDebugInfo.h"
 
 #include <folly/Unit.h>
@@ -25,5 +26,9 @@ int main(int argc, char** argv) {
   // Signal handler required for ThreadDebugInfoTest
   facebook::velox::process::addDefaultFatalSignalHandler();
   folly::Init init(&argc, &argv, false);
+  // Match the regular Velox exec test main. Without an initialized global
+  // memory manager, fixtures that create vectors fail before SetUp() on their
+  // first small allocation, so no cuDF operator code is exercised.
+  facebook::velox::memory::MemoryManager::initialize({});
   return RUN_ALL_TESTS();
 }

--- a/velox/experimental/cudf/tests/OrderByTest.cpp
+++ b/velox/experimental/cudf/tests/OrderByTest.cpp
@@ -29,6 +29,8 @@
 
 #include <fmt/format.h>
 
+#include <limits>
+
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
@@ -563,6 +565,31 @@ TEST_F(OrderByTest, boundedExternalSortMapPayload) {
   EXPECT_GE(OrderByTestHelper::sourceChunks(), kNumRuns);
   EXPECT_GT(OrderByTestHelper::mergeOutputBatches(), 0);
   EXPECT_EQ(OrderByTestHelper::spillCleanups(), 1);
+}
+
+TEST_F(OrderByTest, inMemoryResultMovesWithoutChunkCopies) {
+  constexpr uint64_t kLargeByteLimit = 1ULL << 40;
+  OrderByTestHelper::setMemoryLimits(
+      kLargeByteLimit,
+      4096,
+      kLargeByteLimit,
+      std::numeric_limits<cudf::size_type>::max());
+
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t batch = 0; batch < 4; ++batch) {
+    vectors.push_back(makeRowVector({makeFlatVector<int64_t>(
+        1024, [batch](vector_size_t row) { return 4096 - batch * 1024 - row; })}));
+  }
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy({"c0 ASC NULLS LAST"}, false)
+                  .planNode();
+  assertQueryOrdered(plan, "SELECT * FROM tmp ORDER BY c0", {0});
+
+  EXPECT_EQ(OrderByTestHelper::emittedChunks(), 1);
+  EXPECT_EQ(OrderByTestHelper::spillCleanups(), 0);
 }
 
 /// Verifies output batch rows of OrderBy

--- a/velox/experimental/cudf/tests/OrderByTest.cpp
+++ b/velox/experimental/cudf/tests/OrderByTest.cpp
@@ -577,8 +577,10 @@ TEST_F(OrderByTest, inMemoryResultMovesWithoutChunkCopies) {
 
   std::vector<RowVectorPtr> vectors;
   for (int32_t batch = 0; batch < 4; ++batch) {
-    vectors.push_back(makeRowVector({makeFlatVector<int64_t>(
-        1024, [batch](vector_size_t row) { return 4096 - batch * 1024 - row; })}));
+    vectors.push_back(makeRowVector(
+        {makeFlatVector<int64_t>(1024, [batch](vector_size_t row) {
+          return 4096 - batch * 1024 - row;
+        })}));
   }
   createDuckDbTable(vectors);
 

--- a/velox/experimental/cudf/tests/OrderByTest.cpp
+++ b/velox/experimental/cudf/tests/OrderByTest.cpp
@@ -262,6 +262,26 @@ TEST_F(OrderByTest, externalSpillSchemaEligibility) {
   ASSERT_NE(safeNestedPayload, nullptr);
   EXPECT_TRUE(cudf_velox::CudfOrderBy::isSupported(safeNestedPayload));
 
+  const auto safeMapPayload =
+      std::dynamic_pointer_cast<const core::OrderByNode>(
+          PlanBuilder()
+              .tableScan(ROW(
+                  {"key", "payload"}, {INTEGER(), MAP(VARCHAR(), VARCHAR())}))
+              .orderBy({"key ASC NULLS LAST"}, false)
+              .planNode());
+  ASSERT_NE(safeMapPayload, nullptr);
+  EXPECT_TRUE(cudf_velox::CudfOrderBy::isSupported(safeMapPayload));
+
+  const auto unsupportedMapKey =
+      std::dynamic_pointer_cast<const core::OrderByNode>(
+          PlanBuilder()
+              .tableScan(ROW(
+                  {"key", "payload"}, {MAP(VARCHAR(), VARCHAR()), INTEGER()}))
+              .orderBy({"key ASC NULLS LAST"}, false)
+              .planNode());
+  ASSERT_NE(unsupportedMapKey, nullptr);
+  EXPECT_FALSE(cudf_velox::CudfOrderBy::isSupported(unsupportedMapKey));
+
   const auto unsupportedBinaryPayload =
       std::dynamic_pointer_cast<const core::OrderByNode>(
           PlanBuilder()
@@ -504,6 +524,44 @@ TEST_F(OrderByTest, boundedExternalSortManyRuns) {
   EXPECT_GE(
       OrderByTestHelper::emittedChunks(),
       (kNumRuns * kRowsPerRun + kMaxOutputRows - 1) / kMaxOutputRows);
+  EXPECT_EQ(OrderByTestHelper::spillCleanups(), 1);
+}
+
+TEST_F(OrderByTest, boundedExternalSortMapPayload) {
+  constexpr int32_t kNumRuns = 7;
+  constexpr vector_size_t kRowsPerRun = 31;
+  OrderByTestHelper::setMemoryLimits(1, 2048, 2048, 13);
+
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(kNumRuns);
+  for (int32_t run = 0; run < kNumRuns; ++run) {
+    auto key = makeFlatVector<int64_t>(kRowsPerRun, [run](vector_size_t row) {
+      return run * kRowsPerRun + row;
+    });
+    auto map = makeMapVector<std::string, std::string>(
+        kRowsPerRun,
+        [](vector_size_t row) { return row % 4; },
+        [run](vector_size_t index) {
+          return fmt::format("key-{}-{}", run, index);
+        },
+        [run](vector_size_t index) {
+          return fmt::format("value-{}-{}", run, index);
+        },
+        [run](vector_size_t row) { return (run + row) % 17 == 0; },
+        [run](vector_size_t index) { return (run + index) % 11 == 0; });
+    vectors.push_back(makeRowVector({key, map}));
+  }
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy({"c0 DESC NULLS LAST"}, false)
+                  .planNode();
+  assertQueryOrdered(
+      plan, "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST", {0});
+
+  EXPECT_GE(OrderByTestHelper::sourceChunks(), kNumRuns);
+  EXPECT_GT(OrderByTestHelper::mergeOutputBatches(), 0);
   EXPECT_EQ(OrderByTestHelper::spillCleanups(), 1);
 }
 

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -722,8 +722,8 @@ TEST_F(TableScanTest, splitOffsetAndLengthWithChunkedOutput) {
           cudf_velox::connector::hive::CudfHiveConfig::
               kMaxChunkReadLimitSession,
           "1024")
-      .splits({Split(makeCudfHiveConnectorSplit(
-          filePath->getPath(), 0, halfFileSize))})
+      .splits({Split(
+          makeCudfHiveConnectorSplit(filePath->getPath(), 0, halfFileSize))})
       .assertResults("SELECT * FROM tmp OFFSET 0 LIMIT 6000");
 
   AssertQueryBuilder(plan, duckDbQueryRunner_)
@@ -732,8 +732,8 @@ TEST_F(TableScanTest, splitOffsetAndLengthWithChunkedOutput) {
           cudf_velox::connector::hive::CudfHiveConfig::
               kMaxChunkReadLimitSession,
           "1024")
-      .splits({Split(makeCudfHiveConnectorSplit(
-          filePath->getPath(), halfFileSize))})
+      .splits({Split(
+          makeCudfHiveConnectorSplit(filePath->getPath(), halfFileSize))})
       .assertResults("SELECT * FROM tmp OFFSET 6000 LIMIT 4000");
 }
 

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -708,6 +708,35 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
       "SELECT * FROM tmp LIMIT 0");
 }
 
+TEST_F(TableScanTest, splitOffsetAndLengthWithChunkedOutput) {
+  auto vectors = makeVectors(10, 1'000);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+  createDuckDbTable(vectors);
+
+  const auto halfFileSize = fs::file_size(filePath->getPath()) / 2;
+  auto plan = tableScanNode();
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .connectorSessionProperty(
+          kCudfHiveConnectorId,
+          cudf_velox::connector::hive::CudfHiveConfig::
+              kMaxChunkReadLimitSession,
+          "1024")
+      .splits({Split(makeCudfHiveConnectorSplit(
+          filePath->getPath(), 0, halfFileSize))})
+      .assertResults("SELECT * FROM tmp OFFSET 0 LIMIT 6000");
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .connectorSessionProperty(
+          kCudfHiveConnectorId,
+          cudf_velox::connector::hive::CudfHiveConfig::
+              kMaxChunkReadLimitSession,
+          "1024")
+      .splits({Split(makeCudfHiveConnectorSplit(
+          filePath->getPath(), halfFileSize))})
+      .assertResults("SELECT * FROM tmp OFFSET 6000 LIMIT 4000");
+}
+
 // Verify that extractFiltersFromRemainingFilter extracts simple single-column
 // filters from the remaining filter into subfield filters for pushdown.
 // When a filter like "c0 = 1" is fully extracted, remainingFilterExprSet_ is

--- a/velox/experimental/cudf/tests/TaskOutputManagerTest.cpp
+++ b/velox/experimental/cudf/tests/TaskOutputManagerTest.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
+
+#include "velox/exec/Task.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+#include <folly/ScopeGuard.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+class TaskOutputManagerTest : public HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    auto& config = cudf_velox::CudfConfig::getInstance();
+    previousEnabled_ = config.enabled;
+    previousExchange_ = config.exchange;
+    previousAllowCpuFallback_ = config.allowCpuFallback;
+    previousMemoryResource_ = config.memoryResource;
+    config.enabled = true;
+    config.exchange = true;
+    config.allowCpuFallback = true;
+    config.memoryResource = "async";
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    auto& config = cudf_velox::CudfConfig::getInstance();
+    config.enabled = previousEnabled_;
+    config.exchange = previousExchange_;
+    config.allowCpuFallback = previousAllowCpuFallback_;
+    config.memoryResource = previousMemoryResource_;
+    HiveConnectorTestBase::TearDown();
+  }
+
+  std::shared_ptr<Task> startTask(
+      const std::string& taskId,
+      core::PartitionedOutputNode::TransportType transport,
+      core::QueryConfig queryConfig = core::QueryConfig{{}}) {
+    auto output = std::dynamic_pointer_cast<const core::PartitionedOutputNode>(
+        PlanBuilder()
+            .tableScan(ROW({"c0"}, {BIGINT()}))
+            .partitionedOutputBroadcast()
+            .planNode());
+    auto plan = core::PartitionedOutputNode::Builder(*output)
+                    .transportType(transport)
+                    .build();
+    auto task = Task::create(
+        taskId,
+        core::PlanFragment{std::move(plan)},
+        0,
+        core::QueryCtx::create(driverExecutor_.get(), std::move(queryConfig)),
+        Task::ExecutionMode::kParallel,
+        Consumer{});
+    task->start(1, 1);
+    return task;
+  }
+
+ private:
+  bool previousEnabled_{true};
+  bool previousExchange_{false};
+  bool previousAllowCpuFallback_{true};
+  std::string previousMemoryResource_;
+};
+
+TEST_F(TaskOutputManagerTest, selectionAndCancellationCleanup) {
+  auto queueManager = ucx_exchange::UcxOutputQueueManager::getInstanceRef();
+  const std::string ucxTaskId = "ucx-output-manager-lifecycle";
+  queueManager->removeTask(ucxTaskId);
+  auto cleanup =
+      folly::makeGuard([&]() { queueManager->removeTask(ucxTaskId); });
+
+  auto ucxTask =
+      startTask(ucxTaskId, core::PartitionedOutputNode::TransportType::kUcx);
+  ASSERT_TRUE(queueManager->stats(ucxTaskId).has_value());
+
+  std::atomic_bool cancellationDelivered{false};
+  queueManager->getData(
+      ucxTaskId,
+      0,
+      [&](std::shared_ptr<cudf::packed_columns> data, std::vector<int64_t>) {
+        EXPECT_EQ(data, nullptr);
+        cancellationDelivered = true;
+      });
+  ucxTask->requestAbort().wait();
+  EXPECT_TRUE(cancellationDelivered);
+  EXPECT_FALSE(queueManager->stats(ucxTaskId).has_value());
+  queueManager->removeTask(ucxTaskId);
+  cleanup.dismiss();
+
+  const std::string httpTaskId = "http-output-manager-lifecycle";
+  auto httpTask =
+      startTask(httpTaskId, core::PartitionedOutputNode::TransportType::kHttp);
+  EXPECT_FALSE(queueManager->stats(httpTaskId).has_value());
+  httpTask->requestAbort().wait();
+
+  const std::string disabledTaskId = "disabled-ucx-output-manager-lifecycle";
+  auto disabledTask = startTask(
+      disabledTaskId,
+      core::PartitionedOutputNode::TransportType::kUcx,
+      core::QueryConfig(
+          std::unordered_map<std::string, std::string>{
+              {cudf_velox::CudfConfig::kCudfEnabled, "false"}}));
+  EXPECT_FALSE(queueManager->stats(disabledTaskId).has_value());
+  disabledTask->requestAbort().wait();
+}
+
+} // namespace

--- a/velox/experimental/ucx-exchange/Communicator.cpp
+++ b/velox/experimental/ucx-exchange/Communicator.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<Communicator> Communicator::initAndGet(
     uint16_t port,
     std::string_view coordinatorURL,
     ContinueFuture* future) {
-  if (!FLAGS_velox_ucx_exchange) {
+  if (!CudfConfig::getInstance().exchange) {
     return nullptr;
   }
   std::call_once(onceFlag, [&] {

--- a/velox/experimental/ucx-exchange/Communicator.h
+++ b/velox/experimental/ucx-exchange/Communicator.h
@@ -27,10 +27,6 @@
 #include "velox/experimental/ucx-exchange/CommElement.h"
 #include "velox/experimental/ucx-exchange/WorkQueue.h"
 
-#include <gflags/gflags.h>
-
-DECLARE_bool(velox_ucx_exchange);
-
 namespace facebook::velox::ucx_exchange {
 
 struct HostPort {

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -399,9 +399,7 @@ void UcxExchangeServer::close() {
           << " hasDataRequest=" << (dataRequest_ != nullptr)
           << " hasDataPtr=" << (dataPtr_ != nullptr);
 
-  if (
-      queueMgr_ &&
-      !skipQueueDeleteOnClose_.load(std::memory_order_acquire)) {
+  if (queueMgr_ && !skipQueueDeleteOnClose_.load(std::memory_order_acquire)) {
     queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
   }
 

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.cpp
@@ -298,6 +298,24 @@ void UcxExchangeServer::process() {
                         << " getData callback called after close, ignoring";
                 return;
               }
+              if (sequence != static_cast<int64_t>(self->sequenceNumber_)) {
+                // The destination queue has already advanced beyond this
+                // duplicate/retried server.  Close only this stale server.
+                // In particular, do not deleteResults(): another active
+                // server owns the already-advanced queue and may still need
+                // its remaining pages.
+                LOG(WARNING)
+                    << "Closing stale UCX exchange server for task="
+                    << self->partitionKey_.taskId
+                    << " destination=" << self->partitionKey_.destination
+                    << " requestedSequence=" << self->sequenceNumber_
+                    << " acknowledgedSequence=" << sequence;
+                self->skipQueueDeleteOnClose_.store(
+                    true, std::memory_order_release);
+                self->setState(ServerState::Done);
+                self->wakeCommunicator();
+                return;
+              }
               // This upcall may be called from another thread than the
               // communicator thread. It is called
               // when data on the queue becomes available.
@@ -381,7 +399,9 @@ void UcxExchangeServer::close() {
           << " hasDataRequest=" << (dataRequest_ != nullptr)
           << " hasDataPtr=" << (dataPtr_ != nullptr);
 
-  if (queueMgr_) {
+  if (
+      queueMgr_ &&
+      !skipQueueDeleteOnClose_.load(std::memory_order_acquire)) {
     queueMgr_->deleteResults(partitionKey_.taskId, partitionKey_.destination);
   }
 

--- a/velox/experimental/ucx-exchange/UcxExchangeServer.h
+++ b/velox/experimental/ucx-exchange/UcxExchangeServer.h
@@ -133,6 +133,10 @@ class UcxExchangeServer
   /// thread while the lock is still held.
   std::recursive_mutex dataMutex_;
   std::atomic<bool> closed_{false};
+  // A duplicate server may reconnect at an already-acknowledged sequence.
+  // Its close must not clear the destination queue owned by the active
+  // server.
+  std::atomic<bool> skipQueueDeleteOnClose_{false};
 
   /// Future for intra-node transfer - signaled when source retrieves data.
   std::future<void> intraNodeRetrieveFuture_;

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -102,12 +102,15 @@ int64_t maxInFlightRecvHostBytes() {
 std::atomic<int64_t> inFlightRecvHostBytes{0};
 
 rmm::mr::statistics_resource_adaptor& receiveDeviceMemoryResource() {
-  // Keep UCX receive allocations on a synchronous, fresh cudaMalloc resource,
-  // but wrap it with RMM statistics so queued packed pages are visible in
-  // diagnostics even after ownership moves out of UcxExchangeSource.
+  // Allocate UCX receive pages from the same async resource as cuDF operators.
+  // A separate cuda_memory_resource cannot reuse blocks cached by the async
+  // pool and can therefore fail cudaMalloc while scan/aggregation has ample
+  // reusable memory in that pool. Keep a dedicated statistics adaptor so
+  // receive credit continues to account for packed pages after ownership moves
+  // out of UcxExchangeSource.
   static rmm::mr::statistics_resource_adaptor resource{
       cuda::mr::any_resource<cuda::mr::device_accessible>{
-          rmm::mr::cuda_memory_resource{}}};
+          rmm::mr::get_current_device_resource_ref()}};
   return resource;
 }
 
@@ -785,13 +788,10 @@ bool UcxExchangeSource::tryStartDataReceive(
   ptr->stream = stream;
 
   // UCX writes receive buffers from its progress thread, outside CUDA stream
-  // ordering. Keep these buffers on a dedicated synchronous resource so UCX
-  // can never write into a block that a stream-ordered pool has recycled while
-  // work on another stream is still in flight. This also avoids waiting on an
-  // unrelated compute stream in the single UCX progress thread.
-  //
-  // Only transports without CUDA support stage through host memory and use a
-  // fresh synchronous device allocation for the final copy.
+  // ordering. Allocate from the shared async pool, then synchronize this
+  // allocation stream before exposing the pointer to UCX. Receive completion
+  // transfers ownership to a packed table that retains the same stream, so
+  // downstream work and eventual deallocation remain stream ordered.
   try {
     auto& recvMemoryResource = receiveDeviceMemoryResource();
     ptr->dataBuf = std::make_unique<rmm::device_buffer>(
@@ -799,6 +799,7 @@ bool UcxExchangeSource::tryStartDataReceive(
         stream,
         cuda::mr::any_resource<cuda::mr::device_accessible>{
             recvMemoryResource});
+    CUDF_CUDA_TRY(cudaStreamSynchronize(stream.value()));
     if (facebook::velox::cudf_velox::deviceMemoryDiagnosticsEnabled()) {
       constexpr int64_t kReportStep = 512LL << 20;
       const auto bytes = recvMemoryResource.get_bytes_counter();

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -792,14 +792,44 @@ bool UcxExchangeSource::tryStartDataReceive(
   // allocation stream before exposing the pointer to UCX. Receive completion
   // transfers ownership to a packed table that retains the same stream, so
   // downstream work and eventual deallocation remain stream ordered.
-  try {
-    auto& recvMemoryResource = receiveDeviceMemoryResource();
+  auto& recvMemoryResource = receiveDeviceMemoryResource();
+  const auto allocateReceiveBuffer = [&]() {
     ptr->dataBuf = std::make_unique<rmm::device_buffer>(
         ptr->metadata.dataSizeBytes,
         stream,
         cuda::mr::any_resource<cuda::mr::device_accessible>{
             recvMemoryResource});
     CUDF_CUDA_TRY(cudaStreamSynchronize(stream.value()));
+  };
+  try {
+    allocateReceiveBuffer();
+  } catch (const rmm::bad_alloc& firstError) {
+    // On the allocation-failure slow path, wait for stream-ordered frees and
+    // let the shared async pool reclaim completed blocks, then retry once.
+    cudaGetLastError();
+    const auto syncStatus = cudaDeviceSynchronize();
+    if (syncStatus == cudaSuccess) {
+      try {
+        allocateReceiveBuffer();
+        LOG(WARNING)
+            << toString()
+            << " recovered UCX receive allocation after device synchronize: "
+            << ptr->metadata.dataSizeBytes << " bytes; first error: "
+            << firstError.what();
+      } catch (const rmm::bad_alloc& retryError) {
+        VLOG(0) << toString() << " *** RMM failed to allocate "
+                << ptr->metadata.dataSizeBytes
+                << " bytes after device synchronize retry: "
+                << retryError.what();
+      }
+    } else {
+      VLOG(0) << toString()
+              << " *** cudaDeviceSynchronize failed while recovering "
+                 "receive allocation: "
+              << cudaGetErrorString(syncStatus);
+    }
+  }
+  if (ptr->dataBuf != nullptr) {
     if (facebook::velox::cudf_velox::deviceMemoryDiagnosticsEnabled()) {
       constexpr int64_t kReportStep = 512LL << 20;
       const auto bytes = recvMemoryResource.get_bytes_counter();
@@ -837,10 +867,8 @@ bool UcxExchangeSource::tryStartDataReceive(
                 maxInFlightRecvBytes()));
       }
     }
-  } catch (const rmm::bad_alloc& e) {
+  } else {
     releaseReceiveReservation();
-    VLOG(0) << toString() << " *** RMM failed to allocate "
-            << ptr->metadata.dataSizeBytes << " bytes: " << e.what();
     queue_->setError("Failed to alloc GPU memory");
     deliverEndMarker();
     setState(ReceiverState::Done);

--- a/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchangeSource.cpp
@@ -814,8 +814,8 @@ bool UcxExchangeSource::tryStartDataReceive(
         LOG(WARNING)
             << toString()
             << " recovered UCX receive allocation after device synchronize: "
-            << ptr->metadata.dataSizeBytes << " bytes; first error: "
-            << firstError.what();
+            << ptr->metadata.dataSizeBytes
+            << " bytes; first error: " << firstError.what();
       } catch (const rmm::bad_alloc& retryError) {
         VLOG(0) << toString() << " *** RMM failed to allocate "
                 << ptr->metadata.dataSizeBytes

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.cpp
@@ -82,6 +82,16 @@ bool UcxOutputQueueManager::updateOutputBuffersIfExists(
   return false;
 }
 
+bool UcxOutputQueueManager::updateNumDriversIfExists(
+    std::string_view taskId,
+    uint32_t newNumDrivers) {
+  if (auto queue = getQueueIfExists(taskId)) {
+    queue->updateNumDrivers(newNumDrivers);
+    return true;
+  }
+  return false;
+}
+
 void UcxOutputQueueManager::enqueue(
     std::string_view taskId,
     int destination,

--- a/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
+++ b/velox/experimental/ucx-exchange/UcxOutputQueueManager.h
@@ -65,6 +65,10 @@ class UcxOutputQueueManager {
       int numBuffers,
       bool noMoreBuffers);
 
+  bool updateNumDriversIfExists(
+      std::string_view taskId,
+      uint32_t newNumDrivers);
+
   /// @brief Enqueues a cudf packed column into the queue.
   /// @param taskId The unique task Id.
   /// @param destination The destination (partition, queue number) into which

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -231,7 +231,6 @@ bool partialAggregationBehindProjects(
   }
   return false;
 }
-
 uint64_t targetBytesPerUcxChunk(const core::QueryConfig& queryConfig) {
   if (const char* value =
           std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_BYTES")) {
@@ -1108,4 +1107,3 @@ void UcxPartitionedOutput::splitAndEnqueue(
 }
 
 } // namespace facebook::velox::ucx_exchange
-

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -262,8 +262,7 @@ cudf::size_type rowsPerUcxChunk(
     rowsPerChunk = std::min<cudf::size_type>(
         rowsPerChunk,
         static_cast<cudf::size_type>(std::min<uint64_t>(
-            byteLimitedRows,
-            std::numeric_limits<cudf::size_type>::max())));
+            byteLimitedRows, std::numeric_limits<cudf::size_type>::max())));
   }
   return std::max<cudf::size_type>(1, rowsPerChunk);
 }
@@ -371,8 +370,7 @@ void UcxPartitionedOutput::addInput(RowVectorPtr input) {
 
   if ((targetRowsPerChunk_ <= 0 && targetBytesPerChunk_ == 0) ||
       (targetRowsPerChunk_ > 0 && pendingRows_ >= targetRowsPerChunk_) ||
-      (targetBytesPerChunk_ > 0 &&
-       pendingFlatBytes_ >= targetBytesPerChunk_)) {
+      (targetBytesPerChunk_ > 0 && pendingFlatBytes_ >= targetBytesPerChunk_)) {
     flushPending();
   }
 }
@@ -551,8 +549,7 @@ void UcxPartitionedOutput::advanceActiveFlush() {
       activeRowsPerWindow_, tableRows - activeNextRow_);
   std::optional<cudf_velox::DeviceMemoryAdmissionReservation> memoryAdmission;
 
-  if (numPartitions_ > 1 &&
-      rangeBoundsJson_.empty() &&
+  if (numPartitions_ > 1 && rangeBoundsJson_.empty() &&
       (partitionKeyIndices_.size() > 0 || spec_ == "gather") &&
       hashPartitionInputBatchRows_ > 0 && rowsThisWindow > 0 &&
       activeSourceFlatBytes_ > 0 && tableRows > 0) {
@@ -630,8 +627,7 @@ void UcxPartitionedOutput::advanceActiveFlush() {
       // fallback bound, and give that smaller window one final admission try.
       uint64_t lower = 1;
       uint64_t upper = selectedRows;
-      if (estimatePeakBytes(lower) <=
-          kMaxUnadmittedHashPartitionPeakBytes) {
+      if (estimatePeakBytes(lower) <= kMaxUnadmittedHashPartitionPeakBytes) {
         while (lower < upper) {
           const auto middle = lower + (upper - lower + 1) / 2;
           if (estimatePeakBytes(middle) <=
@@ -1107,8 +1103,7 @@ void UcxPartitionedOutput::splitAndEnqueue(
     if (rowsPerChunk < partitionRows) {
       VLOG(2) << "UcxPartitionedOutput chunking task=" << taskId()
               << " destination=" << i << " rows=" << partitionRows
-              << " bytes=" << partitionBytes
-              << " rowsPerChunk=" << rowsPerChunk
+              << " bytes=" << partitionBytes << " rowsPerChunk=" << rowsPerChunk
               << " targetRowsPerChunk=" << targetRowsPerChunk_
               << " targetBytesPerChunk=" << targetBytesPerChunk_;
       for (cudf::size_type start = 0; start < partitionRows;

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -41,6 +41,12 @@ using facebook::velox::exec::Task;
 namespace facebook::velox::ucx_exchange {
 
 namespace {
+// libcudf's hash-partition exclusive scan can exceed the CUDA kernel launch
+// resource limit on very large tables before memory pressure is visible. Keep
+// an engine-level call-size ceiling even when the caller does not provide one;
+// explicit per-query limits remain authoritative and may be smaller.
+constexpr int64_t kDefaultMaxRowsPerHashPartitionCall = 128'000'000;
+
 int64_t targetRowsPerUcxChunk(const core::QueryConfig& queryConfig) {
   if (const char* value =
           std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_ROWS")) {
@@ -178,6 +184,54 @@ void normalizePartitionOffsets(
   }
 }
 
+int64_t positiveEnvironmentOverride(const char* name) {
+  if (const char* value = std::getenv(name)) {
+    try {
+      const auto parsed = std::stoll(value);
+      if (parsed > 0) {
+        return static_cast<int64_t>(parsed);
+      }
+    } catch (...) {
+    }
+  }
+  return 0;
+}
+
+int64_t maxRowsPerHashPartitionCall(const core::QueryConfig& queryConfig) {
+  const auto environmentRows =
+      positiveEnvironmentOverride("GLUTEN_UCX_HASH_PARTITION_INPUT_BATCH_ROWS");
+  if (environmentRows > 0) {
+    return environmentRows;
+  }
+  const auto configuredRows = queryConfig.ucxHashPartitionInputBatchRows();
+  return configuredRows > 0 ? configuredRows
+                            : kDefaultMaxRowsPerHashPartitionCall;
+}
+
+int64_t maxRowsPerHashPartitionWindow(const core::QueryConfig& queryConfig) {
+  const auto environmentRows =
+      positiveEnvironmentOverride("GLUTEN_UCX_HASH_PARTITION_WINDOW_ROWS");
+  return environmentRows > 0 ? environmentRows
+                             : queryConfig.ucxHashPartitionWindowRows();
+}
+
+bool partialAggregationBehindProjects(
+    std::shared_ptr<const core::PlanNode> source) {
+  while (source) {
+    if (const auto aggregation =
+            std::dynamic_pointer_cast<const core::AggregationNode>(source)) {
+      return aggregation->step() == core::AggregationNode::Step::kPartial ||
+          aggregation->step() == core::AggregationNode::Step::kIntermediate;
+    }
+    if (!std::dynamic_pointer_cast<const core::ProjectNode>(source) ||
+        source->sources().size() != 1) {
+      return false;
+    }
+    source = source->sources().front();
+  }
+  return false;
+}
+
 uint64_t targetBytesPerUcxChunk(const core::QueryConfig& queryConfig) {
   if (const char* value =
           std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_BYTES")) {
@@ -262,8 +316,15 @@ UcxPartitionedOutput::UcxPartitionedOutput(
       numPartitions_(planNode->numPartitions()),
       pipelineId_(ctx->pipelineId),
       driverId_(ctx->driverId),
+      sourceNeedsOwnerBoundaryBackpressure_(
+          partialAggregationBehindProjects(planNode->sources().front())),
+      maxOutputBufferSize_(ctx->queryConfig().maxOutputBufferSize()),
       targetRowsPerChunk_(targetRowsPerUcxChunk(ctx->queryConfig())),
-      targetBytesPerChunk_(targetBytesPerUcxChunk(ctx->queryConfig())) {
+      targetBytesPerChunk_(targetBytesPerUcxChunk(ctx->queryConfig())),
+      hashPartitionInputBatchRows_(
+          maxRowsPerHashPartitionCall(ctx->queryConfig())),
+      hashPartitionWindowRows_(
+          maxRowsPerHashPartitionWindow(ctx->queryConfig())) {
   this->initPartitionKeys(planNode);
   auto sources = planNode->sources();
   std::vector<std::string> inNames, outNames;
@@ -291,20 +352,23 @@ void UcxPartitionedOutput::addInput(RowVectorPtr input) {
   VELOX_CHECK(
       !future_.valid() || future_.hasValue(),
       "addInput with outstanding future!");
+  VELOX_CHECK(!hasActiveFlush(), "addInput while a flush is still active");
 
+  const auto inputFlatBytes = input->estimateFlatSize();
   // Record stats per-input (before buffering).
   {
     auto lockedStats = stats_.wlock();
-    lockedStats->addOutputVector(input->estimateFlatSize(), input->size());
+    lockedStats->addOutputVector(inputFlatBytes, input->size());
   }
 
   pendingRows_ += cudfVector->getTableView().num_rows();
-  pendingBytes_ += cudfVector->estimateFlatSize();
+  pendingFlatBytes_ += inputFlatBytes;
   pendingInputs_.push_back(std::move(cudfVector));
 
   if ((targetRowsPerChunk_ <= 0 && targetBytesPerChunk_ == 0) ||
       (targetRowsPerChunk_ > 0 && pendingRows_ >= targetRowsPerChunk_) ||
-      (targetBytesPerChunk_ > 0 && pendingBytes_ >= targetBytesPerChunk_)) {
+      (targetBytesPerChunk_ > 0 &&
+       pendingFlatBytes_ >= targetBytesPerChunk_)) {
     flushPending();
   }
 }
@@ -313,102 +377,18 @@ void UcxPartitionedOutput::flushPending() {
   CudaAllocationTraceScope allocationTrace(
       fmt::format(
           "UcxPartitionedOutput task={} method=flushPending", taskId()));
-  if (pendingInputs_.empty()) {
+  if (!hasActiveFlush() && pendingInputs_.empty()) {
     return;
   }
 
   try {
-    const auto pendingBytes = pendingBytes_;
-    cudf::table_view tableView;
-    rmm::cuda_stream_view stream = pendingInputs_.back()->stream();
-    // Keeps the merged table alive while tableView references it.
-    std::unique_ptr<cudf::table> mergedTable;
-
-    if (pendingInputs_.size() == 1) {
-      // Fast path: use the single input's view directly (no GPU alloc).
-      auto& cv = pendingInputs_[0];
-      stream = cv->stream();
-      tableView = remap_.empty()
-          ? cv->getTableView()
-          : cv->getTableView().select(remap_.begin(), remap_.end());
-    } else {
-      // Collect (remapped) table views.
-      std::vector<cudf::table_view> views;
-      std::vector<rmm::cuda_stream_view> inputStreams;
-      views.reserve(pendingInputs_.size());
-      inputStreams.reserve(pendingInputs_.size());
-      for (auto& v : pendingInputs_) {
-        inputStreams.push_back(v->stream());
-        views.push_back(
-            remap_.empty()
-                ? v->getTableView()
-                : v->getTableView().select(remap_.begin(), remap_.end()));
-      }
-
-      cudf::detail::join_streams(inputStreams, stream);
-      mergedTable = cudf::concatenate(
-          views, stream, cudf::get_current_device_resource_ref());
-
-      orderCudfVectorDeallocationsAfterStream(
-          pendingInputs_, inputStreams, stream);
-
-      // Free input GPU memory before partitioning (peak = 2x -> 1x).
-      pendingInputs_.clear();
-
-      tableView = mergedTable->view();
+    if (!hasActiveFlush()) {
+      preparePendingFlush();
     }
-
-    // Partition + enqueue (identical to previous addInput logic).
-    auto queueManager = sharedQueueManager();
-    if (numPartitions_ > 1) {
-      if (!rangeBoundsJson_.empty()) {
-        rangePartition(tableView, stream);
-      } else if (partitionKeyIndices_.size() > 0 || spec_ == "gather") {
-        hashPartition(tableView, stream);
-      } else {
-        equalPartition(tableView, stream);
-      }
-    } else {
-      const auto tableRows = tableView.num_rows();
-      const auto rowsPerChunk = rowsPerUcxChunk(
-          tableRows,
-          pendingBytes,
-          targetRowsPerChunk_,
-          targetBytesPerChunk_);
-      // SINGLE/gather exchanges must obey the same chunk bound as HASH and
-      // RANGE.  Packing the whole input here bypassed splitAndEnqueue and let
-      // a global sort/gather create tens-of-GiB host-staging transfers.
-      for (cudf::size_type start = 0; start < tableRows;
-           start += rowsPerChunk) {
-        const auto end =
-            std::min<cudf::size_type>(tableRows, start + rowsPerChunk);
-        auto slicedTables = cudf::slice(tableView, {start, end});
-        VELOX_CHECK_EQ(slicedTables.size(), 1);
-        auto packedCols = cudf::pack(
-            slicedTables[0], stream, cudf::get_current_device_resource_ref());
-        stream.synchronize();
-        auto packedColsPtr = std::make_unique<cudf::packed_columns>(
-            std::move(packedCols.metadata), std::move(packedCols.gpu_data));
-        queueManager->enqueue(
-            this->taskId(),
-            0,
-            std::move(packedColsPtr),
-            slicedTables[0].num_rows());
-      }
-    }
-
-    // Check backpressure after enqueue.
-    auto blocked = queueManager->checkBlocked(this->taskId(), &future_);
-    if (blocked) {
-      VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
-              << " is blocked, can no longer write to output!";
-    }
-    blockingReason_ = blocked ? exec::BlockingReason::kWaitForConsumer
-                              : exec::BlockingReason::kNotBlocked;
-
-    pendingInputs_.clear();
-    pendingRows_ = 0;
-    pendingBytes_ = 0;
+    do {
+      advanceActiveFlush();
+    } while (hasActiveFlush() && activeDrainBeforeBackpressure_ &&
+             blockingReason_ == exec::BlockingReason::kNotBlocked);
 
   } catch (const rmm::bad_alloc& e) {
     VLOG(1)
@@ -416,12 +396,275 @@ void UcxPartitionedOutput::flushPending() {
         << " caught memory alloc error, removing all memory in output queues";
     pendingInputs_.clear();
     pendingRows_ = 0;
-    pendingBytes_ = 0;
+    pendingFlatBytes_ = 0;
+    clearActiveFlush();
     for (int i = 0; i < numPartitions_; i++) {
       sharedQueueManager()->deleteResults(this->taskId(), i);
     }
     throw;
   }
+}
+
+void UcxPartitionedOutput::preparePendingFlush() {
+  VELOX_CHECK(!hasActiveFlush());
+  VELOX_CHECK(!pendingInputs_.empty());
+
+  activeInputs_ = std::move(pendingInputs_);
+  activeSourceFlatBytes_ = pendingFlatBytes_;
+  pendingInputs_.clear();
+  pendingRows_ = 0;
+  pendingFlatBytes_ = 0;
+
+  auto stream = activeInputs_.back()->stream();
+  if (activeInputs_.size() > 1) {
+    std::vector<cudf::table_view> views;
+    std::vector<rmm::cuda_stream_view> inputStreams;
+    views.reserve(activeInputs_.size());
+    inputStreams.reserve(activeInputs_.size());
+    for (auto& input : activeInputs_) {
+      inputStreams.push_back(input->stream());
+      views.push_back(
+          remap_.empty()
+              ? input->getTableView()
+              : input->getTableView().select(remap_.begin(), remap_.end()));
+    }
+
+    cudf::detail::join_streams(inputStreams, stream);
+    activeMergedTable_ = cudf::concatenate(
+        views, stream, cudf::get_current_device_resource_ref());
+    orderCudfVectorDeallocationsAfterStream(
+        activeInputs_, inputStreams, stream);
+    // The concatenated table is now the source owner. Releasing the input
+    // vectors here preserves the old 2x -> 1x peak-memory behavior.
+    activeInputs_.clear();
+  }
+
+  activeStream_ = stream;
+  activeNextRow_ = 0;
+  const auto tableRows = activeTableView().num_rows();
+  if (numPartitions_ > 1 && rangeBoundsJson_.empty() &&
+      (partitionKeyIndices_.size() > 0 || spec_ == "gather") &&
+      hashPartitionInputBatchRows_ > 0) {
+    const auto configuredWindowRows = hashPartitionWindowRows_ > 0
+        ? hashPartitionWindowRows_
+        : (targetRowsPerChunk_ > 0 ? targetRowsPerChunk_
+                                   : hashPartitionInputBatchRows_);
+    const auto configuredRows = static_cast<uint64_t>(
+        std::max<int64_t>(hashPartitionInputBatchRows_, configuredWindowRows));
+    activeRowsPerWindow_ = rowsPerUcxChunk(
+        tableRows,
+        activeSourceFlatBytes_,
+        static_cast<int64_t>(std::min<uint64_t>(
+            configuredRows,
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))),
+        targetBytesPerChunk_);
+  } else if (numPartitions_ == 1) {
+    // SINGLE/gather exchanges yield after each output-sized chunk as well.
+    activeRowsPerWindow_ = rowsPerUcxChunk(
+        tableRows,
+        activeSourceFlatBytes_,
+        targetRowsPerChunk_,
+        targetBytesPerChunk_);
+  } else {
+    // Bound HASH/RANGE residency by the output byte target even when no
+    // explicit hash-call row limit is configured.
+    activeRowsPerWindow_ = rowsPerUcxChunk(
+        tableRows,
+        activeSourceFlatBytes_,
+        targetRowsPerChunk_,
+        targetBytesPerChunk_);
+  }
+
+  activeDrainBeforeBackpressure_ = sourceNeedsOwnerBoundaryBackpressure_ &&
+      maxOutputBufferSize_ > 0 &&
+      activeSourceFlatBytes_ > maxOutputBufferSize_ &&
+      activeRowsPerWindow_ < tableRows;
+  if (activeDrainBeforeBackpressure_) {
+    VLOG(2) << "UcxPartitionedOutput will drain oversized source before "
+               "backpressure task="
+            << taskId() << " sourceRows=" << tableRows
+            << " sourceFlatBytes=" << activeSourceFlatBytes_
+            << " rowsPerWindow=" << activeRowsPerWindow_
+            << " maxOutputBufferBytes=" << maxOutputBufferSize_;
+  }
+}
+
+bool UcxPartitionedOutput::hasActiveFlush() const {
+  return activeMergedTable_ != nullptr || !activeInputs_.empty();
+}
+
+cudf::table_view UcxPartitionedOutput::activeTableView() {
+  VELOX_CHECK(hasActiveFlush());
+  if (activeMergedTable_) {
+    return activeMergedTable_->view();
+  }
+  VELOX_CHECK_EQ(activeInputs_.size(), 1);
+  auto tableView = activeInputs_.front()->getTableView();
+  return remap_.empty() ? tableView
+                        : tableView.select(remap_.begin(), remap_.end());
+}
+
+void UcxPartitionedOutput::clearActiveFlush() {
+  activeInputs_.clear();
+  activeMergedTable_.reset();
+  activeStream_.reset();
+  activeSourceFlatBytes_ = 0;
+  activeNextRow_ = 0;
+  activeRowsPerWindow_ = 0;
+  activeDrainBeforeBackpressure_ = false;
+}
+
+void UcxPartitionedOutput::updateBackpressure() {
+  // The queue is shared by every output driver in this task. Checking after
+  // each residency window bounds overshoot to at most one window per driver,
+  // instead of allowing one addInput() to enqueue every remaining window.
+  // P0 deliberately checks after enqueue: exact packed bytes are only known
+  // then, and pre-reserving a window larger than maxSize would deadlock unless
+  // the credit protocol also grew a special oversized-window grant.
+  auto blocked = sharedQueueManager()->checkBlocked(this->taskId(), &future_);
+  if (blocked) {
+    VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
+            << " is blocked after output window";
+  }
+  blockingReason_ = blocked ? exec::BlockingReason::kWaitForConsumer
+                            : exec::BlockingReason::kNotBlocked;
+}
+
+void UcxPartitionedOutput::advanceActiveFlush() {
+  VELOX_CHECK(hasActiveFlush());
+  VELOX_CHECK(activeStream_.has_value());
+  VELOX_CHECK_EQ(blockingReason_, exec::BlockingReason::kNotBlocked);
+
+  auto tableView = activeTableView();
+  const auto tableRows = tableView.num_rows();
+  if (activeNextRow_ >= tableRows) {
+    clearActiveFlush();
+    return;
+  }
+
+  auto stream = *activeStream_;
+  auto rowsThisWindow = std::min<cudf::size_type>(
+      activeRowsPerWindow_, tableRows - activeNextRow_);
+  std::optional<cudf_velox::DeviceMemoryAdmissionReservation> memoryAdmission;
+
+  if (numPartitions_ > 1 &&
+      rangeBoundsJson_.empty() &&
+      (partitionKeyIndices_.size() > 0 || spec_ == "gather") &&
+      hashPartitionInputBatchRows_ > 0 && rowsThisWindow > 0 &&
+      activeSourceFlatBytes_ > 0 && tableRows > 0) {
+    const auto sourceRows = static_cast<uint64_t>(tableRows);
+    const auto averageRowBytes = activeSourceFlatBytes_ / sourceRows +
+        static_cast<uint64_t>(activeSourceFlatBytes_ % sourceRows != 0);
+    const auto candidateRows = static_cast<uint64_t>(rowsThisWindow);
+    const auto estimatePeakBytes = [&](uint64_t rows) {
+      const auto sourceBytes = averageRowBytes * rows;
+      const auto scratchBytes = rows * uint64_t{12} +
+          static_cast<uint64_t>(numPartitions_) * uint64_t{4096};
+      const auto workingBytes =
+          std::max(sourceBytes + scratchBytes, sourceBytes * uint64_t{2});
+      return workingBytes + workingBytes / uint64_t{4};
+    };
+    const auto fallbackRows = maxOutputBufferSize_ == 0
+        ? candidateRows
+        : std::max<uint64_t>(
+              1,
+              std::min(candidateRows, maxOutputBufferSize_ / averageRowBytes));
+    const auto headroom = cudf_velox::captureDeviceAllocationHeadroom();
+    const auto allocatableBytes = headroom.allocatableBytes();
+    const auto reserveBytes = headroom.totalBytes == 0
+        ? uint64_t{1} << 30
+        : std::max<uint64_t>(
+              uint64_t{1} << 30,
+              static_cast<uint64_t>(headroom.totalBytes) / uint64_t{50});
+    const auto admissionCapacity = allocatableBytes > reserveBytes
+        ? allocatableBytes - reserveBytes
+        : allocatableBytes / uint64_t{2};
+    const auto alreadyReserved =
+        cudf_velox::deviceMemoryAdmissionReservedBytes(headroom.device);
+    const auto availableCapacity = admissionCapacity > alreadyReserved
+        ? admissionCapacity - alreadyReserved
+        : uint64_t{0};
+    const auto candidatePeakBytes = estimatePeakBytes(candidateRows);
+
+    uint64_t selectedRows = candidateRows;
+    if (!headroom.cudaValid || candidatePeakBytes > availableCapacity) {
+      const auto pressureRows = candidatePeakBytes == 0
+          ? candidateRows
+          : std::max<uint64_t>(
+                1,
+                static_cast<uint64_t>(
+                    static_cast<long double>(candidateRows) *
+                    static_cast<long double>(availableCapacity) /
+                    static_cast<long double>(candidatePeakBytes)));
+      // The 1GiB queue-derived bound is no longer the normal workspace cap.
+      // It is retained as the proven emergency floor when a snapshot is
+      // unavailable or severely pressured; Q10 passed 10/10 at this size.
+      selectedRows =
+          std::min(candidateRows, std::max(fallbackRows, pressureRows));
+    }
+
+    auto selectedPeakBytes = estimatePeakBytes(selectedRows);
+    memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
+        headroom.device, selectedPeakBytes, admissionCapacity);
+    if (!memoryAdmission && selectedRows == candidateRows &&
+        fallbackRows < candidateRows) {
+      selectedRows = fallbackRows;
+      selectedPeakBytes = estimatePeakBytes(selectedRows);
+    }
+    rowsThisWindow = static_cast<cudf::size_type>(selectedRows);
+    VLOG(2) << "UcxPartitionedOutput pressure-aware hash window task="
+            << taskId() << " sourceRows=" << tableRows
+            << " sourceFlatBytes=" << activeSourceFlatBytes_
+            << " averageRowBytes=" << averageRowBytes
+            << " candidateRows=" << candidateRows
+            << " selectedRows=" << selectedRows
+            << " estimatedPeakBytes=" << selectedPeakBytes
+            << " cudaFreeBytes=" << headroom.freeBytes
+            << " poolReusableBytes=" << headroom.reusablePoolBytes()
+            << " admissionCapacityBytes=" << admissionCapacity
+            << " alreadyReservedBytes=" << alreadyReserved
+            << " admitted=" << memoryAdmission.has_value();
+  }
+
+  const auto end = activeNextRow_ + rowsThisWindow;
+  auto slices = cudf::slice(tableView, {activeNextRow_, end}, stream);
+  VELOX_CHECK_EQ(slices.size(), 1);
+
+  if (numPartitions_ > 1) {
+    if (!rangeBoundsJson_.empty()) {
+      rangePartition(slices[0], stream);
+    } else if (partitionKeyIndices_.size() > 0 || spec_ == "gather") {
+      // hashPartition() may internally split this residency window into safe
+      // libcudf call-size chunks, but it cannot cross into the next window.
+      hashPartition(slices[0], stream);
+    } else {
+      equalPartition(slices[0], stream);
+    }
+  } else {
+    auto packedCols =
+        cudf::pack(slices[0], stream, cudf::get_current_device_resource_ref());
+    stream.synchronize();
+    auto packedColsPtr = std::make_unique<cudf::packed_columns>(
+        std::move(packedCols.metadata), std::move(packedCols.gpu_data));
+    sharedQueueManager()->enqueue(
+        this->taskId(), 0, std::move(packedColsPtr), slices[0].num_rows());
+  }
+
+  activeNextRow_ = end;
+  const bool drainBeforeBackpressure = activeDrainBeforeBackpressure_;
+  if (activeNextRow_ == tableRows) {
+    // Every enqueue above synchronizes its stream before publication, so the
+    // source owner can be released even if the queue check below blocks.
+    clearActiveFlush();
+  }
+  if (drainBeforeBackpressure && hasActiveFlush()) {
+    // Retaining an oversized source behind a queue future can starve its
+    // upstream operator of the memory needed to produce the next batch. Keep
+    // draining this one source; consumers may concurrently retire published
+    // buffers. Backpressure is checked after the source owner is released.
+    return;
+  }
+  updateBackpressure();
 }
 
 exec::BlockingReason UcxPartitionedOutput::isBlocked(ContinueFuture* future) {
@@ -438,8 +681,18 @@ RowVectorPtr UcxPartitionedOutput::getOutput() {
   if (finished_) {
     return nullptr;
   }
-  if (noMoreInput_) {
-    flushPending(); // drain any remaining buffered inputs
+  // Driver calls isBlocked() before getOutput(). Keep this guard for direct
+  // test drivers and to ensure an outstanding future is never overwritten.
+  if (blockingReason_ != exec::BlockingReason::kNotBlocked) {
+    return nullptr;
+  }
+  if (hasActiveFlush() || (noMoreInput_ && !pendingInputs_.empty())) {
+    flushPending();
+  }
+  // A final work unit may have completed but filled the queue. Defer EOS until
+  // its future has been moved by isBlocked() and resumed by the Driver.
+  if (noMoreInput_ && !hasActiveFlush() && pendingInputs_.empty() &&
+      blockingReason_ == exec::BlockingReason::kNotBlocked) {
     sharedQueueManager()->noMoreData(this->taskId());
     finished_ = true;
   }
@@ -523,6 +776,167 @@ void UcxPartitionedOutput::initPartitionKeys(
 void UcxPartitionedOutput::hashPartition(
     cudf::table_view tableView,
     rmm::cuda_stream_view stream) {
+  const auto maxRows = hashPartitionInputBatchRows_;
+  if (maxRows > 0 && tableView.num_rows() > maxRows) {
+    VLOG(2) << "UcxPartitionedOutput pre-slicing hash input task=" << taskId()
+            << " rows=" << tableView.num_rows()
+            << " maxRowsPerCall=" << maxRows;
+
+    struct PartitionedChunk {
+      std::unique_ptr<cudf::table> table;
+      std::vector<cudf::size_type> offsets;
+    };
+    struct PackedPartition {
+      int32_t rows;
+      std::unique_ptr<cudf::packed_columns> data;
+    };
+    auto queueManager = sharedQueueManager();
+
+    // Bound the temporary residency of the safe hash path.  Keeping every
+    // 500K-row partitioned chunk for the full input, followed by all 32
+    // recombined destinations and all packed buffers, amplified a wide Q10
+    // customer batch by several times before output-buffer backpressure could
+    // run.  Work on one output-sized row window and one destination at a time
+    // instead.  The source vector remains alive, but all hash, concatenate,
+    // and pack temporaries for a window are released before the next window.
+    const auto configuredWindowRows = hashPartitionWindowRows_ > 0
+        ? hashPartitionWindowRows_
+        : (targetRowsPerChunk_ > 0 ? targetRowsPerChunk_ : maxRows);
+    const auto rowsPerWindow = static_cast<cudf::size_type>(
+        std::max<int64_t>(maxRows, configuredWindowRows));
+
+    // When the safety call size and residency window are identical, every
+    // window contains exactly one partitioned table.  Use contiguous_split's
+    // single bulk operation instead of packing 32 destinations one at a time.
+    // Besides avoiding needless concatenate bookkeeping, this changes Q10
+    // from one stream synchronization per destination to one per 8M-row
+    // window while preserving the same hard peak-memory bound.  Q21 uses a
+    // larger recombination window than its 500K call size and therefore keeps
+    // the multi-chunk path below.
+    if (rowsPerWindow == maxRows) {
+      std::vector<cudf::size_type> partitionKeyIndices;
+      partitionKeyIndices.reserve(partitionKeyIndices_.size());
+      for (const auto& idx : partitionKeyIndices_) {
+        partitionKeyIndices.push_back(static_cast<cudf::size_type>(idx));
+      }
+      for (cudf::size_type start = 0; start < tableView.num_rows();
+           start += rowsPerWindow) {
+        const auto end = std::min<cudf::size_type>(
+            tableView.num_rows(), start + rowsPerWindow);
+        auto slices = cudf::slice(tableView, {start, end}, stream);
+        VELOX_CHECK_EQ(slices.size(), 1);
+        auto [partitionedTable, partitionOffsets] = cudf::hash_partition(
+            slices[0],
+            partitionKeyIndices,
+            numPartitions_,
+            cudf::hash_id::HASH_MURMUR3,
+            cudf::DEFAULT_HASH_SEED,
+            stream);
+        VELOX_CHECK_EQ(partitionOffsets.size(), numPartitions_ + 1);
+        VELOX_CHECK_EQ(partitionOffsets.front(), 0);
+        partitionOffsets.erase(partitionOffsets.begin());
+        partitionOffsets.pop_back();
+        splitAndEnqueue(
+            partitionedTable->view(), std::move(partitionOffsets), stream);
+      }
+      return;
+    }
+
+    for (cudf::size_type windowStart = 0; windowStart < tableView.num_rows();
+         windowStart += rowsPerWindow) {
+      const auto windowEnd = std::min<cudf::size_type>(
+          tableView.num_rows(), windowStart + rowsPerWindow);
+      std::vector<PartitionedChunk> chunks;
+      chunks.reserve((windowEnd - windowStart + maxRows - 1) / maxRows);
+
+      for (cudf::size_type start = windowStart; start < windowEnd;) {
+        const auto end = std::min<cudf::size_type>(
+            windowEnd, start + static_cast<cudf::size_type>(maxRows));
+        auto slices = cudf::slice(tableView, {start, end}, stream);
+        VELOX_CHECK_EQ(slices.size(), 1);
+
+        std::vector<cudf::size_type> partitionKeyIndices;
+        partitionKeyIndices.reserve(partitionKeyIndices_.size());
+        for (const auto& idx : partitionKeyIndices_) {
+          partitionKeyIndices.push_back(static_cast<cudf::size_type>(idx));
+        }
+        auto [partitionedTable, partitionOffsets] = cudf::hash_partition(
+            slices[0],
+            partitionKeyIndices,
+            numPartitions_,
+            cudf::hash_id::HASH_MURMUR3,
+            cudf::DEFAULT_HASH_SEED,
+            stream);
+        VELOX_CHECK_EQ(partitionOffsets.size(), numPartitions_ + 1);
+        VELOX_CHECK_EQ(partitionOffsets.front(), 0);
+        chunks.push_back(
+            {std::move(partitionedTable), std::move(partitionOffsets)});
+        start = end;
+      }
+
+      for (int destination = 0; destination < numPartitions_; ++destination) {
+        std::vector<cudf::table_view> destinationViews;
+        destinationViews.reserve(chunks.size());
+        for (const auto& chunk : chunks) {
+          const auto begin = chunk.offsets[destination];
+          const auto end = chunk.offsets[destination + 1];
+          if (begin == end) {
+            continue;
+          }
+          auto slices = cudf::slice(chunk.table->view(), {begin, end}, stream);
+          VELOX_CHECK_EQ(slices.size(), 1);
+          destinationViews.push_back(slices[0]);
+        }
+        if (destinationViews.empty()) {
+          continue;
+        }
+
+        std::unique_ptr<cudf::table> combinedOwner;
+        cudf::table_view destinationView;
+        if (destinationViews.size() == 1) {
+          destinationView = destinationViews.front();
+        } else {
+          combinedOwner = cudf::concatenate(
+              destinationViews,
+              stream,
+              cudf::get_current_device_resource_ref());
+          destinationView = combinedOwner->view();
+        }
+
+        std::vector<PackedPartition> packedPartitions;
+        const auto rowsPerMessage = std::max<cudf::size_type>(
+            1,
+            targetRowsPerChunk_ > 0
+                ? std::min<cudf::size_type>(
+                      destinationView.num_rows(),
+                      static_cast<cudf::size_type>(targetRowsPerChunk_))
+                : destinationView.num_rows());
+        for (cudf::size_type begin = 0; begin < destinationView.num_rows();
+             begin += rowsPerMessage) {
+          const auto end = std::min<cudf::size_type>(
+              destinationView.num_rows(), begin + rowsPerMessage);
+          auto slices = cudf::slice(destinationView, {begin, end}, stream);
+          VELOX_CHECK_EQ(slices.size(), 1);
+          auto packed = cudf::pack(
+              slices[0], stream, cudf::get_current_device_resource_ref());
+          packedPartitions.push_back(
+              {slices[0].num_rows(),
+               std::make_unique<cudf::packed_columns>(
+                   std::move(packed.metadata), std::move(packed.gpu_data))});
+        }
+
+        // UCXX/UCX is not stream-aware.  Publish only completed buffers, then
+        // release this destination's concatenate/pack temporaries immediately.
+        stream.synchronize();
+        for (auto& packed : packedPartitions) {
+          queueManager->enqueue(
+              this->taskId(), destination, std::move(packed.data), packed.rows);
+        }
+      }
+    }
+    return;
+  }
+
   VLOG(3) << "@" << taskId() << "#" << pipelineId_ << "/" << driverId_
           << " Hashing and partitioning into " << numPartitions_ << " chunks";
 
@@ -694,3 +1108,4 @@ void UcxPartitionedOutput::splitAndEnqueue(
 }
 
 } // namespace facebook::velox::ucx_exchange
+

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -47,6 +47,11 @@ namespace {
 // explicit per-query limits remain authoritative and may be smaller.
 constexpr int64_t kDefaultMaxRowsPerHashPartitionCall = 128'000'000;
 
+// Admission is cooperative and can lose a race to another output driver.
+// When no reservation can be obtained, cap this driver's estimated transient
+// hash-partition peak so concurrent unadmitted fallbacks remain bounded.
+constexpr uint64_t kMaxUnadmittedHashPartitionPeakBytes = uint64_t{1} << 30;
+
 int64_t targetRowsPerUcxChunk(const core::QueryConfig& queryConfig) {
   if (const char* value =
           std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_ROWS")) {
@@ -605,11 +610,45 @@ void UcxPartitionedOutput::advanceActiveFlush() {
     auto selectedPeakBytes = estimatePeakBytes(selectedRows);
     memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
         headroom.device, selectedPeakBytes, admissionCapacity);
-    if (!memoryAdmission && selectedRows == candidateRows &&
-        fallbackRows < candidateRows) {
+    bool admissionRetried = false;
+    if (!memoryAdmission && fallbackRows < selectedRows) {
+      // The initial size used a non-atomic reservation snapshot. Another
+      // driver may have acquired capacity before this atomic attempt, so
+      // shrink to the proven queue-sized fallback and retry the reservation.
       selectedRows = fallbackRows;
       selectedPeakBytes = estimatePeakBytes(selectedRows);
+      memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
+          headroom.device, selectedPeakBytes, admissionCapacity);
+      admissionRetried = true;
     }
+    if (!memoryAdmission &&
+        selectedPeakBytes > kMaxUnadmittedHashPartitionPeakBytes) {
+      // Admission can still be unavailable when every byte is temporarily
+      // reserved, or when CUDA headroom could not be sampled. A driver must
+      // not then execute the original large window unaccounted. Find the
+      // largest row count whose estimated peak is at most the explicit 1 GiB
+      // fallback bound, and give that smaller window one final admission try.
+      uint64_t lower = 1;
+      uint64_t upper = selectedRows;
+      if (estimatePeakBytes(lower) <=
+          kMaxUnadmittedHashPartitionPeakBytes) {
+        while (lower < upper) {
+          const auto middle = lower + (upper - lower + 1) / 2;
+          if (estimatePeakBytes(middle) <=
+              kMaxUnadmittedHashPartitionPeakBytes) {
+            lower = middle;
+          } else {
+            upper = middle - 1;
+          }
+        }
+      }
+      selectedRows = lower;
+      selectedPeakBytes = estimatePeakBytes(selectedRows);
+      memoryAdmission = cudf_velox::tryAcquireDeviceMemoryAdmission(
+          headroom.device, selectedPeakBytes, admissionCapacity);
+      admissionRetried = true;
+    }
+    const bool unadmittedFallback = !memoryAdmission;
     rowsThisWindow = static_cast<cudf::size_type>(selectedRows);
     VLOG(2) << "UcxPartitionedOutput pressure-aware hash window task="
             << taskId() << " sourceRows=" << tableRows
@@ -622,7 +661,9 @@ void UcxPartitionedOutput::advanceActiveFlush() {
             << " poolReusableBytes=" << headroom.reusablePoolBytes()
             << " admissionCapacityBytes=" << admissionCapacity
             << " alreadyReservedBytes=" << alreadyReserved
-            << " admitted=" << memoryAdmission.has_value();
+            << " admissionRetried=" << admissionRetried
+            << " admitted=" << memoryAdmission.has_value()
+            << " unadmittedFallback=" << unadmittedFallback;
   }
 
   const auto end = activeNextRow_ + rowsThisWindow;

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -18,6 +18,7 @@
 #include <folly/json.h>
 #include <algorithm>
 #include <cstdlib>
+#include <limits>
 #include "velox/core/PlanNode.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/Driver.h"
@@ -176,6 +177,38 @@ void normalizePartitionOffsets(
     offsets.pop_back();
   }
 }
+
+uint64_t targetBytesPerUcxChunk(const core::QueryConfig& queryConfig) {
+  if (const char* value =
+          std::getenv("GLUTEN_UCX_PARTITIONED_OUTPUT_BATCH_BYTES")) {
+    try {
+      return std::stoull(value);
+    } catch (...) {
+    }
+  }
+  return queryConfig.ucxPartitionedOutputBatchBytes();
+}
+
+cudf::size_type rowsPerUcxChunk(
+    cudf::size_type rows,
+    uint64_t bytes,
+    int64_t targetRows,
+    uint64_t targetBytes) {
+  auto rowsPerChunk = rows;
+  if (targetRows > 0) {
+    rowsPerChunk = std::min<cudf::size_type>(rowsPerChunk, targetRows);
+  }
+  if (targetBytes > 0 && bytes > targetBytes && rows > 0) {
+    const auto byteLimitedRows = std::max<uint64_t>(
+        1, static_cast<uint64_t>(rows) * targetBytes / bytes);
+    rowsPerChunk = std::min<cudf::size_type>(
+        rowsPerChunk,
+        static_cast<cudf::size_type>(std::min<uint64_t>(
+            byteLimitedRows,
+            std::numeric_limits<cudf::size_type>::max())));
+  }
+  return std::max<cudf::size_type>(1, rowsPerChunk);
+}
 } // namespace
 
 // Computes a mapping from names in n2 to names in n1
@@ -229,7 +262,8 @@ UcxPartitionedOutput::UcxPartitionedOutput(
       numPartitions_(planNode->numPartitions()),
       pipelineId_(ctx->pipelineId),
       driverId_(ctx->driverId),
-      targetRowsPerChunk_(targetRowsPerUcxChunk(ctx->queryConfig())) {
+      targetRowsPerChunk_(targetRowsPerUcxChunk(ctx->queryConfig())),
+      targetBytesPerChunk_(targetBytesPerUcxChunk(ctx->queryConfig())) {
   this->initPartitionKeys(planNode);
   auto sources = planNode->sources();
   std::vector<std::string> inNames, outNames;
@@ -265,9 +299,12 @@ void UcxPartitionedOutput::addInput(RowVectorPtr input) {
   }
 
   pendingRows_ += cudfVector->getTableView().num_rows();
+  pendingBytes_ += cudfVector->estimateFlatSize();
   pendingInputs_.push_back(std::move(cudfVector));
 
-  if (targetRowsPerChunk_ <= 0 || pendingRows_ >= targetRowsPerChunk_) {
+  if ((targetRowsPerChunk_ <= 0 && targetBytesPerChunk_ == 0) ||
+      (targetRowsPerChunk_ > 0 && pendingRows_ >= targetRowsPerChunk_) ||
+      (targetBytesPerChunk_ > 0 && pendingBytes_ >= targetBytesPerChunk_)) {
     flushPending();
   }
 }
@@ -281,6 +318,7 @@ void UcxPartitionedOutput::flushPending() {
   }
 
   try {
+    const auto pendingBytes = pendingBytes_;
     cudf::table_view tableView;
     rmm::cuda_stream_view stream = pendingInputs_.back()->stream();
     // Keeps the merged table alive while tableView references it.
@@ -332,13 +370,11 @@ void UcxPartitionedOutput::flushPending() {
       }
     } else {
       const auto tableRows = tableView.num_rows();
-      const auto rowsPerChunk = std::max<cudf::size_type>(
-          1,
-          targetRowsPerChunk_ > 0
-              ? std::min<cudf::size_type>(
-                    tableRows,
-                    static_cast<cudf::size_type>(targetRowsPerChunk_))
-              : tableRows);
+      const auto rowsPerChunk = rowsPerUcxChunk(
+          tableRows,
+          pendingBytes,
+          targetRowsPerChunk_,
+          targetBytesPerChunk_);
       // SINGLE/gather exchanges must obey the same chunk bound as HASH and
       // RANGE.  Packing the whole input here bypassed splitAndEnqueue and let
       // a global sort/gather create tens-of-GiB host-staging transfers.
@@ -372,6 +408,7 @@ void UcxPartitionedOutput::flushPending() {
 
     pendingInputs_.clear();
     pendingRows_ = 0;
+    pendingBytes_ = 0;
 
   } catch (const rmm::bad_alloc& e) {
     VLOG(1)
@@ -379,6 +416,7 @@ void UcxPartitionedOutput::flushPending() {
         << " caught memory alloc error, removing all memory in output queues";
     pendingInputs_.clear();
     pendingRows_ = 0;
+    pendingBytes_ = 0;
     for (int i = 0; i < numPartitions_; i++) {
       sharedQueueManager()->deleteResults(this->taskId(), i);
     }
@@ -606,20 +644,28 @@ void UcxPartitionedOutput::splitAndEnqueue(
       continue;
     }
 
-    const bool rowChunkingNeeded =
-        targetRowsPerChunk_ > 0 && partitionRows > targetRowsPerChunk_;
-    if (rowChunkingNeeded) {
-      cudf::size_type rowsPerChunk = std::min<cudf::size_type>(
-          partitionRows, static_cast<cudf::size_type>(targetRowsPerChunk_));
+    const auto partitionBytes = partitionTable.data.gpu_data->size();
+    const auto rowsPerChunk = rowsPerUcxChunk(
+        partitionRows,
+        partitionBytes,
+        targetRowsPerChunk_,
+        targetBytesPerChunk_);
+    if (rowsPerChunk < partitionRows) {
       VLOG(2) << "UcxPartitionedOutput chunking task=" << taskId()
               << " destination=" << i << " rows=" << partitionRows
+              << " bytes=" << partitionBytes
               << " rowsPerChunk=" << rowsPerChunk
-              << " targetRowsPerChunk=" << targetRowsPerChunk_;
+              << " targetRowsPerChunk=" << targetRowsPerChunk_
+              << " targetBytesPerChunk=" << targetBytesPerChunk_;
       for (cudf::size_type start = 0; start < partitionRows;
            start += rowsPerChunk) {
         const auto end =
             std::min<cudf::size_type>(partitionRows, start + rowsPerChunk);
-        auto slicedTables = cudf::slice(partitionTable.table, {start, end});
+        auto slicedTables = cudf::slice(
+            partitionTable.table,
+            {static_cast<cudf::size_type>(start),
+             static_cast<cudf::size_type>(end)},
+            stream);
         VELOX_CHECK_EQ(slicedTables.size(), 1);
         auto packedCols = cudf::pack(slicedTables[0], stream);
         stream.synchronize();

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <optional>
+
 #include "velox/exec/Operator.h"
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
@@ -47,18 +49,16 @@ class UcxPartitionedOutput : public exec::Operator,
   /// a non-blocked state, otherwise blocked.
   RowVectorPtr getOutput() override;
 
-  /// always true but the caller will check isBlocked before adding input, hence
-  /// the blocked state does not accumulate input.
+  /// Do not accept another input while a large input is being partitioned a
+  /// window at a time. The driver calls getOutput() to resume that work.
   bool needsInput() const override {
-    return true;
+    return !noMoreInput_ && !hasActiveFlush();
   }
 
-  // the operator is blocked if the queues are full, we are ignoring this so
-  // always return kNotBlocked
+  /// Moves the shared output queue's backpressure future to the Driver.
   exec::BlockingReason isBlocked(ContinueFuture* future) override;
 
-  // The operaor is finished when the queue manager say the queues have all been
-  // drained ?
+  /// Finished after all input windows have been enqueued and EOS published.
   bool isFinished() override;
 
  private:
@@ -101,8 +101,12 @@ class UcxPartitionedOutput : public exec::Operator,
 
   const int pipelineId_;
   const int driverId_;
+  /// Partial aggregation may need a large transient allocation to produce its
+  /// next batch. Do not retain one of its oversized outputs across a queue
+  /// wait; scan/join producers keep normal mid-source backpressure.
+  const bool sourceNeedsOwnerBoundaryBackpressure_;
 
-  exec::BlockingReason blockingReason_;
+  exec::BlockingReason blockingReason_{exec::BlockingReason::kNotBlocked};
   ContinueFuture future_;
 
   bool finished_{false};
@@ -113,18 +117,55 @@ class UcxPartitionedOutput : public exec::Operator,
   std::vector<uint32_t> remap_;
 
   /// Concatenates pending inputs and partitions/enqueues the merged result.
+  /// Each invocation advances at most one hash-partition residency window (or
+  /// one SINGLE chunk), allowing the Driver to observe queue backpressure in
+  /// between windows.
   void flushPending();
+
+  /// Moves pending inputs into resumable flush state. For multiple inputs,
+  /// owns the concatenated table; for one input, activeInputs_ owns the vector
+  /// referenced by the active table view.
+  void preparePendingFlush();
+
+  /// Processes and enqueues one resumable work unit from the active flush.
+  void advanceActiveFlush();
+
+  /// Checks task-wide output queue pressure immediately after a work unit.
+  void updateBackpressure();
+
+  bool hasActiveFlush() const;
+  cudf::table_view activeTableView();
+  void clearActiveFlush();
 
   /// Accumulated CudfVectors awaiting flush.
   std::vector<cudf_velox::CudfVectorPtr> pendingInputs_;
   /// Total rows across pendingInputs_.
   int64_t pendingRows_{0};
-  /// Estimated bytes across pendingInputs_.
-  uint64_t pendingBytes_{0};
+  /// Source GPU bytes across pendingInputs_, captured before owners are freed.
+  uint64_t pendingFlatBytes_{0};
+
+  /// Ownership and cursor for a flush that yielded between partition windows.
+  std::vector<cudf_velox::CudfVectorPtr> activeInputs_;
+  std::unique_ptr<cudf::table> activeMergedTable_;
+  std::optional<rmm::cuda_stream_view> activeStream_;
+  uint64_t activeSourceFlatBytes_{0};
+  cudf::size_type activeNextRow_{0};
+  cudf::size_type activeRowsPerWindow_{0};
+  /// A source larger than the task queue cap must not remain pinned while the
+  /// producer is blocked. Such an oversized, multi-window source is drained
+  /// before observing backpressure so its owner can be released promptly.
+  bool activeDrainBeforeBackpressure_{false};
+  /// Task-wide queue byte cap. Normal window sizing uses device headroom;
+  /// this supplies only the emergency schema-width fallback under pressure.
+  const uint64_t maxOutputBufferSize_;
   /// Configured row threshold for flushing (from QueryConfig).
   const int64_t targetRowsPerChunk_;
   /// Configured byte threshold for flushing and destination chunking.
   const uint64_t targetBytesPerChunk_;
+  /// Optional libcudf hash_partition safety limit. Zero disables slicing.
+  const int64_t hashPartitionInputBatchRows_;
+  /// Source-row window for recombining safely sliced hash output.
+  const int64_t hashPartitionWindowRows_;
 };
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.h
@@ -119,8 +119,12 @@ class UcxPartitionedOutput : public exec::Operator,
   std::vector<cudf_velox::CudfVectorPtr> pendingInputs_;
   /// Total rows across pendingInputs_.
   int64_t pendingRows_{0};
+  /// Estimated bytes across pendingInputs_.
+  uint64_t pendingBytes_{0};
   /// Configured row threshold for flushing (from QueryConfig).
   const int64_t targetRowsPerChunk_;
+  /// Configured byte threshold for flushing and destination chunking.
+  const uint64_t targetBytesPerChunk_;
 };
 
 } // namespace facebook::velox::ucx_exchange

--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -137,8 +137,8 @@ UcxDestinationQueue::Data UcxDestinationQueue::getData(
     // the active server's waiter.  Return a deliberately different sequence
     // so the duplicate UcxExchangeServer follows its stale-connection close
     // path while the original callback remains installed.
-    LOG(WARNING) << "Ignoring duplicate UCX queue waiter: sequence="
-                 << sequence << " acknowledgedSequence=" << sequence_;
+    LOG(WARNING) << "Ignoring duplicate UCX queue waiter: sequence=" << sequence
+                 << " acknowledgedSequence=" << sequence_;
     return {nullptr, sequence_ + 1, {}, true};
   }
   VELOX_CHECK(

--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -121,8 +121,26 @@ UcxDestinationQueue::Data UcxDestinationQueue::getData(
     uint64_t maxBytes,
     int64_t sequence,
     UcxDataAvailableCallbackV2 notify) {
-  VELOX_CHECK_GE(
-      sequence, sequence_, "Get received for an already acknowledged item");
+  if (sequence < sequence_) {
+    // A retried/duplicate UCX connection can race with task abort after the
+    // original server has already advanced this destination queue.  Treat
+    // that request as stale instead of throwing on the communicator thread
+    // (an uncaught VeloxException there terminates the whole Spark executor).
+    // Returning the current sequence lets UcxExchangeServer identify and
+    // close only the stale connection without dequeuing or clearing data.
+    LOG(WARNING) << "Ignoring stale UCX queue request: requestedSequence="
+                 << sequence << " acknowledgedSequence=" << sequence_;
+    return {nullptr, sequence_, {}, true};
+  }
+  if (notifyV2_ != nullptr && notify != nullptr) {
+    // A second server for the same task/destination/sequence must not replace
+    // the active server's waiter.  Return a deliberately different sequence
+    // so the duplicate UcxExchangeServer follows its stale-connection close
+    // path while the original callback remains installed.
+    LOG(WARNING) << "Ignoring duplicate UCX queue waiter: sequence="
+                 << sequence << " acknowledgedSequence=" << sequence_;
+    return {nullptr, sequence_ + 1, {}, true};
+  }
   VELOX_CHECK(
       notify_ == nullptr && notifyV2_ == nullptr,
       "UcxDestinationQueue already has a pending data notification");

--- a/velox/experimental/ucx-exchange/tests/Main.cpp
+++ b/velox/experimental/ucx-exchange/tests/Main.cpp
@@ -34,7 +34,6 @@ int main(int argc, char** argv) {
   // Signal handler required for ThreadDebugInfoTest
   facebook::velox::process::addDefaultFatalSignalHandler();
   folly::Init init(&argc, &argv, false);
-  FLAGS_velox_ucx_exchange = true;
   facebook::velox::Type::registerSerDe();
   facebook::velox::cudf_velox::CudfConfig::getInstance().exchangeLogLevel =
       FLAGS_exchange_log_level;

--- a/velox/experimental/ucx-exchange/tests/Main.cpp
+++ b/velox/experimental/ucx-exchange/tests/Main.cpp
@@ -38,5 +38,6 @@ int main(int argc, char** argv) {
   facebook::velox::Type::registerSerDe();
   facebook::velox::cudf_velox::CudfConfig::getInstance().exchangeLogLevel =
       FLAGS_exchange_log_level;
+  facebook::velox::cudf_velox::CudfConfig::getInstance().exchange = true;
   return RUN_ALL_TESTS();
 }

--- a/velox/experimental/ucx-exchange/tests/SourceDriverMock.cpp
+++ b/velox/experimental/ucx-exchange/tests/SourceDriverMock.cpp
@@ -82,22 +82,30 @@ void SourceDriverMock::sendAllData(UcxPartitionedOutput* partitionedOutput) {
   auto* pool = partitionedOutput->pool();
 
   for (uint32_t chunk = 0; chunk < numChunks_; ++chunk) {
-    // 1. Create CudfVector with test data using makeCudfVector helper
-    auto cudfVector = makeCudfVector(
-        pool, numRowsPerChunk_, rowType, tableGenerator_, stream);
-
-    // 2. Check isBlocked() - if blocked, wait on future
+    // 1. Drain resumable output work and wait for backpressure before adding
+    // another input. A real Driver checks both isBlocked() and needsInput().
+    // Keep this mock on the same contract now that UcxPartitionedOutput can
+    // yield between hash-partition residency windows.
     while (true) {
       ContinueFuture future;
       auto blocked = partitionedOutput->isBlocked(&future);
-      if (blocked == exec::BlockingReason::kNotBlocked) {
+      if (blocked != exec::BlockingReason::kNotBlocked) {
+        future.wait();
+        continue;
+      }
+      if (partitionedOutput->needsInput()) {
         break;
       }
-      // Wait for the operator to become unblocked
-      future.wait();
+      partitionedOutput->getOutput();
     }
 
-    // 3. Call addInput() now that we're not blocked
+    // 2. Create the next CudfVector only after the operator can accept it, as
+    // a real upstream operator would. This avoids retaining an extra large
+    // source batch while the prior batch is blocked in output.
+    auto cudfVector = makeCudfVector(
+        pool, numRowsPerChunk_, rowType, tableGenerator_, stream);
+
+    // 3. Call addInput() now that we're not blocked and need input.
     partitionedOutput->addInput(cudfVector);
 
     // 4. Call getOutput() to advance operator state

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -30,12 +30,14 @@
 #include <chrono>
 #include <future>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <vector>
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
@@ -1540,6 +1542,137 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
         sinkDriver->numChunksReceived(), static_cast<uint64_t>(numChunks));
     queueManager_->removeTask(srcTaskId);
   }
+}
+
+// Regression test for resumable hash output. With no consumer, each producer
+// must stop after its first configured residency window instead of enqueueing
+// every remaining window from a single addInput(). Starting the consumers then
+// verifies that saved cursors resume and EOS is delivered. Pressure-aware
+// sizing keeps this full window while device headroom is healthy.
+TEST_P(UcxExchangeTest, hashWindowBackpressureIsResumable) {
+  ExchangeTestParams p = GetParam();
+  if (p.numSrcDrivers != 1 || p.numDstDrivers != 1 || p.numPartitions != 1 ||
+      p.numChunks != 100 || p.numUpstreamTasks != 1 ||
+      p.tableType != TableType::NARROW) {
+    GTEST_SKIP() << "hashWindowBackpressureIsResumable: runs only once";
+  }
+
+  const auto headroom = cudf_velox::captureDeviceAllocationHeadroom();
+  ASSERT_TRUE(headroom.cudaValid);
+  auto admission =
+      cudf_velox::tryAcquireDeviceMemoryAdmission(headroom.device, 96, 128);
+  ASSERT_TRUE(admission.has_value());
+  EXPECT_EQ(
+      cudf_velox::deviceMemoryAdmissionReservedBytes(headroom.device), 96);
+  EXPECT_FALSE(
+      cudf_velox::tryAcquireDeviceMemoryAdmission(headroom.device, 64, 128));
+  admission.reset();
+  EXPECT_EQ(cudf_velox::deviceMemoryAdmissionReservedBytes(headroom.device), 0);
+
+  constexpr int kRowsPerDriver = 300;
+  constexpr int kWindowRows = 200;
+  constexpr int kHashCallRows = 20;
+  constexpr int kNumPartitions = 2;
+  constexpr int kNumDrivers = 2;
+  // One source fits in the queue cap, but the first window from both drivers
+  // exceeds it. This exercises the ordinary resumable path; oversized
+  // multi-window sources intentionally drain before observing backpressure.
+  constexpr uint64_t kQueueCapacityRows = kRowsPerDriver;
+  const std::string taskPrefix = getUniqueTaskPrefix();
+  const std::string srcTaskId = taskPrefix + "sourceTask0";
+  auto rowType = WideTestTable::kRowType;
+  auto tableGenerator = std::make_shared<WideTestTable>();
+  tableGenerator->initialize(kRowsPerDriver);
+
+  uint64_t averageRowBytes;
+  {
+    auto sizingVector = makeCudfVector(
+        pool_.get(),
+        kRowsPerDriver,
+        rowType,
+        tableGenerator,
+        cudf::get_default_stream());
+    const auto flatBytes = sizingVector->estimateFlatSize();
+    averageRowBytes = flatBytes / kRowsPerDriver +
+        static_cast<uint64_t>(flatBytes % kRowsPerDriver != 0);
+  }
+  cudf::get_default_stream().synchronize();
+  ASSERT_GT(averageRowBytes, 0);
+  const auto maxOutputBufferBytes = averageRowBytes * kQueueCapacityRows;
+
+  std::unordered_map<std::string, std::string> extraConfig{
+      {core::QueryConfig::kUcxPartitionedOutputBatchRows,
+       std::to_string(kRowsPerDriver)},
+      {core::QueryConfig::kUcxHashPartitionInputBatchRows,
+       std::to_string(kHashCallRows)},
+      {core::QueryConfig::kUcxHashPartitionWindowRows,
+       std::to_string(kWindowRows)}};
+  auto srcTask = createPartitionedOutputTask(
+      srcTaskId,
+      pool_,
+      rowType,
+      kNumPartitions,
+      {"int32_col"},
+      maxOutputBufferBytes,
+      extraConfig);
+  queueManager_->initializeTask(
+      srcTask,
+      core::PartitionedOutputNode::Kind::kPartitioned,
+      kNumPartitions,
+      kNumDrivers);
+
+  auto sourceDriver = std::make_shared<SourceDriverMock>(
+      srcTask, kNumDrivers, 1, kRowsPerDriver, tableGenerator);
+  sourceDriver->run();
+
+  // Do not start a consumer yet. Once the first adaptive window reaches the
+  // byte cap, SourceDriverMock must be waiting on the shared queue future.
+  bool sawFirstWindow = false;
+  std::optional<exec::OutputBuffer::Stats> blockedStats;
+  for (int attempt = 0; attempt < 200; ++attempt) {
+    blockedStats = queueManager_->stats(srcTaskId);
+    if (blockedStats &&
+        blockedStats->totalRowsSent == kNumDrivers * kWindowRows) {
+      sawFirstWindow = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  EXPECT_TRUE(sawFirstWindow);
+  if (blockedStats) {
+    EXPECT_EQ(blockedStats->totalRowsSent, kNumDrivers * kWindowRows)
+        << "producers crossed the one-window-per-driver backpressure bound";
+  }
+
+  std::vector<std::shared_ptr<SinkDriverMock>> sinkDrivers;
+  for (int partition = 0; partition < kNumPartitions; ++partition) {
+    core::PlanNodeId exchangeNodeId;
+    auto sinkTask = createExchangeTask(
+        taskPrefix + "sinkTask" + std::to_string(partition),
+        rowType,
+        partition,
+        exchangeNodeId);
+    auto sinkDriver = std::make_shared<SinkDriverMock>(sinkTask, 1);
+    std::vector<exec::Split> splits;
+    splits.push_back(remoteSplit(srcTaskId, partition));
+    sinkDriver->addSplits(splits);
+    sinkDriver->run();
+    sinkDrivers.push_back(std::move(sinkDriver));
+  }
+
+  sourceDriver->joinThreads();
+  uint64_t receivedRows = 0;
+  for (auto& sinkDriver : sinkDrivers) {
+    sinkDriver->joinThreads();
+    receivedRows += sinkDriver->numRows();
+  }
+  EXPECT_EQ(receivedRows, kNumDrivers * kRowsPerDriver);
+
+  auto finalStats = queueManager_->stats(srcTaskId);
+  ASSERT_TRUE(finalStats.has_value());
+  EXPECT_TRUE(finalStats->noMoreData);
+  EXPECT_EQ(finalStats->totalRowsSent, kNumDrivers * kRowsPerDriver);
+  queueManager_->removeTask(srcTaskId);
 }
 
 // Regression test: aborting a source task while UCXX tagRecv requests are

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -1483,6 +1483,63 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
 
     queueManager_->removeTask(srcTaskId);
   }
+
+  // --- Scenario 5: Byte-only threshold via QueryConfig ---
+  {
+    const int numChunks = 20;
+    // Use a one-row repeated pattern so validation remains independent of
+    // byte-based output slice boundaries.
+    const int numRowsPerChunk = 1;
+    const int numPartitions = 1;
+    const int numDrivers = 1;
+    const std::string taskPrefix = getUniqueTaskPrefix();
+    const std::string srcTaskId = taskPrefix + "sourceTask0";
+
+    auto dataToSend = std::make_shared<UcxTestData>();
+    dataToSend->initialize(numRowsPerChunk);
+
+    std::unordered_map<std::string, std::string> extraConfig{
+        {core::QueryConfig::kUcxPartitionedOutputBatchRows, "0"},
+        {core::QueryConfig::kUcxPartitionedOutputBatchBytes, "256"}};
+    auto srcTask = createPartitionedOutputTask(
+        srcTaskId,
+        pool_,
+        UcxTestData::kTestRowType,
+        numPartitions,
+        {},
+        FOUR_GBYTES,
+        extraConfig);
+    queueManager_->initializeTask(
+        srcTask,
+        core::PartitionedOutputNode::Kind::kPartitioned,
+        numPartitions,
+        numDrivers);
+
+    auto sourceDriver = std::make_shared<SourceDriverMock>(
+        srcTask, numDrivers, numChunks, numRowsPerChunk, dataToSend);
+    const std::string sinkTaskId = taskPrefix + "sinkTask0";
+    core::PlanNodeId exchangeNodeId;
+    auto sinkTask = createExchangeTask(
+        sinkTaskId, UcxTestData::kTestRowType, 0, exchangeNodeId);
+    auto sinkDriver =
+        std::make_shared<SinkDriverMock>(sinkTask, numDrivers, dataToSend);
+    std::vector<exec::Split> splits{remoteSplit(srcTaskId, 0)};
+    sinkDriver->addSplits(splits);
+
+    sourceDriver->run();
+    sinkDriver->run();
+    sourceDriver->joinThreads();
+    sinkDriver->joinThreads();
+
+    EXPECT_EQ(
+        sinkDriver->numRows(),
+        static_cast<size_t>(numChunks) * numRowsPerChunk);
+    EXPECT_TRUE(sinkDriver->dataIsValid());
+    EXPECT_GT(sinkDriver->numChunksReceived(), 1);
+    EXPECT_LT(
+        sinkDriver->numChunksReceived(), static_cast<uint64_t>(numChunks));
+    queueManager_->removeTask(srcTaskId);
+  }
 }
 
 // Regression test: aborting a source task while UCXX tagRecv requests are

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -23,6 +23,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <folly/Executor.h>
+#include <folly/ScopeGuard.h>
 #include <folly/synchronization/EventCount.h>
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
@@ -849,6 +850,16 @@ TEST_P(UcxExchangeTest, sharedClientSurvivesOneExchangeClose) {
     GTEST_SKIP() << "sharedClientSurvivesOneExchangeClose: runs only once";
   }
 
+  // This test isolates ownership of a client shared by two operators. Avoid
+  // coupling that contract to loopback UCX TCP behavior by using the
+  // same-process transfer registry for the data path.
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  const bool origIntraNode = config.intraNodeExchange;
+  config.intraNodeExchange = true;
+  SCOPE_EXIT {
+    config.intraNodeExchange = origIntraNode;
+  };
+
   const std::string taskPrefix = getUniqueTaskPrefix();
   const std::string srcTaskId = taskPrefix + "sharedClientSrc";
   const std::string sinkTaskId = taskPrefix + "sharedClientSink";
@@ -1556,6 +1567,16 @@ TEST_P(UcxExchangeTest, hashWindowBackpressureIsResumable) {
       p.tableType != TableType::NARROW) {
     GTEST_SKIP() << "hashWindowBackpressureIsResumable: runs only once";
   }
+
+  // The behavior under test is producer-side queue backpressure and cursor
+  // resumption. Use the deterministic same-process transport so loopback UCX
+  // TCP failures cannot mask that contract.
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  const bool origIntraNode = config.intraNodeExchange;
+  config.intraNodeExchange = true;
+  SCOPE_EXIT {
+    config.intraNodeExchange = origIntraNode;
+  };
 
   const auto headroom = cudf_velox::captureDeviceAllocationHeadroom();
   ASSERT_TRUE(headroom.cudaValid);

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -1210,6 +1210,16 @@ TEST_P(UcxExchangeTest, batchAccumulationTest) {
     }
   }
 
+  // This test exercises accumulation and chunk-boundary semantics, not the
+  // UCX TCP transport. Use the same-process registry so loopback transport
+  // failures cannot mask row-count, integrity, or chunk-count regressions.
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  const bool origIntraNode = config.intraNodeExchange;
+  config.intraNodeExchange = true;
+  SCOPE_EXIT {
+    config.intraNodeExchange = origIntraNode;
+  };
+
   const int kTargetRows = UcxPartitionedOutput::kDefaultTargetRowsPerChunk;
 
   // --- Scenario 1: Small chunks that SHOULD be accumulated ---

--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -442,6 +442,93 @@ TEST_F(UcxOutputQueueManagerTest, v2OversizeRequestReturnsOneChunk) {
   queueManager_->removeTask(taskId);
 }
 
+TEST_F(UcxOutputQueueManagerTest, v2StaleSequenceDoesNotDequeue) {
+  const std::string taskId = "v2StaleSequence";
+  const int destination = 0;
+  const auto maxBytes = std::numeric_limits<uint64_t>::max();
+
+  initializeTask(taskId, 1 /* numDestinations */, 1 /* numDrivers */);
+
+  enqueue(taskId, destination, 10);
+  enqueue(taskId, destination, 20);
+  noMoreData(taskId);
+
+  auto first = fetchV2Data(taskId, destination, maxBytes, 0);
+  ASSERT_NE(first.data, nullptr);
+  EXPECT_EQ(first.sequence, 0);
+
+  // Simulate a duplicate server reconnecting from sequence zero. It should
+  // be told that sequence one is current, without consuming sequence one.
+  auto stale = fetchV2Data(taskId, destination, maxBytes, 0);
+  EXPECT_EQ(stale.data, nullptr);
+  EXPECT_EQ(stale.sequence, 1);
+
+  auto second = fetchV2Data(taskId, destination, maxBytes, 1);
+  ASSERT_NE(second.data, nullptr);
+  EXPECT_EQ(second.sequence, 1);
+
+  auto end = fetchV2Data(taskId, destination, maxBytes, 2);
+  EXPECT_EQ(end.data, nullptr);
+  EXPECT_EQ(end.sequence, 2);
+
+  queueManager_->deleteResults(taskId, destination);
+  EXPECT_TRUE(queueManager_->isFinished(taskId));
+  queueManager_->removeTask(taskId);
+}
+
+TEST_F(UcxOutputQueueManagerTest, v2DuplicateWaiterPreservesOriginal) {
+  const std::string taskId = "v2DuplicateWaiter";
+  const int destination = 0;
+  const auto maxBytes = std::numeric_limits<uint64_t>::max();
+
+  initializeTask(taskId, 1 /* numDestinations */, 1 /* numDrivers */);
+
+  bool originalFired = false;
+  std::shared_ptr<cudf::packed_columns> originalData;
+  queueManager_->getData(
+      taskId,
+      destination,
+      maxBytes,
+      0,
+      [&](std::shared_ptr<cudf::packed_columns> data,
+          int64_t sequence,
+          std::vector<int64_t>) {
+        EXPECT_EQ(sequence, 0);
+        originalData = std::move(data);
+        originalFired = true;
+      });
+  EXPECT_FALSE(originalFired);
+
+  bool duplicateFired = false;
+  queueManager_->getData(
+      taskId,
+      destination,
+      maxBytes,
+      0,
+      [&](std::shared_ptr<cudf::packed_columns> data,
+          int64_t sequence,
+          std::vector<int64_t>) {
+        EXPECT_EQ(data, nullptr);
+        EXPECT_EQ(sequence, 1);
+        duplicateFired = true;
+      });
+  EXPECT_TRUE(duplicateFired);
+  EXPECT_FALSE(originalFired);
+
+  enqueue(taskId, destination, 10);
+  EXPECT_TRUE(originalFired);
+  EXPECT_NE(originalData, nullptr);
+
+  noMoreData(taskId);
+  auto end = fetchV2Data(taskId, destination, maxBytes, 1);
+  EXPECT_EQ(end.data, nullptr);
+  EXPECT_EQ(end.sequence, 1);
+
+  queueManager_->deleteResults(taskId, destination);
+  EXPECT_TRUE(queueManager_->isFinished(taskId));
+  queueManager_->removeTask(taskId);
+}
+
 TEST_F(UcxOutputQueueManagerTest, v2RemovedTaskReturnsNullAtRequestedSequence) {
   const std::string taskId = "v2RemovedTask";
   const int destination = 0;


### PR DESCRIPTION
# PR Description
## Summary

This PR adds the native cuDF execution support required by cost-based MPP existence-join plans and hardens UCX partitioned output for large GPU workloads.

The main changes are:

- Add native `RIGHT_SEMI_PROJECT` hash-join execution.
- Preserve build-side rows and append the existence match column after all probe drivers finish.
- Support AST and evaluated residual join filters.
- Preserve SQL null-aware existence semantics, including empty and nullable probe inputs.
- Replace full-build match-vector updates with sparse, monotonic match scattering.
- Make UCX partitioned-output flushing resumable across backpressure boundaries.
- Bound temporary hash-partition residency with configurable row windows.
- Select smaller residency windows dynamically when GPU memory is under pressure.
- Account for reusable memory in the primary `cudaMallocAsync` pool.
- Coordinate memory admission across concurrent operators on the same GPU.
- Apply a default 128-million-row ceiling to each libcudf hash-partition call when no smaller limit is configured.
- Release concatenated source batches as soon as stream ordering makes their deallocation safe.

## Motivation

### RIGHT_SEMI_PROJECT

Candidate-first plans for paired `EXISTS` / `NOT EXISTS` predicates need a build-preserving semi-project join. The native join must retain each build row and emit a Boolean existence result after all probe batches and drivers have contributed their matches.

The previous full-column match update was also too expensive for large MPP consumers. For every probe batch it materialized and updated a Boolean vector covering the complete build side, resulting in approximately `O(build rows x probe batches)` work.

This PR records only the matched build indices for each probe batch. The update is monotonic and idempotent, so duplicate residual matches and multiple probe drivers are handled safely without rescanning the full build state.

### UCX partitioned output

Large source batches previously allowed one `addInput()` call to process and enqueue all remaining hash windows before honoring output-queue backpressure. This could retain the source batch together with multiple hash, split, concatenate, and packed-output temporaries.

The new state machine processes one residency window at a time, publishes its output, and yields when the shared queue applies backpressure. Overshoot is bounded to one window per active output driver.

For oversized partial-aggregation output, the operator finishes draining the current source owner before blocking. This prevents an output future from retaining a large source allocation and starving upstream aggregation.

## GPU memory handling

The operator captures both:

- free device memory reported by CUDA; and
- reusable reserved memory in the primary `cudaMallocAsync` pool.

Concurrent operators use a process-wide, per-device admission reservation so they do not all make decisions from the same optimistic memory snapshot.

The selected hash window accounts for source bytes, partition scratch space, concurrent reservations, and a device-memory reserve. An existing queue-derived bound remains available as the emergency fallback when memory information is unavailable or severely constrained.

Explicit query limits remain authoritative. When no positive hash-partition call limit is configured, the engine uses a general 128-million-row ceiling. This prevents libcudf's partition exclusive scan from exceeding CUDA kernel launch resources before memory pressure is otherwise visible.

## Correctness and safety

The implementation includes:

- End-of-probe coordination across hash-join drivers.
- Per-driver match state followed by a single build-side output phase.
- Correct nullable existence results for null-aware joins.
- AST and non-AST residual predicate handling.
- Idempotent updates for duplicate build indices.
- Backpressure futures that remain valid across resumable output windows.
- RAII-based release of cooperative GPU-memory reservations.
- Stream-ordered release of source vectors after concatenation.

## Validation

The change was tested with the original canonical TPC-H SQL without SQL or benchmark application changes.

Environment:

- TPC-H SF30000 / 30 TB
- 32 x NVIDIA GB200 GPUs
- 8 NVL72 compute trays
- Three iterations per query

Full regression result:

- 22 queries x 3 iterations
- 66/66 executions passed
- Hot total: 130.676 seconds
- Presto on GPU hot total: 178.040 seconds
- Gluten is approximately 1.362x faster overall

Relevant query results:

| Query | Hot mean | Validation |
|---|---:|---|
| Q10 | 8.273 s | Passed all three iterations after the full preceding query stream |
| Q17 | 4.091 s | Scalar result oracle passed on all iterations |
| Q21 | 12.891 s | Golden result SHA256 matched |
| Q22 | 2.456 s | Passed all three iterations without a CUDA launch failure |

Before the default hash-call ceiling, Q22 intermittently failed in `cudfPartitionedOutput` with:

```text
cudaErrorLaunchOutOfResources: too many resources requested for launch
after dispatching exclusive_scan kernel
```

The focused Q10/Q17/Q21/Q22 gate passed 12/12 executions, followed by the complete 66/66 regression gate.

Native test coverage includes:

- Build-left `RIGHT_SEMI_PROJECT` joins.
- Nullable residual predicates.
- Empty probe inputs.
- Multi-threaded hash-join execution.
- Resumable multi-window UCX backpressure.
- Per-device memory-admission accounting and release.

## Dependency

This PR is the native companion to the Spark-Gluten PR that adds cost-based selective-aggregate and candidate-first existence-join planning