### PR TITLE
fix(cudf): compile task lifecycle integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,6 +528,7 @@ if(VELOX_ENABLE_WAVE OR VELOX_ENABLE_CUDF)
         PROPERTIES INTERFACE_LINK_LIBRARIES "${override_curl_lib}"
       )
     endif()
+    add_compile_definitions(VELOX_ENABLE_CUDF)
   endif()
 endif()
 

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -243,6 +243,10 @@ velox_link_libraries(
   velox_vector
 )
 
+if(VELOX_ENABLE_CUDF)
+  velox_link_libraries(velox_exec cudf::cudf)
+endif()
+
 if(VELOX_ENABLE_GEO)
   velox_compile_definitions(velox_exec PRIVATE VELOX_ENABLE_GEO)
   velox_link_libraries(velox_exec velox_common_geospatial_serde)


### PR DESCRIPTION
## Summary

- Define VELOX_ENABLE_CUDF for Velox translation units whenever the cuDF backend is enabled, including Task.cpp in the monolithic velox target.
- Link velox_exec with cudf::cudf under the same build option.

## Why

Task.cpp guards the UCX output-queue lifecycle with VELOX_ENABLE_CUDF. The prior build enabled and linked the cuDF/UCX operators but compiled Task.cpp without that definition, so multi-peer queries reached UcxPartitionedOutput without initializing or removing their output queues.

## Validation

- The rebuilt Task.cpp compile command contains -DVELOX_ENABLE_CUDF.
- The resulting libgluten.so contains the UcxOutputQueueManager lifecycle symbols and calls.
- The exact rebuilt native artifact completed NDS-H FLOAT SF=100 at 22/22 with four executors and four GPUs on EMR on EKS; SF=1000 completed 21/22, with only Q21 hitting the separate 32-GiB capacity limit.